### PR TITLE
UpdateTags support for VPC

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-09-07T14:24:14Z"
+  build_date: "2022-09-07T22:46:46Z"
   build_hash: 585f06bbd6d4cc1b738acb85901e7a009bf452c7
-  go_version: go1.18.1
+  go_version: go1.18.3
   version: v0.20.0
 api_directory_checksum: 3960da50b98c36b05635d3abbfd129ae7bb48e32
 api_version: v1alpha1
 aws_sdk_go_version: v1.42.0
 generator_config_info:
-  file_checksum: 6c21f6d996045b6c6c7c79074147f9bbcff5a73c
+  file_checksum: 7862e66fc124ed9cba5b17483244f5619039eb23
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-07T22:46:46Z"
+  build_date: "2022-09-08T18:33:19Z"
   build_hash: 585f06bbd6d4cc1b738acb85901e7a009bf452c7
   go_version: go1.18.3
   version: v0.20.0

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -451,6 +451,8 @@ resources:
         template_path: hooks/vpc/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/vpc/sdk_read_many_post_set_output.go.tpl
+      sdk_file_end:
+        template_path: hooks/vpc/sdk_file_end.go.tpl
   VpcEndpoint:
     fields:
       PolicyDocument:

--- a/config/crd/common/bases/services.k8s.aws_fieldexports.yaml
+++ b/config/crd/common/bases/services.k8s.aws_fieldexports.yaml
@@ -66,6 +66,10 @@ spec:
                 description: FieldExportTarget provides the values necessary to identify
                   the output path for a field export.
                 properties:
+                  key:
+                    description: Key overrides the default value (`<namespace>.<FieldExport-resource-name>`)
+                      for the FieldExport target
+                    type: string
                   kind:
                     description: FieldExportOutputType represents all types that can
                       be produced by a field export operation

--- a/generator.yaml
+++ b/generator.yaml
@@ -451,6 +451,8 @@ resources:
         template_path: hooks/vpc/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/vpc/sdk_read_many_post_set_output.go.tpl
+      sdk_file_end:
+        template_path: hooks/vpc/sdk_file_end.go.tpl
   VpcEndpoint:
     fields:
       PolicyDocument:

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -66,6 +66,10 @@ spec:
                 description: FieldExportTarget provides the values necessary to identify
                   the output path for a field export.
                 properties:
+                  key:
+                    description: Key overrides the default value (`<namespace>.<FieldExport-resource-name>`)
+                      for the FieldExport target
+                    type: string
                   kind:
                     description: FieldExportOutputType represents all types that can
                       be produced by a field export operation

--- a/pkg/resource/vpc/hook.go
+++ b/pkg/resource/vpc/hook.go
@@ -281,6 +281,121 @@ func applyPrimaryCIDRBlockInCreateRequest(r *resource,
 	}
 }
 
+// syncTags used to keep tags in sync using createTags and deleteTags functions
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func(err error) {
+		exit(err)
+	}(err)
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if err = rm.deleteTags(ctx, latest, toDelete); err != nil {
+		return err
+	}
+
+	if err = rm.createTags(ctx, desired, toAdd); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createTags function creates tags for VPC resource using CreateTags API calls
+func (rm *resourceManager) createTags(
+	ctx context.Context,
+	r *resource,
+	tags []*svcapitypes.Tag,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.createTags")
+	defer exit(err)
+
+	resourceId := []*string{r.ko.Status.VPCID}
+
+	for _, i := range tags {
+		toAdd := rm.newTag(*i)
+		req := &svcsdk.CreateTagsInput{
+			Resources: resourceId,
+			Tags:      []*svcsdk.Tag{toAdd},
+		}
+		_, err := rm.sdkapi.CreateTagsWithContext(ctx, req)
+		rm.metrics.RecordAPICall("CREATE", "CreateTags", err)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// deleteTags function deletes tags from VPC resource using DeleteTags API calls
+func (rm *resourceManager) deleteTags(
+	ctx context.Context,
+	r *resource,
+	tags []*svcapitypes.Tag,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.deleteTags")
+	defer exit(err)
+
+	resourceId := []*string{r.ko.Status.VPCID}
+
+	for _, i := range tags {
+		toDelete := rm.newTag(*i)
+		req := &svcsdk.DeleteTagsInput{
+			Resources: resourceId,
+			Tags:      []*svcsdk.Tag{toDelete},
+		}
+		_, err = rm.sdkapi.DeleteTagsWithContext(ctx, req)
+		rm.metrics.RecordAPICall("DELETE", "DeleteTags", err)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// computeTagsDelta returns tags to be added and removed from the resource
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
+
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[*tag.Key] = *tag.Value
+	}
+
+	latestTags := map[string]string{}
+	for _, tag := range latest {
+		latestTags[*tag.Key] = *tag.Value
+	}
+
+	for _, tag := range desired {
+		val, ok := latestTags[*tag.Key]
+		if !ok || val != *tag.Value {
+			toAdd = append(toAdd, tag)
+		}
+	}
+
+	for _, tag := range latest {
+		_, ok := desiredTags[*tag.Key]
+		if !ok {
+			toDelete = append(toDelete, tag)
+		}
+	}
+
+	return toAdd, toDelete
+
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateVpcInput.TagSpecification
 // and ensures the ResourceType is always set to 'vpc'

--- a/pkg/resource/vpc/hook.go
+++ b/pkg/resource/vpc/hook.go
@@ -267,6 +267,12 @@ func (rm *resourceManager) customUpdate(
 		}
 	}
 
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+
 	rm.setStatusDefaults(ko)
 	return &resource{ko}, nil
 }

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -569,29 +569,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 }
 
-func compareTag(
-	a *svcapitypes.Tag,
-	b *svcapitypes.Tag,
-) *ackcompare.Delta {
-	delta := ackcompare.NewDelta()
-	if ackcompare.HasNilDifference(a.Key, b.Key) {
-		delta.Add("Tag.Key", a.Key, b.Key)
-	} else if a.Key != nil && b.Key != nil {
-		if *a.Key != *b.Key {
-			delta.Add("Tag.Key", a.Key, b.Key)
-		}
-	}
-	if ackcompare.HasNilDifference(a.Value, b.Value) {
-		delta.Add("Tag.Value", a.Value, b.Value)
-	} else if a.Value != nil && b.Value != nil {
-		if *a.Value != *b.Value {
-			delta.Add("Tag.Value", a.Value, b.Value)
-		}
-	}
-
-	return delta
-}
-
 func (rm *resourceManager) newTag(
 	c svcapitypes.Tag,
 ) *svcsdk.Tag {

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -568,3 +568,40 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 		return false
 	}
 }
+
+func compareTag(
+	a *svcapitypes.Tag,
+	b *svcapitypes.Tag,
+) *ackcompare.Delta {
+	delta := ackcompare.NewDelta()
+	if ackcompare.HasNilDifference(a.Key, b.Key) {
+		delta.Add("Tag.Key", a.Key, b.Key)
+	} else if a.Key != nil && b.Key != nil {
+		if *a.Key != *b.Key {
+			delta.Add("Tag.Key", a.Key, b.Key)
+		}
+	}
+	if ackcompare.HasNilDifference(a.Value, b.Value) {
+		delta.Add("Tag.Value", a.Value, b.Value)
+	} else if a.Value != nil && b.Value != nil {
+		if *a.Value != *b.Value {
+			delta.Add("Tag.Value", a.Value, b.Value)
+		}
+	}
+
+	return delta
+}
+
+func (rm *resourceManager) newTag(
+	c svcapitypes.Tag,
+) *svcsdk.Tag {
+	res := &svcsdk.Tag{}
+	if c.Key != nil {
+		res.SetKey(*c.Key)
+	}
+	if c.Value != nil {
+		res.SetValue(*c.Value)
+	}
+
+	return res
+}

--- a/templates/hooks/subnet/delta_pre_compare.go.tpl
+++ b/templates/hooks/subnet/delta_pre_compare.go.tpl
@@ -1,1 +1,0 @@
-compareTags(delta, a, b)

--- a/templates/hooks/vpc/sdk_file_end.go.tpl
+++ b/templates/hooks/vpc/sdk_file_end.go.tpl
@@ -1,0 +1,32 @@
+{{ $CRD := .CRD }}
+{{ $SDKAPI := .SDKAPI }}
+
+{{/* Generate helper methods for VPC */}}
+{{- range $specFieldName, $specField := $CRD.Config.Resources.Vpc.Fields }}
+{{- if $specField.From }}
+{{- $operationName := $specField.From.Operation }}
+{{- $operation := (index $SDKAPI.API.Operations $operationName) -}}
+{{- range $vpcRefName, $vpcMemberRefs := $operation.InputRef.Shape.MemberRefs -}}
+{{- if eq $vpcRefName "Tags" }}
+{{- $vpcRef := $vpcMemberRefs.Shape.MemberRef }}
+{{- $vpcRefName = "Tag" }}
+func compare{{ $vpcRefName }}(
+	    a *svcapitypes.{{ $vpcRefName }},
+	    b *svcapitypes.{{ $vpcRefName }},
+) *ackcompare.Delta {
+	delta := ackcompare.NewDelta()
+{{ GoCodeCompareStruct $CRD $vpcRef.Shape "delta" "a" "b" $vpcRefName 1 }}
+	return delta
+}
+
+func (rm *resourceManager) new{{ $vpcRefName }}(
+	    c svcapitypes.{{ $vpcRefName }},
+) *svcsdk.{{ $vpcRefName }} {
+	res := &svcsdk.{{ $vpcRefName }}{}
+{{ GoCodeSetSDKForStruct $CRD "" "res" $vpcRef "" "c" 1 }}
+	return res
+}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/templates/hooks/vpc/sdk_file_end.go.tpl
+++ b/templates/hooks/vpc/sdk_file_end.go.tpl
@@ -10,15 +10,6 @@
 {{- if eq $vpcRefName "Tags" }}
 {{- $vpcRef := $vpcMemberRefs.Shape.MemberRef }}
 {{- $vpcRefName = "Tag" }}
-func compare{{ $vpcRefName }}(
-	    a *svcapitypes.{{ $vpcRefName }},
-	    b *svcapitypes.{{ $vpcRefName }},
-) *ackcompare.Delta {
-	delta := ackcompare.NewDelta()
-{{ GoCodeCompareStruct $CRD $vpcRef.Shape "delta" "a" "b" $vpcRefName 1 }}
-	return delta
-}
-
 func (rm *resourceManager) new{{ $vpcRefName }}(
 	    c svcapitypes.{{ $vpcRefName }},
 ) *svcsdk.{{ $vpcRefName }} {

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -74,10 +74,10 @@ def simple_vpc(request):
             replacements["ENABLE_DNS_SUPPORT"] = data['enable_dns_support']
         if 'enable_dns_hostnames' in data:
             replacements["ENABLE_DNS_HOSTNAMES"] = data['enable_dns_hostnames']
-        if 'key' in data:
-            replacements["TAG_KEY"] = data['key']
-        if 'value' in data:
-            replacements["TAG_VALUE"] = data['value']
+        if 'tag_key' in data:
+            replacements["TAG_KEY"] = data['tag_key']
+        if 'tag_value' in data:
+            replacements["TAG_VALUE"] = data['tag_value']
 
     # Load VPC CR
     resource_data = load_ec2_resource(

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -74,6 +74,10 @@ def simple_vpc(request):
             replacements["ENABLE_DNS_SUPPORT"] = data['enable_dns_support']
         if 'enable_dns_hostnames' in data:
             replacements["ENABLE_DNS_HOSTNAMES"] = data['enable_dns_hostnames']
+        if 'key' in data:
+            replacements["KEY"] = data['key']
+        if 'value' in data:
+            replacements["VALUE"] = data['value']
 
     # Load VPC CR
     resource_data = load_ec2_resource(

--- a/test/e2e/conftest.py
+++ b/test/e2e/conftest.py
@@ -75,9 +75,9 @@ def simple_vpc(request):
         if 'enable_dns_hostnames' in data:
             replacements["ENABLE_DNS_HOSTNAMES"] = data['enable_dns_hostnames']
         if 'key' in data:
-            replacements["KEY"] = data['key']
+            replacements["TAG_KEY"] = data['key']
         if 'value' in data:
-            replacements["VALUE"] = data['value']
+            replacements["TAG_VALUE"] = data['value']
 
     # Load VPC CR
     resource_data = load_ec2_resource(

--- a/test/e2e/resources/vpc.yaml
+++ b/test/e2e/resources/vpc.yaml
@@ -7,3 +7,6 @@ spec:
   - $CIDR_BLOCK
   enableDNSSupport: $ENABLE_DNS_SUPPORT
   enableDNSHostnames: $ENABLE_DNS_HOSTNAMES
+  tags:
+    - key: $KEY
+      value: $VALUE

--- a/test/e2e/resources/vpc.yaml
+++ b/test/e2e/resources/vpc.yaml
@@ -8,5 +8,5 @@ spec:
   enableDNSSupport: $ENABLE_DNS_SUPPORT
   enableDNSHostnames: $ENABLE_DNS_HOSTNAMES
   tags:
-    - key: $KEY
-      value: $VALUE
+    - key: $TAG_KEY
+      value: $TAG_VALUE

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -84,7 +84,7 @@ class TestVpc:
         # Check VPC no longer exists in AWS
         ec2_validator.assert_vpc(resource_id, exists=False)
 
-    @pytest.mark.resource_data({'key': 'initialtagkey', 'value': 'initialtagvalue'})
+    @pytest.mark.resource_data({'tag_key': 'initialtagkey', 'tag_value': 'initialtagvalue'})
     def test_crud_tags(self, ec2_client, simple_vpc):
         (ref, cr) = simple_vpc
         

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -84,6 +84,72 @@ class TestVpc:
         # Check VPC no longer exists in AWS
         ec2_validator.assert_vpc(resource_id, exists=False)
 
+    @pytest.mark.resource_data({'key': 'initialtagkey', 'value': 'initialtagvalue'})
+    def test_crud_tags(self, ec2_client, simple_vpc):
+        (ref, cr) = simple_vpc
+        
+        resource = k8s.get_resource(ref)
+        resource_id = cr["status"]["vpcID"]
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Check VPC exists in AWS
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_vpc(resource_id)
+        
+        # Check tags exist for VPC resource
+        assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
+        assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
+
+        # New pair of tags
+        new_tags = [
+                {
+                    "key": "updatedtagkey",
+                    "value": "updatedtagvalue",
+                }
+               
+            ]
+
+        # Patch the VPC, updating the tags with new pair
+        updates = {
+            "spec": {"tags": new_tags},
+        }
+
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        
+        # Assert tags are updated for VPC resource
+        resource = k8s.get_resource(ref)
+        assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
+        assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
+
+        # Patch the VPC resource, deleting the tags
+        updates = {
+                "spec": {"tags": []},
+        }
+
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        
+        # Assert tags are deleted
+        resource = k8s.get_resource(ref)
+        assert len(resource['spec']['tags']) == 0
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check VPC no longer exists in AWS
+        ec2_validator.assert_vpc(resource_id, exists=False)
+
     @pytest.mark.resource_data({'enable_dns_support': 'true', 'enable_dns_hostnames': 'true'})
     def test_enable_attributes(self, ec2_client, simple_vpc):
         (ref, cr) = simple_vpc


### PR DESCRIPTION
Description of changes:

- Implemented updateTags support for **VPC** resource using go templates and hook code.
- Added integration tests for updateTags.
- Removed existing `delta_pre_compare.go.tpl` file from subnet templates as we are using `sdk_file_end.go.tpl`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
