### PR TITLE
Fix duplicated key in `generator.yaml`

### DIFF
--- a/generator.yaml
+++ b/generator.yaml
@@ -1,5 +1,6 @@
 ignore:
   operations:
+    - ModifyTransitGateway
     - ModifyVpcEndpoint
   field_paths:
     - CreateVpcEndpointInput.DryRun
@@ -66,9 +67,7 @@ ignore:
     - VpcPeeringConnection
     - VpnConnectionRoute
     - VpnConnection
-    - VpnGateway
-  operations:
-    - ModifyTransitGateway
+    - VpnGateway    
 
 operations:
   CreateVpcEndpoint:


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
* Move *ignore operations* away from *operations* block for clarity

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
