### PR TITLE
Fix Internet Gateway terminal codes

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-08-02T21:22:57Z"
+  build_date: "2022-08-08T17:04:17Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
   go_version: go1.18.3
   version: v0.19.3
@@ -7,7 +7,7 @@ api_directory_checksum: 8c35bdcab21768638dfaa277896e05fdd8a11969
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: adb5f55a4d7edff7d658a208d5ae3bf6d86f3172
+  file_checksum: da927f39a013c7d5ed82db3df0daf4cd22c605d3
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -236,9 +236,6 @@ resources:
       sdk_read_many_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_read_many_post_build_request.go.tpl
   InternetGateway:
-    exceptions:
-      terminal_codes:
-      - InvalidVpcId.Malformed
     fields:
       Tags:
         from:

--- a/generator.yaml
+++ b/generator.yaml
@@ -236,9 +236,6 @@ resources:
       sdk_read_many_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_read_many_post_build_request.go.tpl
   InternetGateway:
-    exceptions:
-      terminal_codes:
-      - InvalidVpcId.Malformed
     fields:
       Tags:
         from:

--- a/pkg/resource/internet_gateway/sdk.go
+++ b/pkg/resource/internet_gateway/sdk.go
@@ -415,17 +415,6 @@ func (rm *resourceManager) updateConditions(
 // and if the exception indicates that it is a Terminal exception
 // 'Terminal' exception are specified in generator configuration
 func (rm *resourceManager) terminalAWSError(err error) bool {
-	if err == nil {
-		return false
-	}
-	awsErr, ok := ackerr.AWSError(err)
-	if !ok {
-		return false
-	}
-	switch awsErr.Code() {
-	case "InvalidVpcId.Malformed":
-		return true
-	default:
-		return false
-	}
+	// No terminal_errors specified for this resource in generator config
+	return false
 }


### PR DESCRIPTION
Issue #, if available: [1362](https://github.com/aws-controllers-k8s/community/issues/1362)

Description of changes: 

- Removed `InvalidVpcId.Malformed` error from terminal codes for **Internet Gateway** resource.
- Removed Integration tests for the `InvalidVpcId.Malformed` terminal code.

Initially, I thought `InvalidVpcId.Malformed` should be included in the terminal codes. Later, observed that Internet Gateway resource being created after adding the integration tests for the malformed vpc id terminal code. This is expected as per our code because initially the resource will be created with no vpc attachment and later if we pass VPC ID, it will be attached to the resource. After discussions and local testing I observed that if you add malformed VPC ID it will create a resource and if you try to update the VPC ID to a valid one, it will create a new resource and leave the initial one in dangling state that cannot be deleted, so we decided not to include malformed VPC ID  for Internet Gateway resource.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
