### PR TITLE
Removing InvalidVpcId Not Found error from terminal codes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-07-27T20:49:18Z"
+  build_date: "2022-08-02T21:22:57Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
   go_version: go1.18.3
   version: v0.19.3
@@ -7,7 +7,7 @@ api_directory_checksum: 8c35bdcab21768638dfaa277896e05fdd8a11969
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 408f1670239ae06ac55ce0b26cb642eccfe68915
+  file_checksum: adb5f55a4d7edff7d658a208d5ae3bf6d86f3172
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -477,7 +477,6 @@ resources:
     exceptions:
       terminal_codes:
         - InvalidVpcId.Malformed
-        - InvalidVpcId.NotFound
         - InvalidServiceName
     hooks:
       sdk_create_post_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -477,7 +477,6 @@ resources:
     exceptions:
       terminal_codes:
         - InvalidVpcId.Malformed
-        - InvalidVpcId.NotFound
         - InvalidServiceName
     hooks:
       sdk_create_post_build_request:

--- a/pkg/resource/vpc_endpoint/sdk.go
+++ b/pkg/resource/vpc_endpoint/sdk.go
@@ -656,7 +656,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 	switch awsErr.Code() {
 	case "InvalidVpcId.Malformed",
-		"InvalidVpcId.NotFound",
 		"InvalidServiceName":
 		return true
 	default:


### PR DESCRIPTION
Issue #, if available: [1362](https://github.com/aws-controllers-k8s/community/issues/1362)

Description of changes:

- Removed **InvalidVpcId.NotFound** from terminal codes for **VpcEndpoint** resource as 'NotFound' errors should not be included in terminal codes as per prior discussions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
