### PR TITLE
Update tags support for Instance resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-15T16:27:05Z"
+  build_date: "2022-09-15T19:23:13Z"
   build_hash: 1da44f4be322eea156ed23a86e33c29da5cede9c
   go_version: go1.18.3
   version: v0.20.1-2-g1da44f4
@@ -7,7 +7,7 @@ api_directory_checksum: 127aa0f51fbcdde596b8f42f93bcdf3b6dee8488
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 42f9161f3b7c319d753fd54b681eecd9916d67f6
+  file_checksum: 8d5d72356a71b4768f16b33995ce72c0912e6219
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -207,6 +207,10 @@ resources:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/instance/sdk_delete_post_build_request.go.tpl
+      sdk_file_end:
+        template_path: hooks/instance/sdk_file_end.go.tpl
+    update_operation:
+      custom_method_name: customUpdateInstance
   ElasticIPAddress:
     exceptions:
       terminal_codes:

--- a/generator.yaml
+++ b/generator.yaml
@@ -207,6 +207,10 @@ resources:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/instance/sdk_delete_post_build_request.go.tpl
+      sdk_file_end:
+        template_path: hooks/instance/sdk_file_end.go.tpl
+    update_operation:
+      custom_method_name: customUpdateInstance
   ElasticIPAddress:
     exceptions:
       terminal_codes:

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -14,8 +14,12 @@
 package instance
 
 import (
+	"context"
 	"errors"
 
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -29,6 +33,129 @@ func addInstanceIDsToTerminateRequest(r *resource,
 	}
 	input.InstanceIds = append(input.InstanceIds, r.ko.Status.InstanceID)
 	return nil
+}
+
+func (rm *resourceManager) customUpdateInstance(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (updated *resource, err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdateInstance")
+	defer exit(err)
+
+	// Merge in the information we read from the API call above to the copy of
+	// the original Kubernetes object we passed to the function
+	ko := desired.ko.DeepCopy()
+
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+
+	rm.setStatusDefaults(ko)
+	return &resource{ko}, nil
+}
+
+// syncTags used to keep tags in sync by calling Create and Delete API's
+func (rm *resourceManager) syncTags(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+) (err error) {
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.syncTags")
+	defer func(err error) {
+		exit(err)
+	}(err)
+
+	resourceId := []*string{latest.ko.Status.InstanceID}
+
+	toAdd, toDelete := computeTagsDelta(
+		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+	)
+
+	if len(toDelete) > 0 {
+		rlog.Debug("removing tags from Instance resource", "tags", toDelete)
+		_, err = rm.sdkapi.DeleteTagsWithContext(
+			ctx,
+			&svcsdk.DeleteTagsInput{
+				Resources: resourceId,
+				Tags:      rm.sdkTags(toDelete),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	if len(toAdd) > 0 {
+		rlog.Debug("adding tags to Instance resource", "tags", toAdd)
+		_, err = rm.sdkapi.CreateTagsWithContext(
+			ctx,
+			&svcsdk.CreateTagsInput{
+				Resources: resourceId,
+				Tags:      rm.sdkTags(toAdd),
+			},
+		)
+		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
+func (rm *resourceManager) sdkTags(
+	tags []*svcapitypes.Tag,
+) (sdktags []*svcsdk.Tag) {
+
+	for _, i := range tags {
+		sdktag := rm.newTag(*i)
+		sdktags = append(sdktags, sdktag)
+	}
+
+	return sdktags
+}
+
+// computeTagsDelta returns tags to be added and removed from the resource
+func computeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
+
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[*tag.Key] = *tag.Value
+	}
+
+	latestTags := map[string]string{}
+	for _, tag := range latest {
+		latestTags[*tag.Key] = *tag.Value
+	}
+
+	for _, tag := range desired {
+		val, ok := latestTags[*tag.Key]
+		if !ok || val != *tag.Value {
+			toAdd = append(toAdd, tag)
+		}
+	}
+
+	for _, tag := range latest {
+		_, ok := desiredTags[*tag.Key]
+		if !ok {
+			toDelete = append(toDelete, tag)
+		}
+	}
+
+	return toAdd, toDelete
+
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/instance/sdk.go
+++ b/pkg/resource/instance/sdk.go
@@ -1672,8 +1672,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	// TODO(jaypipes): Figure this out...
-	return nil, ackerr.NotImplemented
+	return rm.customUpdateInstance(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API
@@ -1811,4 +1810,18 @@ func (rm *resourceManager) updateConditions(
 func (rm *resourceManager) terminalAWSError(err error) bool {
 	// No terminal_errors specified for this resource in generator config
 	return false
+}
+
+func (rm *resourceManager) newTag(
+	c svcapitypes.Tag,
+) *svcsdk.Tag {
+	res := &svcsdk.Tag{}
+	if c.Key != nil {
+		res.SetKey(*c.Key)
+	}
+	if c.Value != nil {
+		res.SetValue(*c.Value)
+	}
+
+	return res
 }

--- a/templates/hooks/instance/sdk_file_end.go.tpl
+++ b/templates/hooks/instance/sdk_file_end.go.tpl
@@ -1,0 +1,23 @@
+{{ $CRD := .CRD }}
+{{ $SDKAPI := .SDKAPI }}
+
+{{/* Generate helper methods for Instance */}}
+{{- range $specFieldName, $specField := $CRD.Config.Resources.Instance.Fields }}
+{{- if $specField.From }}
+{{- $operationName := $specField.From.Operation }}
+{{- $operation := (index $SDKAPI.API.Operations $operationName) -}}
+{{- range $instanceRefName, $instanceMemberRefs := $operation.InputRef.Shape.MemberRefs -}}
+{{- if eq $instanceRefName "Tags" }}
+{{- $instanceRef := $instanceMemberRefs.Shape.MemberRef }}
+{{- $instanceRefName = "Tag" }}
+func (rm *resourceManager) new{{ $instanceRefName }}(
+	    c svcapitypes.{{ $instanceRefName }},
+) *svcsdk.{{ $instanceRefName }} {
+	res := &svcsdk.{{ $instanceRefName }}{}
+{{ GoCodeSetSDKForStruct $CRD "" "res" $instanceRef "" "c" 1 }}
+	return res
+}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Description of changes:

- Included `update_operation` in `generator.yaml` file.
- Implemented update tags support for **Instance** resource.
- Added e2e tests for update tags.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
