### PR TITLE
Internet Gateway terminal codes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-06-28T16:37:45Z"
+  build_date: "2022-07-12T21:32:12Z"
   build_hash: 208b1e15257d57c46729698f47a40fd59441ecbd
-  go_version: go1.18.1
+  go_version: go1.18.3
   version: v0.19.2-1-g208b1e1
 api_directory_checksum: 8c35bdcab21768638dfaa277896e05fdd8a11969
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 93b679809f07b0ffa74b5ac6dce890d955e2cc19
+  file_checksum: a449c60961ff34281c9c0a0bd24b38b40feac2da
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-12T21:32:12Z"
+  build_date: "2022-07-12T22:37:06Z"
   build_hash: 208b1e15257d57c46729698f47a40fd59441ecbd
   go_version: go1.18.3
   version: v0.19.2-1-g208b1e1
@@ -7,7 +7,7 @@ api_directory_checksum: 8c35bdcab21768638dfaa277896e05fdd8a11969
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: a449c60961ff34281c9c0a0bd24b38b40feac2da
+  file_checksum: ce0253f7770660b25e56de37ffd357fc65d00cd0
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-12T22:37:06Z"
+  build_date: "2022-07-13T18:52:15Z"
   build_hash: 208b1e15257d57c46729698f47a40fd59441ecbd
   go_version: go1.18.3
   version: v0.19.2-1-g208b1e1
@@ -7,7 +7,7 @@ api_directory_checksum: 8c35bdcab21768638dfaa277896e05fdd8a11969
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: ce0253f7770660b25e56de37ffd357fc65d00cd0
+  file_checksum: b8c9656298e66891b1a4ecf1c915423499795c6c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -235,11 +235,7 @@ resources:
   InternetGateway:
     exceptions:
       terminal_codes:
-      - InvalidInternetGatewayID.NotFound
-      - InvalidInternetGatewayId.Malformed
       - InvalidVpcId.Malformed
-      - InvalidVpcID.NotFound
-      - InvalidParameterValue
     fields:
       Tags:
         from:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -237,8 +237,6 @@ resources:
       terminal_codes:
       - InvalidInternetGatewayID.NotFound
       - InvalidInternetGatewayId.Malformed
-      - Resource.AlreadyAssociated
-      - Gateway.NotAttached
       - InvalidVpcId.Malformed
       - InvalidVpcID.NotFound
       - InvalidParameterValue

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -233,6 +233,15 @@ resources:
       sdk_read_many_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_read_many_post_build_request.go.tpl
   InternetGateway:
+    exceptions:
+      terminal_codes:
+      - InvalidInternetGatewayID.NotFound
+      - InvalidInternetGatewayId.Malformed
+      - Resource.AlreadyAssociated
+      - Gateway.NotAttached
+      - InvalidVpcId.Malformed
+      - InvalidVpcID.NotFound
+      - InvalidParameterValue
     fields:
       Tags:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -235,11 +235,7 @@ resources:
   InternetGateway:
     exceptions:
       terminal_codes:
-      - InvalidInternetGatewayID.NotFound
-      - InvalidInternetGatewayId.Malformed
       - InvalidVpcId.Malformed
-      - InvalidVpcID.NotFound
-      - InvalidParameterValue
     fields:
       Tags:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -237,8 +237,6 @@ resources:
       terminal_codes:
       - InvalidInternetGatewayID.NotFound
       - InvalidInternetGatewayId.Malformed
-      - Resource.AlreadyAssociated
-      - Gateway.NotAttached
       - InvalidVpcId.Malformed
       - InvalidVpcID.NotFound
       - InvalidParameterValue

--- a/generator.yaml
+++ b/generator.yaml
@@ -233,6 +233,15 @@ resources:
       sdk_read_many_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_read_many_post_build_request.go.tpl
   InternetGateway:
+    exceptions:
+      terminal_codes:
+      - InvalidInternetGatewayID.NotFound
+      - InvalidInternetGatewayId.Malformed
+      - Resource.AlreadyAssociated
+      - Gateway.NotAttached
+      - InvalidVpcId.Malformed
+      - InvalidVpcID.NotFound
+      - InvalidParameterValue
     fields:
       Tags:
         from:

--- a/pkg/resource/internet_gateway/sdk.go
+++ b/pkg/resource/internet_gateway/sdk.go
@@ -421,8 +421,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	switch awsErr.Code() {
 	case "InvalidInternetGatewayID.NotFound",
 		"InvalidInternetGatewayId.Malformed",
-		"Resource.AlreadyAssociated",
-		"Gateway.NotAttached",
 		"InvalidVpcId.Malformed",
 		"InvalidVpcID.NotFound",
 		"InvalidParameterValue":

--- a/pkg/resource/internet_gateway/sdk.go
+++ b/pkg/resource/internet_gateway/sdk.go
@@ -411,6 +411,23 @@ func (rm *resourceManager) updateConditions(
 // and if the exception indicates that it is a Terminal exception
 // 'Terminal' exception are specified in generator configuration
 func (rm *resourceManager) terminalAWSError(err error) bool {
-	// No terminal_errors specified for this resource in generator config
-	return false
+	if err == nil {
+		return false
+	}
+	awsErr, ok := ackerr.AWSError(err)
+	if !ok {
+		return false
+	}
+	switch awsErr.Code() {
+	case "InvalidInternetGatewayID.NotFound",
+		"InvalidInternetGatewayId.Malformed",
+		"Resource.AlreadyAssociated",
+		"Gateway.NotAttached",
+		"InvalidVpcId.Malformed",
+		"InvalidVpcID.NotFound",
+		"InvalidParameterValue":
+		return true
+	default:
+		return false
+	}
 }

--- a/pkg/resource/internet_gateway/sdk.go
+++ b/pkg/resource/internet_gateway/sdk.go
@@ -419,11 +419,7 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		return false
 	}
 	switch awsErr.Code() {
-	case "InvalidInternetGatewayID.NotFound",
-		"InvalidInternetGatewayId.Malformed",
-		"InvalidVpcId.Malformed",
-		"InvalidVpcID.NotFound",
-		"InvalidParameterValue":
+	case "InvalidVpcId.Malformed":
 		return true
 	default:
 		return false

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -183,40 +183,9 @@ class TestInternetGateway:
         # Check Internet Gateway no longer exists in AWS
         ec2_validator.assert_internet_gateway(resource_id, exists=False)
 
-    def test_terminal_condition_invalid_vpcid(self):
-        test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("ig-ack-fail-1", 24)
-        test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
-        test_resource_values["VPC_ID"] = "vpc-12345678"
-
-        # Load Internet Gateway CR
-        resource_data = load_ec2_resource(
-            "internet_gateway_vpc_attachment",
-            additional_replacements=test_resource_values,
-        )
-        logging.debug(resource_data)
-
-        # Create k8s resource
-        ref = k8s.CustomResourceReference(
-            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
-            resource_name, namespace="default",
-        )
-        k8s.create_custom_resource(ref, resource_data)
-        cr = k8s.wait_resource_consumed_by_controller(ref)
-
-        assert cr is not None
-        assert k8s.get_resource_exists(ref)
-
-        expected_msg = "InvalidVpcID.NotFound: The vpc ID 'vpc-12345678' does not exist"
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # An error occurred (InvalidVpcID.NotFound) when calling the AttachInternetGateway operation: 
-        # The vpc ID 'vpc-12345678' does not exist
-        assert expected_msg in terminal_condition['message']
-
     def test_terminal_condition_malformed_vpc(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("ig-ack-fail-2", 24)
+        resource_name = random_suffix_name("ig-ack-fail-1", 24)
         test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
         test_resource_values["VPC_ID"] = "MalformedVpcId"
 

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -185,7 +185,7 @@ class TestInternetGateway:
 
     def test_terminal_condition_invalid_vpcid(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("ig-invalid-vpcid", 24)
+        resource_name = random_suffix_name("internet-gateway-fail-1", 24)
         test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
         test_resource_values["VPC_ID"] = "vpc-12345678"
 
@@ -216,7 +216,7 @@ class TestInternetGateway:
 
     def test_terminal_condition_malformed_vpc(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("ig-malformed-vpcid", 24)
+        resource_name = random_suffix_name("internet-gateway-fail-2", 24)
         test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
         test_resource_values["VPC_ID"] = "MalformedVpcId"
 

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -185,7 +185,7 @@ class TestInternetGateway:
 
     def test_terminal_condition_invalid_vpcid(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("internet-gateway-fail-1", 24)
+        resource_name = random_suffix_name("ig-ack-fail-1", 24)
         test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
         test_resource_values["VPC_ID"] = "vpc-12345678"
 
@@ -216,7 +216,7 @@ class TestInternetGateway:
 
     def test_terminal_condition_malformed_vpc(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
-        resource_name = random_suffix_name("internet-gateway-fail-2", 24)
+        resource_name = random_suffix_name("ig-ack-fail-2", 24)
         test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
         test_resource_values["VPC_ID"] = "MalformedVpcId"
 

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -182,3 +182,66 @@ class TestInternetGateway:
 
         # Check Internet Gateway no longer exists in AWS
         ec2_validator.assert_internet_gateway(resource_id, exists=False)
+
+    def test_terminal_condition_invalid_vpcid(self):
+        test_resource_values = REPLACEMENT_VALUES.copy()
+        resource_name = random_suffix_name("ig-invalid-vpcid", 24)
+        test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
+        test_resource_values["VPC_ID"] = "vpc-12345678"
+
+        # Load Internet Gateway CR
+        resource_data = load_ec2_resource(
+            "internet_gateway_vpc_attachment",
+            additional_replacements=test_resource_values,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        expected_msg = "InvalidVpcID.NotFound: The vpc ID 'vpc-12345678' does not exist"
+        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
+        # Example condition message:
+        # An error occurred (InvalidVpcID.NotFound) when calling the AttachInternetGateway operation: 
+        # The vpc ID 'vpc-12345678' does not exist
+        assert expected_msg in terminal_condition['message']
+
+    def test_terminal_condition_malformed_vpc(self):
+        test_resource_values = REPLACEMENT_VALUES.copy()
+        resource_name = random_suffix_name("ig-malformed-vpcid", 24)
+        test_resource_values["INTERNET_GATEWAY_NAME"] = resource_name
+        test_resource_values["VPC_ID"] = "MalformedVpcId"
+
+        # Load Internet Gateway CR
+        resource_data = load_ec2_resource(
+            "internet_gateway_vpc_attachment",
+            additional_replacements=test_resource_values,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        expected_msg = 'InvalidVpcId.Malformed: Invalid id: "MalformedVpcId"'
+        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
+        # Example condition message:
+        # An error occurred (InvalidVpcId.Malformed) when calling the AttachInternetGateway operation:
+        # Invalid id: "MalformedVpcId" 
+        # (expecting "vpc-...")
+        assert expected_msg in terminal_condition['message']


### PR DESCRIPTION
Issue #, if available: [1362](https://github.com/aws-controllers-k8s/community/issues/1362)

Description of changes:

Made the following changes in order to map exceptions for **internet gateway** resource in ec2-controller.
      - Added terminal codes in the "generator.yaml" for internet gateway resource.
      - Added few integration tests for internet gateway resource that cover invalid and malformed vpc-id.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
