### PR TITLE
Refactor `InternetGateway` tests to use fixture

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -13,11 +13,20 @@
 
 import boto3
 import pytest
+import time
+import logging
+
 from acktest.aws.identity import get_region
+from acktest.resources import random_suffix_name
+from acktest.k8s import resource as k8s
+from e2e import CRD_GROUP, CRD_VERSION, load_ec2_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+
+VPC_CREATE_WAIT_AFTER_SECONDS = 10
+VPC_RESOURCE_PLURAL = "vpcs"
 
 def pytest_addoption(parser):
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
-
 
 def pytest_configure(config):
     config.addinivalue_line(
@@ -46,3 +55,50 @@ def pytest_collection_modifyitems(config, items):
 def ec2_client():
     region = get_region()
     return boto3.client("ec2", region)
+
+@pytest.fixture
+def simple_vpc(request):
+    resource_name = random_suffix_name("vpc-ack-test", 24)
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["VPC_NAME"] = resource_name
+    replacements["CIDR_BLOCK"] = "10.0.0.0/16"
+    replacements["ENABLE_DNS_SUPPORT"] = "False"
+    replacements["ENABLE_DNS_HOSTNAMES"] = "False"
+
+    marker = request.node.get_closest_marker("vpc_data")
+    if marker is not None:
+        data = marker.args[0]
+        if 'cidr_block' in data:
+            replacements["CIDR_BLOCK"] = data['cidr_block']
+        if 'enable_dns_support' in data:
+            replacements["ENABLE_DNS_SUPPORT"] = data['enable_dns_support']
+        if 'enable_dns_hostnames' in data:
+            replacements["ENABLE_DNS_HOSTNAMES"] = data['enable_dns_hostnames']
+
+    # Load VPC CR
+    resource_data = load_ec2_resource(
+        "vpc",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, VPC_RESOURCE_PLURAL,
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    time.sleep(VPC_CREATE_WAIT_AFTER_SECONDS)
+
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+    except:
+        pass


### PR DESCRIPTION
Refactoring e2e tests to use pytest.fixture for the resource under
test. Prior to these changes, assertion failures could leave dangling
resources in the testing account.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
