### PR TITLE
Ignore comparing `Tags`  in generated Delta

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2022-10-13T18:47:02Z"
+  build_date: "2022-10-13T20:17:24Z"
   build_hash: 5ee0ac052c54f008dff50f6f5ebb73f2cf3a0bd7
   go_version: go1.18.1
   version: v0.20.1-4-g5ee0ac0
@@ -7,7 +7,7 @@ api_directory_checksum: b3a2878ca8a156389214b900257c4d572ad4e3a5
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 0260a4e58e3e1667fc456baff448cbabc2da4bf6
+  file_checksum: cc2c6590c6e77a6125d5eec82ff5f693109d4f99
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -184,6 +184,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)
@@ -212,6 +214,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)
@@ -244,6 +248,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     list_operation:
       match_fields:
       - AllocationId
@@ -268,6 +274,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VPC:
         from:
           operation: AttachInternetGateway
@@ -321,6 +329,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     synced:
       when:
       - path: Status.State
@@ -362,6 +372,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -418,6 +430,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -491,6 +505,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -518,6 +534,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       State:
         print:
           path: Status.state
@@ -565,6 +583,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcID:
         print:
           path: Status.vpcID
@@ -588,6 +608,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC

--- a/generator.yaml
+++ b/generator.yaml
@@ -184,6 +184,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)
@@ -212,6 +214,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     hooks:
       delta_pre_compare:
         code: compareTags(delta, a, b)
@@ -244,6 +248,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     list_operation:
       match_fields:
       - AllocationId
@@ -268,6 +274,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VPC:
         from:
           operation: AttachInternetGateway
@@ -321,6 +329,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
     synced:
       when:
       - path: Status.State
@@ -362,6 +372,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -418,6 +430,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -491,6 +505,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -518,6 +534,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       State:
         print:
           path: Status.state
@@ -565,6 +583,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcID:
         print:
           path: Status.vpcID
@@ -588,6 +608,8 @@ resources:
         from:
           operation: CreateTags
           path: Tags
+        compare:
+          is_ignored: True
       VpcId:
         references:
           resource: VPC

--- a/pkg/resource/dhcp_options/delta.go
+++ b/pkg/resource/dhcp_options/delta.go
@@ -45,9 +45,6 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations) {
 		delta.Add("Spec.DHCPConfigurations", a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations)
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }

--- a/pkg/resource/elastic_ip_address/delta.go
+++ b/pkg/resource/elastic_ip_address/delta.go
@@ -70,9 +70,6 @@ func newResourceDelta(
 			delta.Add("Spec.PublicIPv4Pool", a.ko.Spec.PublicIPv4Pool, b.ko.Spec.PublicIPv4Pool)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }

--- a/pkg/resource/instance/delta.go
+++ b/pkg/resource/instance/delta.go
@@ -483,9 +483,6 @@ func newResourceDelta(
 			delta.Add("Spec.SubnetID", a.ko.Spec.SubnetID, b.ko.Spec.SubnetID)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.UserData, b.ko.Spec.UserData) {
 		delta.Add("Spec.UserData", a.ko.Spec.UserData, b.ko.Spec.UserData)
 	} else if a.ko.Spec.UserData != nil && b.ko.Spec.UserData != nil {

--- a/pkg/resource/internet_gateway/delta.go
+++ b/pkg/resource/internet_gateway/delta.go
@@ -42,9 +42,6 @@ func newResourceDelta(
 	}
 	compareTags(delta, a, b)
 
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPC, b.ko.Spec.VPC) {
 		delta.Add("Spec.VPC", a.ko.Spec.VPC, b.ko.Spec.VPC)
 	} else if a.ko.Spec.VPC != nil && b.ko.Spec.VPC != nil {

--- a/pkg/resource/nat_gateway/delta.go
+++ b/pkg/resource/nat_gateway/delta.go
@@ -69,9 +69,6 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef) {
 		delta.Add("Spec.SubnetRef", a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef)
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }

--- a/pkg/resource/route_table/delta.go
+++ b/pkg/resource/route_table/delta.go
@@ -45,9 +45,6 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.Routes, b.ko.Spec.Routes) {
 		delta.Add("Spec.Routes", a.ko.Spec.Routes, b.ko.Spec.Routes)
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)
 	} else if a.ko.Spec.VPCID != nil && b.ko.Spec.VPCID != nil {

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -62,9 +62,6 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)
 	} else if a.ko.Spec.VPCID != nil && b.ko.Spec.VPCID != nil {

--- a/pkg/resource/subnet/delta.go
+++ b/pkg/resource/subnet/delta.go
@@ -139,9 +139,6 @@ func newResourceDelta(
 	if !ackcompare.SliceStringPEqual(a.ko.Spec.RouteTables, b.ko.Spec.RouteTables) {
 		delta.Add("Spec.RouteTables", a.ko.Spec.RouteTables, b.ko.Spec.RouteTables)
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)
 	} else if a.ko.Spec.VPCID != nil && b.ko.Spec.VPCID != nil {

--- a/pkg/resource/transit_gateway/delta.go
+++ b/pkg/resource/transit_gateway/delta.go
@@ -105,9 +105,6 @@ func newResourceDelta(
 			}
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }

--- a/pkg/resource/vpc/delta.go
+++ b/pkg/resource/vpc/delta.go
@@ -122,9 +122,6 @@ func newResourceDelta(
 			delta.Add("Spec.IPv6Pool", a.ko.Spec.IPv6Pool, b.ko.Spec.IPv6Pool)
 		}
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 
 	return delta
 }

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -99,9 +99,6 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs) {
 		delta.Add("Spec.SubnetRefs", a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs)
 	}
-	if !reflect.DeepEqual(a.ko.Spec.Tags, b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCEndpointType, b.ko.Spec.VPCEndpointType) {
 		delta.Add("Spec.VPCEndpointType", a.ko.Spec.VPCEndpointType, b.ko.Spec.VPCEndpointType)
 	} else if a.ko.Spec.VPCEndpointType != nil && b.ko.Spec.VPCEndpointType != nil {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: This `compare: is_ignored` config is needed alongside the `delta_pre_compare: compareTags` otherwise the generated `Delta` may still return a false difference due to Tag order

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
