### PR TITLE
Consolidate pytest markers in e2e tests

### DIFF
--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -39,7 +39,7 @@ def pytest_configure(config):
         "markers", "slow: mark test as slow to run"
     )
     config.addinivalue_line(
-        "markers", "vpc_data: mark test with data to pass to vpc fixture"
+        "markers", "resource_data: mark test with data to use when creating fixture"
     )
 
 def pytest_collection_modifyitems(config, items):
@@ -65,7 +65,7 @@ def simple_vpc(request):
     replacements["ENABLE_DNS_SUPPORT"] = "False"
     replacements["ENABLE_DNS_HOSTNAMES"] = "False"
 
-    marker = request.node.get_closest_marker("vpc_data")
+    marker = request.node.get_closest_marker("resource_data")
     if marker is not None:
         data = marker.args[0]
         if 'cidr_block' in data:

--- a/test/e2e/tests/test_dhcp_options.py
+++ b/test/e2e/tests/test_dhcp_options.py
@@ -42,7 +42,7 @@ def simple_dhcp_options(request):
     replacements["DHCP_VAL_2_1"] = "10.2.5.1"
     replacements["DHCP_VAL_2_2"] = "10.2.5.2"
 
-    marker = request.node.get_closest_marker("dhcp_options_data")
+    marker = request.node.get_closest_marker("resource_data")
     if marker is not None:
         data = marker.args[0]
         if 'dhcp_key_1' in data:
@@ -102,7 +102,7 @@ class TestDhcpOptions:
         # Check DHCP Options no longer exists in AWS
         ec2_validator.assert_dhcp_options(resource_id, exists=False)
 
-    @pytest.mark.dhcp_options_data({'dhcp_key_1': 'InvalidValue'})
+    @pytest.mark.resource_data({'dhcp_key_1': 'InvalidValue'})
     def test_terminal_condition_invalid_parameter_value(self, simple_dhcp_options):
         (ref, _) = simple_dhcp_options
 

--- a/test/e2e/tests/test_elastic_ip_address.py
+++ b/test/e2e/tests/test_elastic_ip_address.py
@@ -55,7 +55,7 @@ def simple_elastic_ip_address(request):
     replacements["ADDRESS_NAME"] = resource_name
     replacements["PUBLIC_IPV4_POOL"] = "amazon"
 
-    marker = request.node.get_closest_marker("elastic_ip_address_data")
+    marker = request.node.get_closest_marker("resource_data")
     if marker is not None:
         data = marker.args[0]
         if 'resource_file' in data:
@@ -114,7 +114,7 @@ class TestElasticIPAddress:
         exists = address_exists(ec2_client, resource_id)
         assert not exists
     
-    @pytest.mark.elastic_ip_address_data({'public_ipv4_pool': 'InvalidIpV4Address'})
+    @pytest.mark.resource_data({'public_ipv4_pool': 'InvalidIpV4Address'})
     def test_terminal_condition_invalid_parameter_value(self, simple_elastic_ip_address):
         (ref, _) = simple_elastic_ip_address
 
@@ -125,7 +125,7 @@ class TestElasticIPAddress:
         # invalid value for parameter pool: InvalidIpV4Address
         assert expected_msg in terminal_condition['message']
 
-    @pytest.mark.elastic_ip_address_data({'address': '52.27.68.220', 'resource_file': 'invalid/elastic_ip_invalid_combination'})
+    @pytest.mark.resource_data({'address': '52.27.68.220', 'resource_file': 'invalid/elastic_ip_invalid_combination'})
     def test_terminal_condition_invalid_parameter_combination(self, simple_elastic_ip_address):
         (ref, _) = simple_elastic_ip_address
 

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -41,7 +41,7 @@ def simple_internet_gateway(request, simple_vpc):
     replacements = REPLACEMENT_VALUES.copy()
     replacements["INTERNET_GATEWAY_NAME"] = resource_name
 
-    marker = request.node.get_closest_marker("bootstrap_options")
+    marker = request.node.get_closest_marker("resource_data")
     if marker is not None:
         data = marker.args[0]
         if 'resource_file' in data:
@@ -99,7 +99,7 @@ class TestInternetGateway:
         # Check Internet Gateway no longer exists in AWS
         ec2_validator.assert_internet_gateway(resource_id, exists=False)
 
-    @pytest.mark.bootstrap_options({'create_vpc': True, 'resource_file': 'internet_gateway_vpc_attachment'})
+    @pytest.mark.resource_data({'create_vpc': True, 'resource_file': 'internet_gateway_vpc_attachment'})
     def test_vpc_association(self, ec2_client, simple_internet_gateway):
         (ref, cr) = simple_internet_gateway
 

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -41,7 +41,7 @@ def simple_security_group(request):
     replacements["VPC_ID"] = test_vpc.vpc_id
     replacements["SECURITY_GROUP_DESCRIPTION"] = "TestSecurityGroup"
 
-    marker = request.node.get_closest_marker("fixture_overrides")
+    marker = request.node.get_closest_marker("resource_data")
     if marker is not None:
         data = marker.args[0]
         if 'resource_file' in data:
@@ -97,7 +97,7 @@ class TestSecurityGroup:
         # Check Security Group no longer exists in AWS
         ec2_validator.assert_security_group(resource_id, exists=False)
 
-    @pytest.mark.fixture_overrides({
+    @pytest.mark.resource_data({
         'resource_file': 'security_group_rule',
         'IP_PROTOCOL': 'tcp',
         'FROM_PORT': "80",

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -65,7 +65,7 @@ class TestVpc:
         # Check VPC no longer exists in AWS
         ec2_validator.assert_vpc(resource_id, exists=False)
 
-    @pytest.mark.vpc_data({'enable_dns_support': 'true', 'enable_dns_hostnames': 'true'})
+    @pytest.mark.resource_data({'enable_dns_support': 'true', 'enable_dns_hostnames': 'true'})
     def test_enable_attributes(self, ec2_client, simple_vpc):
         (ref, cr) = simple_vpc
         resource_id = cr["status"]["vpcID"]


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Consolidates markers used to pass data to fixtures into `resource_data`. This also removes *Warning* logs from the test because now all markers will be registered

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
