### PR TITLE
Update to ACK runtime `v0.20.0`, code-generator `v0.20.0`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-09-06T21:58:54Z"
-  build_hash: 87477ae8ca8ac6ddb8c565bbd910cc7e30f55ed0
-  go_version: go1.18.3
-  version: v0.19.3
+  build_date: "2022-09-07T14:08:15Z"
+  build_hash: 585f06bbd6d4cc1b738acb85901e7a009bf452c7
+  go_version: go1.18.1
+  version: v0.20.0
 api_directory_checksum: 3960da50b98c36b05635d3abbfd129ae7bb48e32
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws-controllers-k8s/ec2-controller
 go 1.17
 
 require (
-	github.com/aws-controllers-k8s/runtime v0.19.3
+	github.com/aws-controllers-k8s/runtime v0.20.0
 	github.com/aws/aws-sdk-go v1.42.0
 	github.com/go-logr/logr v1.2.0
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
-github.com/aws-controllers-k8s/runtime v0.19.3 h1:difFG8eFrQuIZb+FGEKMLrGlhY/QwKq++W33oMg+c3Q=
-github.com/aws-controllers-k8s/runtime v0.19.3/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
+github.com/aws-controllers-k8s/runtime v0.20.0 h1:W91KYhjc+AvMhxguJTs3P5ZbkI6DUDzLdhL9pMjBxZE=
+github.com/aws-controllers-k8s/runtime v0.20.0/go.mod h1:oA8ML1/LL3chPn26P6SzBNu1CUI2nekB+PTqykNs0qU=
 github.com/aws/aws-sdk-go v1.42.0 h1:BMZws0t8NAhHFsfnT3B40IwD13jVDG5KerlRksctVIw=
 github.com/aws/aws-sdk-go v1.42.0/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -106,7 +106,7 @@ spec:
       affinity: {{ toYaml .Values.deployment.affinity | nindent 8 }}
       {{ end -}}
       {{ if .Values.deployment.priorityClassName -}}
-      priorityClassName: {{ .Values.deployment.priorityClassName -}}
+      priorityClassName: {{ .Values.deployment.priorityClassName }}
       {{ end -}}
       hostIPC: false
       hostNetwork: false


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: update `go.mod` to use *runtime* `v0.20.0` & generate with *code-generator* `v0.20.0`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
