### PR TITLE
release ec2-controller `v0.0.8`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,6 +1,6 @@
 ack_generate_info:
-  build_date: "2022-02-17T19:24:44Z"
-  build_hash: f8c0f4711a91e50335450521e3c49673d135d56d
+  build_date: "2022-02-25T19:43:13Z"
+  build_hash: 58a012980ae17d216d53f2a929815ab31cec8270
   go_version: go1.17
   version: v0.17.0
 api_directory_checksum: ad688fd5a2b395bf5f01413c99ac635e7670ba75

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/ec2-controller
-  newTag: v0.0.7
+  newTag: v0.0.8

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: ec2-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic Cloud Compute (EC2)
-version: v0.0.7
-appVersion: v0.0.7
+version: v0.0.8
+appVersion: v0.0.8
 home: https://github.com/aws-controllers-k8s/ec2-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/ec2-controller:v0.0.7".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/ec2-controller:v0.0.8".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/ec2-controller
-  tag: v0.0.7
+  tag: v0.0.8
   pullPolicy: IfNotPresent
   pullSecrets: []
 

--- a/pkg/resource/dhcp_options/manager.go
+++ b/pkg/resource/dhcp_options/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/dhcp_options/references.go
+++ b/pkg/resource/dhcp_options/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/internet_gateway/manager.go
+++ b/pkg/resource/internet_gateway/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/internet_gateway/references.go
+++ b/pkg/resource/internet_gateway/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/route_table/manager.go
+++ b/pkg/resource/route_table/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/route_table/references.go
+++ b/pkg/resource/route_table/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/security_group/manager.go
+++ b/pkg/resource/security_group/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/security_group/references.go
+++ b/pkg/resource/security_group/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/subnet/manager.go
+++ b/pkg/resource/subnet/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/subnet/references.go
+++ b/pkg/resource/subnet/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/transit_gateway/manager.go
+++ b/pkg/resource/transit_gateway/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/transit_gateway/references.go
+++ b/pkg/resource/transit_gateway/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/vpc/manager.go
+++ b/pkg/resource/vpc/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/vpc/references.go
+++ b/pkg/resource/vpc/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present

--- a/pkg/resource/vpc_endpoint/manager.go
+++ b/pkg/resource/vpc_endpoint/manager.go
@@ -211,6 +211,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Unable to complete Read operation required for late initialization"
 		lateInitConditionReason = "Late Initialization Failure"
 		ackcondition.SetLateInitialized(latestCopy, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(latestCopy, corev1.ConditionFalse, nil, nil)
 		return latestCopy, err
 	}
 	lateInitializedRes := rm.lateInitializeFromReadOneOutput(observed, latestCopy)
@@ -220,6 +221,7 @@ func (rm *resourceManager) LateInitialize(
 		lateInitConditionMessage = "Late initialization did not complete, requeuing with delay of 5 seconds"
 		lateInitConditionReason = "Delayed Late Initialization"
 		ackcondition.SetLateInitialized(lateInitializedRes, corev1.ConditionFalse, &lateInitConditionMessage, &lateInitConditionReason)
+		ackcondition.SetSynced(lateInitializedRes, corev1.ConditionFalse, nil, nil)
 		return lateInitializedRes, ackrequeue.NeededAfter(nil, time.Duration(5)*time.Second)
 	}
 	// Set LateInitialized condition to True

--- a/pkg/resource/vpc_endpoint/references.go
+++ b/pkg/resource/vpc_endpoint/references.go
@@ -19,9 +19,8 @@ import (
 	"context"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
-
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 )
 
 // ResolveReferences finds if there are any Reference field(s) present


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/489

Description of changes:
* release `v0.0.8` which adds create/delete support for `DHCPOptions`, the last of the requested resources in vpc controller issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
