### PR TITLE
add recommended policy ARN

### DIFF
--- a/config/iam/recommended-policy-arn
+++ b/config/iam/recommended-policy-arn
@@ -1,0 +1,1 @@
+arn:aws:iam::aws:policy/AmazonEC2FullAccess


### PR DESCRIPTION
Issue #, if available: N/A
* PR checks failing: https://github.com/aws-controllers-k8s/ec2-controller/pull/13 due to [recommended-policy-test](https://prow.ack.aws.dev/view/s3/ack-prow-logs/pr-logs/pull/aws-controllers-k8s_ec2-controller/13/ec2-recommended-policy-test/1446549112567631872) failing

Description of changes:
* adds full EC2 access as recommended policy

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
