### PR TITLE
Fix test resources link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The latest images and Helm Charts can be found in their respective ECR Public re
 
 ## Create/Delete an ACK Resource
 
-* Navigate to [test resources]() for a list of resource `yaml` templates
+* Navigate to [test resources](https://github.com/aws-controllers-k8s/ec2-controller/tree/main/test/e2e/resources) for a list of resource `yaml` templates
 * Copy the file to the local terminal and substitute `$` values. Ex: [vpc.yaml](https://github.com/aws-controllers-k8s/ec2-controller/blob/main/test/e2e/resources/vpc.yaml)
 
 ```


### PR DESCRIPTION
Description of changes:

Added `test resources` link in `README.md`, now it points to resources template yaml files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
