### PR TITLE
refactor vpc test to use fixture

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -29,6 +29,9 @@ def pytest_configure(config):
     config.addinivalue_line(
         "markers", "slow: mark test as slow to run"
     )
+    config.addinivalue_line(
+        "markers", "vpc_data: mark test with data to pass to vpc fixture"
+    )
 
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--runslow"):


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Refactoring e2e tests to use `pytest.fixture` for the **resource under test**. Otherwise, assertion failures within the test may not lead to successful resource cleanup.

Testing: Prior to changes, added an assert to fail `test_enable_attributes` and saw dangling VPC in account. Tested the same after changes and VPC was deleted as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
