### PR TITLE
late init `VPCEndpoint.PolicyDocument` field

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-03-29T17:33:11Z"
-  build_hash: 6f659f796434e8fd6443c0b3a5b495daae910035
-  go_version: go1.17.8
-  version: v0.18.0
+  build_date: "2022-03-30T20:36:15Z"
+  build_hash: c6b852a8017aa73cfc5a882b1ba60c88d820e967
+  go_version: go1.17
+  version: v0.18.1
 api_directory_checksum: e5bf2003f6be051fdeda5059df47eb7fff0a9c86
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: c041dcc9493bdd9baed2e0599d8bc4401b5f2d25
+  file_checksum: e017fb539a06710c6713157e5f61e2a0c20e70ba
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -281,6 +281,8 @@ resources:
         template_path: hooks/vpc/sdk_read_many_post_set_output.go.tpl
   VpcEndpoint:
     fields:
+      PolicyDocument:
+        late_initialize: {}
       VpcId:
         references:
           resource: VPC

--- a/generator.yaml
+++ b/generator.yaml
@@ -281,6 +281,8 @@ resources:
         template_path: hooks/vpc/sdk_read_many_post_set_output.go.tpl
   VpcEndpoint:
     fields:
+      PolicyDocument:
+        late_initialize: {}
       VpcId:
         references:
           resource: VPC

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -118,6 +118,7 @@ class TestEC2References:
         assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert k8s.wait_on_condition(sg_ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert k8s.wait_on_condition(subnet_ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ResourceSynced", "True", wait_periods=5)
 
         assert k8s.wait_on_condition(sg_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
         assert k8s.wait_on_condition(subnet_ref, "ACK.ReferencesResolved", "True", wait_periods=5)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1205

Description of changes:
* Late initializes `PolicyDocument` field so VPCEndpoint can achieve Synced state if `PolicyDocument` is not provided in the Spec. This is necessary because the API [defaults PolicyDocument](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateVpcEndpoint.html), if not provided.
* Updates related test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
