### PR TITLE
Update tags support for Transit Gateway resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-15T16:27:05Z"
+  build_date: "2022-09-15T18:20:58Z"
   build_hash: 1da44f4be322eea156ed23a86e33c29da5cede9c
   go_version: go1.18.3
   version: v0.20.1-2-g1da44f4
@@ -7,7 +7,7 @@ api_directory_checksum: 127aa0f51fbcdde596b8f42f93bcdf3b6dee8488
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 42f9161f3b7c319d753fd54b681eecd9916d67f6
+  file_checksum: 765a0d09844f3b22d5d0b2d24f39fc0eec244d5c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -435,6 +435,10 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
+      sdk_file_end:
+        template_path: hooks/transit_gateway/sdk_file_end.go.tpl
+    update_operation:
+      custom_method_name: customUpdateTransitGateway
   Vpc:
     update_operation:
       custom_method_name: customUpdate

--- a/generator.yaml
+++ b/generator.yaml
@@ -435,6 +435,10 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
+      sdk_file_end:
+        template_path: hooks/transit_gateway/sdk_file_end.go.tpl
+    update_operation:
+      custom_method_name: customUpdateTransitGateway
   Vpc:
     update_operation:
       custom_method_name: customUpdate

--- a/pkg/resource/transit_gateway/hook.go
+++ b/pkg/resource/transit_gateway/hook.go
@@ -14,8 +14,136 @@
 package transit_gateway
 
 import (
+	"context"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 )
+
+func (rm *resourceManager) customUpdateTransitGateway(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdateTransitGateway")
+	defer exit(err)
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+
+	rm.setStatusDefaults(ko)
+	return &resource{ko}, nil
+}
+
+// syncTags used to keep tags in sync by calling Create and Delete API's
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func(err error) {
+		exit(err)
+	}(err)
+
+	resourceId := []*string{latest.ko.Status.TransitGatewayID}
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if len(toDelete) > 0 {
+		rlog.Debug("removing tags from TransitGateway resource", "tags", toDelete)
+		_, err = rm.sdkapi.DeleteTagsWithContext(
+			ctx,
+			&svcsdk.DeleteTagsInput{
+				Resources: resourceId,
+				Tags:      rm.sdkTags(toDelete),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to TransitGateway resource", "tags", toAdd)
+		_, err = rm.sdkapi.CreateTagsWithContext(
+			ctx,
+			&svcsdk.CreateTagsInput{
+				Resources: resourceId,
+				Tags:      rm.sdkTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
+func (rm *resourceManager) sdkTags(
+	tags []*svcapitypes.Tag,
+) (sdktags []*svcsdk.Tag) {
+
+	for _, i := range tags {
+		sdktag := rm.newTag(*i)
+		sdktags = append(sdktags, sdktag)
+	}
+
+	return sdktags
+}
+
+// computeTagsDelta returns tags to be added and removed from the resource
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
+
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[*tag.Key] = *tag.Value
+	}
+
+	latestTags := map[string]string{}
+	for _, tag := range latest {
+		latestTags[*tag.Key] = *tag.Value
+	}
+
+	for _, tag := range desired {
+		val, ok := latestTags[*tag.Key]
+		if !ok || val != *tag.Value {
+			toAdd = append(toAdd, tag)
+		}
+	}
+
+	for _, tag := range latest {
+		_, ok := desiredTags[*tag.Key]
+		if !ok {
+			toDelete = append(toDelete, tag)
+		}
+	}
+
+	return toAdd, toDelete
+
+}
 
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateTransitGatewayInput.TagSpecification

--- a/pkg/resource/transit_gateway/sdk.go
+++ b/pkg/resource/transit_gateway/sdk.go
@@ -384,8 +384,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateTransitGateway(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API
@@ -524,4 +523,18 @@ func (rm *resourceManager) updateConditions(
 func (rm *resourceManager) terminalAWSError(err error) bool {
 	// No terminal_errors specified for this resource in generator config
 	return false
+}
+
+func (rm *resourceManager) newTag(
+	c svcapitypes.Tag,
+) *svcsdk.Tag {
+	res := &svcsdk.Tag{}
+	if c.Key != nil {
+		res.SetKey(*c.Key)
+	}
+	if c.Value != nil {
+		res.SetValue(*c.Value)
+	}
+
+	return res
 }

--- a/templates/hooks/transit_gateway/sdk_file_end.go.tpl
+++ b/templates/hooks/transit_gateway/sdk_file_end.go.tpl
@@ -1,0 +1,23 @@
+{{ $CRD := .CRD }}
+{{ $SDKAPI := .SDKAPI }}
+
+{{/* Generate helper methods for Transit Gateway */}}
+{{- range $specFieldName, $specField := $CRD.Config.Resources.TransitGateway.Fields }}
+{{- if $specField.From }}
+{{- $operationName := $specField.From.Operation }}
+{{- $operation := (index $SDKAPI.API.Operations $operationName) -}}
+{{- range $transitGatewayRefName, $transitGatewayMemberRefs := $operation.InputRef.Shape.MemberRefs -}}
+{{- if eq $transitGatewayRefName "Tags" }}
+{{- $transitGatewayRef := $transitGatewayMemberRefs.Shape.MemberRef }}
+{{- $transitGatewayRefName = "Tag" }}
+func (rm *resourceManager) new{{ $transitGatewayRefName }}(
+	    c svcapitypes.{{ $transitGatewayRefName }},
+) *svcsdk.{{ $transitGatewayRefName }} {
+	res := &svcsdk.{{ $transitGatewayRefName }}{}
+{{ GoCodeSetSDKForStruct $CRD "" "res" $transitGatewayRef "" "c" 1 }}
+	return res
+}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/test/e2e/resources/transitgateway.yaml
+++ b/test/e2e/resources/transitgateway.yaml
@@ -2,4 +2,7 @@ apiVersion: ec2.services.k8s.aws/v1alpha1
 kind: TransitGateway
 metadata:
   name: $TGW_NAME
-spec: {}
+spec:
+  tags:
+    - key: $TAG_KEY
+      value: $TAG_VALUE

--- a/test/e2e/tests/test_transit_gateway.py
+++ b/test/e2e/tests/test_transit_gateway.py
@@ -31,12 +31,21 @@ RESOURCE_PLURAL = "transitgateways"
 ## TGWs are unable to be deleted while in "pending"
 CREATE_WAIT_AFTER_SECONDS = 90
 DELETE_WAIT_AFTER_SECONDS = 10
+MODIFY_WAIT_AFTER_SECONDS = 5
 
 @pytest.fixture
-def simple_transit_gateway():
+def simple_transit_gateway(request):
     resource_name = random_suffix_name("tgw-ack-test", 24)
     replacements = REPLACEMENT_VALUES.copy()
     replacements["TGW_NAME"] = resource_name
+
+    marker = request.node.get_closest_marker("resource_data")
+    if marker is not None:
+        data = marker.args[0]
+        if 'tag_key' in data:
+            replacements["TAG_KEY"] = data['tag_key']
+        if 'tag_value' in data:
+            replacements["TAG_VALUE"] = data['tag_value']
 
     # Load TGW CR
     resource_data = load_ec2_resource(
@@ -87,4 +96,70 @@ class TestTGW:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
         # Check TGW no longer exists in AWS
+        ec2_validator.assert_transit_gateway(resource_id, exists=False)
+
+    @pytest.mark.resource_data({'tag_key': 'initialtagkey', 'tag_value': 'initialtagvalue'})
+    def test_crud_tags(self, ec2_client, simple_transit_gateway):
+        (ref, cr) = simple_transit_gateway
+        
+        resource = k8s.get_resource(ref)
+        resource_id = cr["status"]["transitGatewayID"]
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Check TransitGateway exists in AWS
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_transit_gateway(resource_id)
+        
+        # Check tags exist for TransitGateway resource
+        assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
+        assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
+
+        # New pair of tags
+        new_tags = [
+                {
+                    "key": "updatedtagkey",
+                    "value": "updatedtagvalue",
+                }
+               
+            ]
+
+        # Patch the TransitGateway, updating the tags with new pair
+        updates = {
+            "spec": {"tags": new_tags},
+        }
+
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        
+        # Assert tags are updated for TransitGateway resource
+        resource = k8s.get_resource(ref)
+        assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
+        assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
+
+        # Patch the TransitGateway resource, deleting the tags
+        updates = {
+                "spec": {"tags": []},
+        }
+
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        
+        # Assert tags are deleted
+        resource = k8s.get_resource(ref)
+        assert len(resource['spec']['tags']) == 0
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check TransitGateway no longer exists in AWS
         ec2_validator.assert_transit_gateway(resource_id, exists=False)


### PR DESCRIPTION
Description of changes:

- Included `update_operation` in `generator.yaml` file.
- Implemented update tags support for **Transit Gateway** resource.
- Added integration tests for update tags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
