### PR TITLE
Fix hook code for `Tags`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2022-10-12T21:27:52Z"
+  build_date: "2022-10-13T18:47:02Z"
   build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
-  go_version: go1.18.2
+  go_version: go1.18.1
   version: v0.20.1-4-g5ee0ac0
-api_directory_checksum: 3638dfc2a8e94a1ea91486172874d0b0b4e039f7
+api_directory_checksum: b3a2878ca8a156389214b900257c4d572ad4e3a5
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: b50a20e57aaf81d2a636ebf9a74d9693a82eeeb7
+  file_checksum: 0260a4e58e3e1667fc456baff448cbabc2da4bf6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -185,6 +185,8 @@ resources:
           operation: CreateTags
           path: Tags
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/dhcp_options/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -211,6 +213,8 @@ resources:
           operation: CreateTags
           path: Tags
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -244,6 +248,8 @@ resources:
       match_fields:
       - AllocationId
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
@@ -274,6 +280,8 @@ resources:
           path: Status.internetGatewayID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/internet_gateway/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -319,6 +327,8 @@ resources:
         in:
         - available
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -374,7 +384,7 @@ resources:
           path: Status.VPCEndpointID
     hooks:
       delta_pre_compare:
-        code: customPreCompare(a, b)
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/route_table/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -429,6 +439,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -488,6 +500,8 @@ resources:
         - InvalidParameterValue
         - InvalidCustomerOwnedIpv4PoolID.Malformed
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/subnet/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -513,6 +527,8 @@ resources:
           path: Status.transitGatewayID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -554,6 +570,8 @@ resources:
           path: Status.vpcID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -599,6 +617,8 @@ resources:
         - InvalidVpcId.Malformed
         - InvalidServiceName
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -185,6 +185,8 @@ resources:
           operation: CreateTags
           path: Tags
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/dhcp_options/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -211,6 +213,8 @@ resources:
           operation: CreateTags
           path: Tags
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -244,6 +248,8 @@ resources:
       match_fields:
       - AllocationId
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
@@ -274,6 +280,8 @@ resources:
           path: Status.internetGatewayID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/internet_gateway/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -319,6 +327,8 @@ resources:
         in:
         - available
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -374,7 +384,7 @@ resources:
           path: Status.VPCEndpointID
     hooks:
       delta_pre_compare:
-        code: customPreCompare(a, b)
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/route_table/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -429,6 +439,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -488,6 +500,8 @@ resources:
         - InvalidParameterValue
         - InvalidCustomerOwnedIpv4PoolID.Malformed
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/subnet/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -513,6 +527,8 @@ resources:
           path: Status.transitGatewayID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -554,6 +570,8 @@ resources:
           path: Status.vpcID
           name: ID
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -599,6 +617,8 @@ resources:
         - InvalidVpcId.Malformed
         - InvalidServiceName
     hooks:
+      delta_pre_compare:
+        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:

--- a/pkg/resource/dhcp_options/delta.go
+++ b/pkg/resource/dhcp_options/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations) {
 		delta.Add("Spec.DHCPConfigurations", a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations)

--- a/pkg/resource/dhcp_options/hooks.go
+++ b/pkg/resource/dhcp_options/hooks.go
@@ -152,6 +152,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'dhcp-options'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateDhcpOptionsInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -166,6 +167,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("dhcp-options")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/dhcp_options/hooks.go
+++ b/pkg/resource/dhcp_options/hooks.go
@@ -147,6 +147,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateDhcpOptionsInput.TagSpecification
 // and ensures the ResourceType is always set to 'dhcp-options'

--- a/pkg/resource/elastic_ip_address/delta.go
+++ b/pkg/resource/elastic_ip_address/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Address, b.ko.Spec.Address) {
 		delta.Add("Spec.Address", a.ko.Spec.Address, b.ko.Spec.Address)

--- a/pkg/resource/elastic_ip_address/hooks.go
+++ b/pkg/resource/elastic_ip_address/hooks.go
@@ -152,6 +152,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'elastic-ip'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.AllocateAddressInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -166,6 +167,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("elastic-ip")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/elastic_ip_address/hooks.go
+++ b/pkg/resource/elastic_ip_address/hooks.go
@@ -147,6 +147,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to AllocateAddressInput.TagSpecification
 // and ensures the ResourceType is always set to 'elastic-ip'

--- a/pkg/resource/instance/delta.go
+++ b/pkg/resource/instance/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.BlockDeviceMappings, b.ko.Spec.BlockDeviceMappings) {
 		delta.Add("Spec.BlockDeviceMappings", a.ko.Spec.BlockDeviceMappings, b.ko.Spec.BlockDeviceMappings)

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -165,6 +165,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'instance'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.RunInstancesInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		instanceTags := []*svcsdk.Tag{}
@@ -179,6 +180,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("instance")
 		desiredTagSpecs.SetTags(instanceTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -160,6 +160,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to RunInstancesInput.TagSpecification
 // and ensures the ResourceType is always set to 'instance'

--- a/pkg/resource/internet_gateway/delta.go
+++ b/pkg/resource/internet_gateway/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)

--- a/pkg/resource/internet_gateway/hooks.go
+++ b/pkg/resource/internet_gateway/hooks.go
@@ -241,6 +241,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateInternetGatewayInput.TagSpecification
 // and ensures the ResourceType is always set to 'internet-gateway'

--- a/pkg/resource/internet_gateway/hooks.go
+++ b/pkg/resource/internet_gateway/hooks.go
@@ -246,6 +246,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'internet-gateway'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateInternetGatewayInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -260,6 +261,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("internet-gateway")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/nat_gateway/delta.go
+++ b/pkg/resource/nat_gateway/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocationID, b.ko.Spec.AllocationID) {
 		delta.Add("Spec.AllocationID", a.ko.Spec.AllocationID, b.ko.Spec.AllocationID)

--- a/pkg/resource/nat_gateway/hooks.go
+++ b/pkg/resource/nat_gateway/hooks.go
@@ -152,6 +152,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'natgateway'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateNatGatewayInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -166,6 +167,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("natgateway")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/nat_gateway/hooks.go
+++ b/pkg/resource/nat_gateway/hooks.go
@@ -147,6 +147,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateNatGatewayInput.TagSpecification
 // and ensures the ResourceType is always set to 'natgateway'

--- a/pkg/resource/route_table/delta.go
+++ b/pkg/resource/route_table/delta.go
@@ -40,7 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	customPreCompare(a, b)
+	customPreCompare(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.Routes, b.ko.Spec.Routes) {
 		delta.Add("Spec.Routes", a.ko.Spec.Routes, b.ko.Spec.Routes)

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -375,6 +375,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'route-table'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateRouteTableInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -389,6 +390,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("route-table")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -243,14 +243,33 @@ func (rm *resourceManager) addRoutesToStatus(
 	}
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // customPreCompare ensures that default values of types are initialised and
 // server side defaults are excluded from the delta.
 func customPreCompare(
+	delta *ackcompare.Delta,
 	a *resource,
 	b *resource,
 ) {
 	a.ko.Spec.Routes = removeLocalRoute(a.ko.Spec.Routes)
 	b.ko.Spec.Routes = removeLocalRoute(b.ko.Spec.Routes)
+	compareTags(delta, a, b)
 }
 
 // removeLocalRoute will filter out any routes that have a gateway ID that

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -446,6 +446,23 @@ func (rm *resourceManager) customUpdateSecurityGroup(
 	return updated, nil
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // defaultEgressRule returns the egress rule that
 // is created and associated with a security group by default
 func (rm *resourceManager) defaultEgressRule() *svcapitypes.IPPermission {

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -260,6 +260,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'security-group'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateSecurityGroupInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -274,8 +275,8 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("security-group")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }
 
 // createSecurityGroupRules takes a list of ingress and egress

--- a/pkg/resource/subnet/delta.go
+++ b/pkg/resource/subnet/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AssignIPv6AddressOnCreation, b.ko.Spec.AssignIPv6AddressOnCreation) {
 		delta.Add("Spec.AssignIPv6AddressOnCreation", a.ko.Spec.AssignIPv6AddressOnCreation, b.ko.Spec.AssignIPv6AddressOnCreation)

--- a/pkg/resource/subnet/hooks.go
+++ b/pkg/resource/subnet/hooks.go
@@ -476,6 +476,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'subnet'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateSubnetInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -490,6 +491,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("subnet")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/subnet/hooks.go
+++ b/pkg/resource/subnet/hooks.go
@@ -471,6 +471,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateSubnetInput.TagSpecification
 // and ensures the ResourceType is always set to 'subnet'

--- a/pkg/resource/transit_gateway/delta.go
+++ b/pkg/resource/transit_gateway/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/transit_gateway/hooks.go
+++ b/pkg/resource/transit_gateway/hooks.go
@@ -152,6 +152,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'transit-gateway'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateTransitGatewayInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -166,6 +167,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("transit-gateway")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/transit_gateway/hooks.go
+++ b/pkg/resource/transit_gateway/hooks.go
@@ -147,6 +147,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateTransitGatewayInput.TagSpecification
 // and ensures the ResourceType is always set to 'transit-gateway'

--- a/pkg/resource/vpc/delta.go
+++ b/pkg/resource/vpc/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AmazonProvidedIPv6CIDRBlock, b.ko.Spec.AmazonProvidedIPv6CIDRBlock) {
 		delta.Add("Spec.AmazonProvidedIPv6CIDRBlock", a.ko.Spec.AmazonProvidedIPv6CIDRBlock, b.ko.Spec.AmazonProvidedIPv6CIDRBlock)

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -388,6 +388,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateVpcInput.TagSpecification
 // and ensures the ResourceType is always set to 'vpc'

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -393,6 +393,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'vpc'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateVpcInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -407,6 +408,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("vpc")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -40,6 +40,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DNSOptions, b.ko.Spec.DNSOptions) {
 		delta.Add("Spec.DNSOptions", a.ko.Spec.DNSOptions, b.ko.Spec.DNSOptions)

--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -165,6 +165,7 @@ func computeTagsDelta(
 // and ensures the ResourceType is always set to 'vpc-endpoint'
 func updateTagSpecificationsInCreateRequest(r *resource,
 	input *svcsdk.CreateVpcEndpointInput) {
+	input.TagSpecifications = nil
 	desiredTagSpecs := svcsdk.TagSpecification{}
 	if r.ko.Spec.Tags != nil {
 		requestedTags := []*svcsdk.Tag{}
@@ -179,6 +180,6 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		}
 		desiredTagSpecs.SetResourceType("vpc-endpoint")
 		desiredTagSpecs.SetTags(requestedTags)
+		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
-	input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 }

--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -160,6 +160,23 @@ func computeTagsDelta(
 
 }
 
+// compareTags is a custom comparison function for comparing lists of Tag
+// structs where the order of the structs in the list is not important.
+func compareTags(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	} else if len(a.ko.Spec.Tags) > 0 {
+		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
+		if len(addedOrUpdated) != 0 || len(removed) != 0 {
+			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+		}
+	}
+}
+
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateVpcEndpointInput.TagSpecification
 // and ensures the ResourceType is always set to 'vpc-endpoint'


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1493

Description of changes:
* set `input.TagSpecifications` to non-nil in `updateTagSpecificationsInCreateRequest` iff there are desired tags
* apply workaround to all resources to maintain `Spec.Tags` order; otherwise, unnecessary `Update` calls may be triggered

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
