### PR TITLE
Refactor e2e tests to use `acktest.tags` helper

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-21T13:36:34Z"
+  build_date: "2022-09-27T22:29:46Z"
   build_hash: 6e2ffbc3b16a30ac59be6719918c601c2c864064
   go_version: go1.18.1
   version: v0.20.1-3-g6e2ffbc
@@ -7,7 +7,7 @@ api_directory_checksum: 127aa0f51fbcdde596b8f42f93bcdf3b6dee8488
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 8573a89b8220023263610579bfb84b762d99f5fa
+  file_checksum: a31177552ce6ea5ce3b624520711382f113cf05b
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -205,6 +205,10 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/instance/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/instance/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/instance/sdk_delete_post_build_request.go.tpl
       sdk_file_end:

--- a/generator.yaml
+++ b/generator.yaml
@@ -205,6 +205,10 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/instance/sdk_create_post_set_output.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/instance/sdk_read_many_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/instance/sdk_delete_post_build_request.go.tpl
       sdk_file_end:

--- a/pkg/resource/instance/sdk.go
+++ b/pkg/resource/instance/sdk.go
@@ -629,6 +629,14 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+
+	toAdd, toDelete := computeTagsDelta(r.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if resource's initial tags and response tags are equal,
+		// then assign resource's tags to maintain tag order
+		ko.Spec.Tags = r.ko.Spec.Tags
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -1227,6 +1235,12 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if desired tags and response tags are equal,
+		// then assign desired tags to maintain tag order
+		ko.Spec.Tags = desired.ko.Spec.Tags
+	}
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/route_table/sdk.go
+++ b/pkg/resource/route_table/sdk.go
@@ -228,6 +228,12 @@ func (rm *resourceManager) sdkFind(
 	if found {
 		rm.addRoutesToStatus(ko, resp.RouteTables[0])
 	}
+	toAdd, toDelete := computeTagsDelta(r.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if resource's initial tags and response tags are equal,
+		// then assign resource's tags to maintain tag order
+		ko.Spec.Tags = r.ko.Spec.Tags
+	}
 
 	return &resource{ko}, nil
 }
@@ -429,6 +435,13 @@ func (rm *resourceManager) sdkCreate(
 		if err := rm.createRoutes(ctx, &resource{ko}); err != nil {
 			return nil, err
 		}
+	}
+
+	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if desired tags and response tags are equal,
+		// then assign desired tags to maintain tag order
+		ko.Spec.Tags = desired.ko.Spec.Tags
 	}
 	return &resource{ko}, nil
 }

--- a/templates/hooks/instance/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/instance/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,6 @@
+	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if desired tags and response tags are equal,
+		// then assign desired tags to maintain tag order
+		ko.Spec.Tags = desired.ko.Spec.Tags
+	}

--- a/templates/hooks/instance/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/instance/sdk_read_many_post_set_output.go.tpl
@@ -1,7 +1,4 @@
 	
-    if found {
-        rm.addRoutesToStatus(ko, resp.RouteTables[0])
-    }
 	toAdd, toDelete := computeTagsDelta(r.ko.Spec.Tags, ko.Spec.Tags)
 	if len(toAdd) == 0 && len(toDelete) == 0 {
 		// if resource's initial tags and response tags are equal,

--- a/templates/hooks/route_table/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/route_table/sdk_create_post_set_output.go.tpl
@@ -11,3 +11,10 @@
 			return nil, err
 		}
 	}
+
+	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
+	if len(toAdd) == 0 && len(toDelete) == 0 {
+		// if desired tags and response tags are equal,
+		// then assign desired tags to maintain tag order
+		ko.Spec.Tags = desired.ko.Spec.Tags
+	}

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@5220331d003e3a23de4470e68d02c99b16c81989
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@73eb0d5af8ac19d17fad8787d6462d56f4e3e37d

--- a/test/e2e/tests/helper.py
+++ b/test/e2e/tests/helper.py
@@ -21,6 +21,15 @@ class EC2Validator:
     def __init__(self, ec2_client):
         self.ec2_client = ec2_client
 
+    def get_dhcp_options(self, dhcp_options_id: str):
+        try:
+            aws_res = self.ec2_client.describe_dhcp_options(DhcpOptionsIds=[dhcp_options_id])
+            if len(aws_res["DhcpOptions"]) > 0:
+                return aws_res["DhcpOptions"][0]
+            return None
+        except self.ec2_client.exceptions.ClientError:
+            return None
+
     def assert_dhcp_options(self, dhcp_options_id: str, exists=True):
         res_found = False
         try:
@@ -41,6 +50,15 @@ class EC2Validator:
 
     def assert_internet_gateway(self, igw_id: str, exists=True):
         assert (self.get_internet_gateway(igw_id) is not None) == exists
+
+    def get_nat_gateway(self, ngw_id: str):
+        try:
+            aws_res = self.ec2_client.describe_nat_gateways(NatGatewayIds=[ngw_id])
+            if len(aws_res["NatGateways"]) > 0:
+                return aws_res["NatGateways"][0]
+            return None
+        except self.ec2_client.exceptions.ClientError:
+            return None
 
     def assert_nat_gateway(self, ngw_id: str, exists=True):
         res_found = False
@@ -116,6 +134,15 @@ class EC2Validator:
     def assert_subnet(self, subnet_id: str, exists=True):
         assert (self.get_subnet(subnet_id) is not None) == exists
 
+    def get_transit_gateway(self, tgw_id: str) -> Union[None, Dict]:
+        try:
+            aws_res = self.ec2_client.describe_transit_gateways(TransitGatewayIds=[tgw_id])
+            if len(aws_res["TransitGateways"]) > 0:
+                return aws_res["TransitGateways"][0]
+            return None
+        except self.ec2_client.exceptions.ClientError:
+            return None
+
     def assert_transit_gateway(self, tgw_id: str, exists=True):
         res_found = False
         try:
@@ -145,6 +172,15 @@ class EC2Validator:
         except self.ec2_client.exceptions.ClientError:
             pass
         assert res_found is exists
+
+    def get_vpc_endpoint(self, vpc_endpoint_id: str) -> Union[None, Dict]:
+        try:
+            aws_res = self.ec2_client.describe_vpc_endpoints(VpcEndpointIds=[vpc_endpoint_id])
+            if len(aws_res["VpcEndpoints"]) > 0:
+                return aws_res["VpcEndpoints"][0]
+            return None
+        except self.ec2_client.exceptions.ClientError:
+            return None
 
     def assert_vpc_endpoint(self, vpc_endpoint_id: str, exists=True):
         res_found = False

--- a/test/e2e/tests/test_dhcp_options.py
+++ b/test/e2e/tests/test_dhcp_options.py
@@ -18,6 +18,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -131,23 +132,36 @@ class TestDhcpOptions:
         # Check dhcpOptions exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_dhcp_options(resource_id)
+
+        # Check system and user tags exist for dhcpOptions resource
+        dhcp_options = ec2_validator.get_dhcp_options(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=dhcp_options["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=dhcp_options["Tags"],
+        )
         
-        # Check tags exist for dhcpOptions resource
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the dhcpOptions, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
@@ -156,8 +170,22 @@ class TestDhcpOptions:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are updated for dhcpOptions resource
+        # Check for updated user tags; system tags should persist
+        dhcp_options = ec2_validator.get_dhcp_options(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=dhcp_options["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=dhcp_options["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -172,9 +200,19 @@ class TestDhcpOptions:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are deleted
+        # Check for removed user tags; system tags should persist
+        dhcp_options = ec2_validator.get_dhcp_options(resource_id)
+        tags.assert_ack_system_tags(
+            tags=dhcp_options["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=dhcp_options["Tags"],
+        )
+        
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -18,6 +18,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -160,22 +161,35 @@ class TestInternetGateway:
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_internet_gateway(resource_id)
         
-        # Check tags exist for IGW resource
+        # Check system and user tags exist for igw resource
+        internet_gateway = ec2_validator.get_internet_gateway(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=internet_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=internet_gateway["Tags"],
+        )
+        
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the IGW, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
@@ -184,8 +198,22 @@ class TestInternetGateway:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are updated for IGW resource
+        # Check for updated user tags; system tags should persist
+        internet_gateway = ec2_validator.get_internet_gateway(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=internet_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=internet_gateway["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -199,10 +227,20 @@ class TestInternetGateway:
 
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+        # Check for removed user tags; system tags should persist
+        internet_gateway = ec2_validator.get_internet_gateway(resource_id)
+        tags.assert_ack_system_tags(
+            tags=internet_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=internet_gateway["Tags"],
+        )
         
-        # Assert tags are deleted
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)

--- a/test/e2e/tests/test_nat_gateway.py
+++ b/test/e2e/tests/test_nat_gateway.py
@@ -18,6 +18,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -156,29 +157,56 @@ class TestNATGateway:
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_nat_gateway(resource_id)
         
-        # Check tags exist for natGateway resource
+        # Check system and user tags exist for natGateway resource
+        nat_gateway = ec2_validator.get_nat_gateway(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=nat_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=nat_gateway["Tags"],
+        )
+        
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the natGateway, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
         
-        # Assert tags are updated for natGateway resource
+        # Check for updated user tags; system tags should persist
+        nat_gateway = ec2_validator.get_nat_gateway(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=nat_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=nat_gateway["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -189,10 +217,23 @@ class TestNATGateway:
 
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are deleted
+        # Check for removed user tags; system tags should persist
+        nat_gateway = ec2_validator.get_nat_gateway(resource_id)
+        tags.assert_ack_system_tags(
+            tags=nat_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=nat_gateway["Tags"],
+        )
+        
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)

--- a/test/e2e/tests/test_subnet.py
+++ b/test/e2e/tests/test_subnet.py
@@ -18,6 +18,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -178,23 +179,36 @@ class TestSubnet:
         # Check Subnet exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_subnet(resource_id)
+
+        # Check system and user tags exist for subnet resource
+        subnet = ec2_validator.get_subnet(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=subnet["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=subnet["Tags"],
+        )
         
-        # Check tags exist for subnet resource
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the subnet, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
@@ -203,8 +217,22 @@ class TestSubnet:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are updated for subnet resource
+        # Check for updated user tags; system tags should persist
+        subnet = ec2_validator.get_subnet(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=subnet["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=subnet["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -219,9 +247,19 @@ class TestSubnet:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are deleted
+        # Check for removed user tags; system tags should persist
+        subnet = ec2_validator.get_subnet(resource_id)
+        tags.assert_ack_system_tags(
+            tags=subnet["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=subnet["Tags"],
+        )
+        
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)

--- a/test/e2e/tests/test_transit_gateway.py
+++ b/test/e2e/tests/test_transit_gateway.py
@@ -19,6 +19,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -111,22 +112,35 @@ class TestTGW:
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_transit_gateway(resource_id)
         
-        # Check tags exist for TransitGateway resource
+        # Check system and user tags exist for transit gateway resource
+        transit_gateway = ec2_validator.get_transit_gateway(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=transit_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=transit_gateway["Tags"],
+        )
+        
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the TransitGateway, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
@@ -135,8 +149,22 @@ class TestTGW:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are updated for TransitGateway resource
+        # Check for updated user tags; system tags should persist
+        transit_gateway = ec2_validator.get_transit_gateway(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=transit_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=transit_gateway["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -151,9 +179,19 @@ class TestTGW:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are deleted
+        # Check for removed user tags; system tags should persist
+        transit_gateway = ec2_validator.get_transit_gateway(resource_id)
+        tags.assert_ack_system_tags(
+            tags=transit_gateway["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=transit_gateway["Tags"],
+        )
+        
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)

--- a/test/e2e/tests/test_vpc_endpoint.py
+++ b/test/e2e/tests/test_vpc_endpoint.py
@@ -19,6 +19,7 @@ import pytest
 import time
 import logging
 
+from acktest import tags
 from acktest.resources import random_suffix_name
 from acktest.k8s import resource as k8s
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
@@ -117,22 +118,35 @@ class TestVpcEndpoint:
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc_endpoint(resource_id)
         
-        # Check tags exist for vpcEndpoint resource
+        # Check system and user tags exist for vpc endpoint resource
+        vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
+        user_tags = {
+            "initialtagkey": "initialtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=vpc_endpoint["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=user_tags,
+            actual=vpc_endpoint["Tags"],
+        )
+        
+        # Only user tags should be present in Spec
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "initialtagkey"
         assert resource["spec"]["tags"][0]["value"] == "initialtagvalue"
 
-        # New pair of tags
-        new_tags = [
+        # Update tags
+        update_tags = [
                 {
                     "key": "updatedtagkey",
                     "value": "updatedtagvalue",
                 }
-               
             ]
 
         # Patch the vpcEndpoint, updating the tags with new pair
         updates = {
-            "spec": {"tags": new_tags},
+            "spec": {"tags": update_tags},
         }
 
         k8s.patch_custom_resource(ref, updates)
@@ -141,8 +155,22 @@ class TestVpcEndpoint:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are updated for vpcEndpoint resource
+        # Check for updated user tags; system tags should persist
+        vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
+        updated_tags = {
+            "updatedtagkey": "updatedtagvalue"
+        }
+        tags.assert_ack_system_tags(
+            tags=vpc_endpoint["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=updated_tags,
+            actual=vpc_endpoint["Tags"],
+        )
+               
+        # Only user tags should be present in Spec
         resource = k8s.get_resource(ref)
+        assert len(resource["spec"]["tags"]) == 1
         assert resource["spec"]["tags"][0]["key"] == "updatedtagkey"
         assert resource["spec"]["tags"][0]["value"] == "updatedtagvalue"
 
@@ -157,9 +185,19 @@ class TestVpcEndpoint:
         # Check resource synced successfully
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
         
-        # Assert tags are deleted
+        # Check for removed user tags; system tags should persist
+        vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
+        tags.assert_ack_system_tags(
+            tags=vpc_endpoint["Tags"],
+        )
+        tags.assert_equal_without_ack_tags(
+            expected=[],
+            actual=vpc_endpoint["Tags"],
+        )
+        
+        # Check user tags are removed from Spec
         resource = k8s.get_resource(ref)
-        assert len(resource['spec']['tags']) == 0
+        assert len(resource["spec"]["tags"]) == 0
 
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1235

Description of changes: 
* Use `acktest.tags` assertions in e2e tests to accurately test for ACK tags and user-defined tags
* Enhance existing tag tests by checking both server-side values as well as `Spec.Tags` values
* Add hook code for `Instance` and `RouteTable` so ACK tags are not populated in `Spec`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
