### PR TITLE
remove dev preview from olm file in preparation for GA

### DIFF
--- a/olm/olmconfig.yaml
+++ b/olm/olmconfig.yaml
@@ -18,7 +18,7 @@ description: |-
 
 
   This controller is a component of the [AWS Controller for Kubernetes](https://github.com/aws/aws-controllers-k8s)
-  project. This project is currently in **developer preview**.
+  project.
 
 
   **Pre-Installation Steps**
@@ -39,6 +39,14 @@ samples:
 - kind: Subnet
   spec: '{}'
 - kind: TransitGateway
+  spec: '{}'
+- kind: Instance
+  spec: '{}'
+- kind: DHCPOptions
+  spec: '{}'
+- kind: NATGateway
+  spec: '{}'
+- kind: ElasticIPAddress
   spec: '{}'
 maintainers:
 - name: "ec2 maintainer team"


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Removing dev preview to prepare for GA as well as adding in the missing kinds to the samples section, so the CSV is fully filled out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
