### PR TITLE
Set `Instance` to synced iff it's in a permanent state

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-09-27T22:29:46Z"
+  build_date: "2022-10-03T20:46:38Z"
   build_hash: 6e2ffbc3b16a30ac59be6719918c601c2c864064
   go_version: go1.18.1
   version: v0.20.1-3-g6e2ffbc
@@ -7,7 +7,7 @@ api_directory_checksum: 127aa0f51fbcdde596b8f42f93bcdf3b6dee8488
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: a31177552ce6ea5ce3b624520711382f113cf05b
+  file_checksum: f505725abe74c681f7c1e3fac3a1a884fba1a0cc
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -191,6 +191,8 @@ resources:
     fields:
       HibernationOptions:
         late_initialize: {}
+      BlockDeviceMappings:
+        late_initialize: {}
       MaxCount:
         is_required: false
       MinCount:

--- a/generator.yaml
+++ b/generator.yaml
@@ -191,6 +191,8 @@ resources:
     fields:
       HibernationOptions:
         late_initialize: {}
+      BlockDeviceMappings:
+        late_initialize: {}
       MaxCount:
         is_required: false
       MinCount:

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -16,6 +16,7 @@ package instance
 import (
 	"context"
 	"errors"
+	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -179,4 +180,12 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		desiredTagSpecs.SetTags(instanceTags)
 	}
 	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
+}
+
+// inTransitoryState returns true if the Instance
+// resource is in a temporary, non-permanent state
+func inTransitoryState(r *resource) bool {
+	return strings.EqualFold(*r.ko.Status.State.Name, "pending") ||
+		strings.EqualFold(*r.ko.Status.State.Name, "shutting-down") ||
+		strings.EqualFold(*r.ko.Status.State.Name, "stopping")
 }

--- a/pkg/resource/instance/manager.go
+++ b/pkg/resource/instance/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=instances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=instances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"HibernationOptions"}
+var lateInitializeFieldNames = []string{"BlockDeviceMappings", "HibernationOptions"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -249,6 +249,9 @@ func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.BlockDeviceMappings == nil {
+		return true
+	}
 	if ko.Spec.HibernationOptions == nil {
 		return true
 	}
@@ -263,6 +266,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 ) acktypes.AWSResource {
 	observedKo := rm.concreteResource(observed).ko.DeepCopy()
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.BlockDeviceMappings != nil && latestKo.Spec.BlockDeviceMappings == nil {
+		latestKo.Spec.BlockDeviceMappings = observedKo.Spec.BlockDeviceMappings
+	}
 	if observedKo.Spec.HibernationOptions != nil && latestKo.Spec.HibernationOptions == nil {
 		latestKo.Spec.HibernationOptions = observedKo.Spec.HibernationOptions
 	}

--- a/templates/hooks/instance/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/instance/sdk_read_many_post_set_output.go.tpl
@@ -5,4 +5,16 @@
 		// then assign resource's tags to maintain tag order
 		ko.Spec.Tags = r.ko.Spec.Tags
 	}
+
+	// A resource is synced when it has achieved the desired state. However, users
+	// cannot desire a temporary state for an Instance (i.e. pending); therefore, 
+	// if the resource is in a temporary state, then set synced to false and reconcile 
+	// until a permanent state is achieved.
+	if inTransitoryState(&resource{ko}) {
+		msg := "Instance is in a transitory  state, current status=" + string(*ko.Status.State.Name)
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
+		return &resource{ko}, nil
+	} else {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+	}
     


### PR DESCRIPTION
**Issue #, if available:** N/A. `Instance` would be set to `Synced` immediately after creation while it is still in 'pending' state. Because it's `Synced`, reconciliation ceases and the `Instance` state is never updated to 'running' (or any other permanent/terminal state).

**Description of changes:** Re-queue `Instance` if it is in a temporary state (pending, shutting-down, stopping) until a permanent state is achieved; update tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
