### PR TITLE
Fix updateTags support for Subnet

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-08T18:33:19Z"
+  build_date: "2022-09-13T16:18:40Z"
   build_hash: 585f06bbd6d4cc1b738acb85901e7a009bf452c7
   go_version: go1.18.3
   version: v0.20.0

--- a/pkg/resource/subnet/sdk.go
+++ b/pkg/resource/subnet/sdk.go
@@ -599,29 +599,6 @@ func (rm *resourceManager) terminalAWSError(err error) bool {
 	}
 }
 
-func compareTag(
-	a *svcapitypes.Tag,
-	b *svcapitypes.Tag,
-) *ackcompare.Delta {
-	delta := ackcompare.NewDelta()
-	if ackcompare.HasNilDifference(a.Key, b.Key) {
-		delta.Add("Tag.Key", a.Key, b.Key)
-	} else if a.Key != nil && b.Key != nil {
-		if *a.Key != *b.Key {
-			delta.Add("Tag.Key", a.Key, b.Key)
-		}
-	}
-	if ackcompare.HasNilDifference(a.Value, b.Value) {
-		delta.Add("Tag.Value", a.Value, b.Value)
-	} else if a.Value != nil && b.Value != nil {
-		if *a.Value != *b.Value {
-			delta.Add("Tag.Value", a.Value, b.Value)
-		}
-	}
-
-	return delta
-}
-
 func (rm *resourceManager) newTag(
 	c svcapitypes.Tag,
 ) *svcsdk.Tag {

--- a/pkg/resource/vpc/hook.go
+++ b/pkg/resource/vpc/hook.go
@@ -306,7 +306,7 @@ func (rm *resourceManager) syncTags(
 	)
 
 	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from parameter group", "tags", toDelete)
+		rlog.Debug("removing tags from vpc resource", "tags", toDelete)
 		_, err = rm.sdkapi.DeleteTagsWithContext(
 			ctx,
 			&svcsdk.DeleteTagsInput{
@@ -322,7 +322,7 @@ func (rm *resourceManager) syncTags(
 	}
 
 	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to parameter group", "tags", toAdd)
+		rlog.Debug("adding tags to vpc resource", "tags", toAdd)
 		_, err = rm.sdkapi.CreateTagsWithContext(
 			ctx,
 			&svcsdk.CreateTagsInput{

--- a/templates/hooks/subnet/sdk_file_end.go.tpl
+++ b/templates/hooks/subnet/sdk_file_end.go.tpl
@@ -10,15 +10,6 @@
 {{- if eq $subnetRefName "Tags" }}
 {{- $subnetRef := $subnetMemberRefs.Shape.MemberRef }}
 {{- $subnetRefName = "Tag" }}
-func compare{{ $subnetRefName }}(
-	    a *svcapitypes.{{ $subnetRefName }},
-	    b *svcapitypes.{{ $subnetRefName }},
-) *ackcompare.Delta {
-	delta := ackcompare.NewDelta()
-{{ GoCodeCompareStruct $CRD $subnetRef.Shape "delta" "a" "b" $subnetRefName 1 }}
-	return delta
-}
-
 func (rm *resourceManager) new{{ $subnetRefName }}(
 	    c svcapitypes.{{ $subnetRefName }},
 ) *svcsdk.{{ $subnetRefName }} {

--- a/test/e2e/resources/subnet.yaml
+++ b/test/e2e/resources/subnet.yaml
@@ -6,5 +6,5 @@ spec:
   cidrBlock: $CIDR_BLOCK
   vpcID: $VPC_ID
   tags:
-    - key: $KEY
-      value: $VALUE
+    - key: $TAG_KEY
+      value: $TAG_VALUE

--- a/test/e2e/tests/test_subnet.py
+++ b/test/e2e/tests/test_subnet.py
@@ -147,8 +147,8 @@ class TestSubnet:
         test_resource_values["VPC_ID"] = vpc_id
         # CIDR needs to be within SharedTestVPC range and not overlap other subnets
         test_resource_values["CIDR_BLOCK"] = "10.0.255.0/24"
-        test_resource_values["KEY"] = "initialtagkey"
-        test_resource_values["VALUE"] = "initialtagvalue"
+        test_resource_values["TAG_KEY"] = "initialtagkey"
+        test_resource_values["TAG_VALUE"] = "initialtagvalue"
 
         # Load Subnet CR
         resource_data = load_ec2_resource(


### PR DESCRIPTION
Description of changes:

- Removed unused `compareTag` function and changed key-value names to be `TAG_KEY` and `TAG_VALUE` in e2e tests.
- Removed `createTags`, `deleteTags` functions and added `sdkTags` function to reduce the number of API calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
