### PR TITLE
Add `Update` functionality for `VPC.CIDRBlocks`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-09-06T18:39:23Z"
+  build_date: "2022-09-06T20:17:17Z"
   build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
   go_version: go1.18.1
   version: v0.19.3
-api_directory_checksum: 6b7708a8cacb471891466f5851f248e0e895f2c2
+api_directory_checksum: 3960da50b98c36b05635d3abbfd129ae7bb48e32
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 9586b277b014daec6188d09741c607c96b1201fb
+  file_checksum: b17fda4c7e3ae9446dd568f3be1f08d70ce15588
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -429,6 +429,7 @@ resources:
       CIDRBlocks:
         custom_field:
           list_of: String
+        is_required: true
       EnableDNSSupport:
         from:
           operation: ModifyVpcAttribute

--- a/apis/v1alpha1/vpc.go
+++ b/apis/v1alpha1/vpc.go
@@ -29,7 +29,8 @@ type VPCSpec struct {
 	// CIDR block.
 	AmazonProvidedIPv6CIDRBlock *bool `json:"amazonProvidedIPv6CIDRBlock,omitempty"`
 
-	CIDRBlocks []*string `json:"cidrBlocks,omitempty"`
+	// +kubebuilder:validation:Required
+	CIDRBlocks []*string `json:"cidrBlocks"`
 	// The attribute value. The valid values are true or false.
 	EnableDNSHostnames *bool `json:"enableDNSHostnames,omitempty"`
 	// The attribute value. The valid values are true or false.

--- a/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
@@ -90,6 +90,8 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - cidrBlocks
             type: object
           status:
             description: VPCStatus defines the observed state of VPC

--- a/generator.yaml
+++ b/generator.yaml
@@ -429,6 +429,7 @@ resources:
       CIDRBlocks:
         custom_field:
           list_of: String
+        is_required: true
       EnableDNSSupport:
         from:
           operation: ModifyVpcAttribute

--- a/helm/crds/ec2.services.k8s.aws_vpcs.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcs.yaml
@@ -90,6 +90,8 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - cidrBlocks
             type: object
           status:
             description: VPCStatus defines the observed state of VPC

--- a/pkg/resource/vpc/hook.go
+++ b/pkg/resource/vpc/hook.go
@@ -168,11 +168,9 @@ func (rm *resourceManager) syncCIDRBlocks(
 	exit := rlog.Trace("rm.syncCIDRBlocks")
 	defer exit(err)
 
-	desRes := desired.ko.DeepCopy()
-	latestRes := latest.ko.DeepCopy()
-	desiredCIDRs := desRes.Spec.CIDRBlocks
-	latestCIDRs := latestRes.Spec.CIDRBlocks
-	latestCIDRStates := latestRes.Status.CIDRBlockAssociationSet
+	desiredCIDRs := desired.ko.Spec.CIDRBlocks
+	latestCIDRs := latest.ko.Spec.CIDRBlocks
+	latestCIDRStates := latest.ko.Status.CIDRBlockAssociationSet
 	toAddCIDRs, toDeleteCIDRs := computeStringPDifference(desiredCIDRs, latestCIDRs)
 
 	// extract associationID for the DisassociateVpcCidr request

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -200,6 +200,7 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	rm.setSpecCIDRs(ko)
 	if dnsAttrs, err := rm.getDNSAttributes(ctx, *ko.Status.VPCID); err != nil {
 		return nil, err
 	} else {
@@ -373,6 +374,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	rm.setSpecCIDRs(ko)
 	err = rm.createAttributes(ctx, &resource{ko})
 	if err != nil {
 		return nil, err

--- a/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,4 @@
+    rm.setSpecCIDRs(ko)
     err = rm.createAttributes(ctx, &resource{ko})
     if err != nil {
         return nil, err

--- a/templates/hooks/vpc/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/vpc/sdk_read_many_post_set_output.go.tpl
@@ -1,3 +1,4 @@
+	rm.setSpecCIDRs(ko)
 	if dnsAttrs, err := rm.getDNSAttributes(ctx, *ko.Status.VPCID); err != nil {
 		return nil, err
 	} else {

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -128,6 +128,15 @@ class EC2Validator:
             pass
         assert res_found is exists
 
+    def get_vpc(self, vpc_id: str) -> Union[None, Dict]:
+        try:
+            aws_res = self.ec2_client.describe_vpcs(VpcIds=[vpc_id])
+            if len(aws_res["Vpcs"]) > 0:
+                return aws_res["Vpcs"][0]
+            return None
+        except self.ec2_client.exceptions.ClientError:
+            return None
+            
     def assert_vpc(self, vpc_id: str, exists=True):
         res_found = False
         try:


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1198

Description of changes: Enables associating multiple IPv4 CIDR Blocks to a single VPC 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
