### PR TITLE
Fix reconciler not detecting differences

### DIFF
--- a/pkg/resource/dhcp_options/hooks.go
+++ b/pkg/resource/dhcp_options/hooks.go
@@ -37,7 +37,7 @@ func (rm *resourceManager) customUpdateDHCPOptions(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {

--- a/pkg/resource/elastic_ip_address/hooks.go
+++ b/pkg/resource/elastic_ip_address/hooks.go
@@ -37,7 +37,7 @@ func (rm *resourceManager) customUpdateElasticIP(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -50,7 +50,7 @@ func (rm *resourceManager) customUpdateInstance(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {

--- a/pkg/resource/internet_gateway/hooks.go
+++ b/pkg/resource/internet_gateway/hooks.go
@@ -39,7 +39,7 @@ func (rm *resourceManager) customUpdateInternetGateway(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.VPC") {
 		if latest.ko.Spec.VPC != nil {

--- a/pkg/resource/nat_gateway/hooks.go
+++ b/pkg/resource/nat_gateway/hooks.go
@@ -37,7 +37,7 @@ func (rm *resourceManager) customUpdateNATGateway(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -196,7 +196,7 @@ func (rm *resourceManager) customUpdateRouteTable(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Routes") {
 		if err := rm.syncRoutes(ctx, desired, latest); err != nil {

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -421,7 +421,7 @@ func (rm *resourceManager) customUpdateSecurityGroup(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.IngressRules") || delta.DifferentAt("Spec.EgressRules") {
 		if err := rm.syncSGRules(ctx, desired, latest); err != nil {

--- a/pkg/resource/subnet/hooks.go
+++ b/pkg/resource/subnet/hooks.go
@@ -40,7 +40,7 @@ func (rm *resourceManager) customUpdateSubnet(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.RouteTables") {
 		if err = rm.updateRouteTableAssociations(ctx, desired, latest, delta); err != nil {

--- a/pkg/resource/transit_gateway/hooks.go
+++ b/pkg/resource/transit_gateway/hooks.go
@@ -37,7 +37,7 @@ func (rm *resourceManager) customUpdateTransitGateway(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -250,7 +250,7 @@ func (rm *resourceManager) customUpdateVPC(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.CIDRBlocks") {
 		if err := rm.syncCIDRBlocks(ctx, desired, latest); err != nil {

--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -50,7 +50,7 @@ func (rm *resourceManager) customUpdateVPCEndpoint(
 	// If the `modify` calls (i.e. `sync`) do NOT return
 	// an error, then the update was successful and desired.Spec
 	// (now updated.Spec) reflects the latest resource state.
-	updated = desired
+	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1552

Description of changes:
When attempting to debug why conditions were not being set on resources, I discovered that the reconciler was not detecting a difference between the `latest` and `desired` objects' conditions. I determined that this was because `latest.status.conditions` was sharing the same memory as `desired.status.conditions`. Walking through the code with a debugger, I found that it was inside the `Update` code where the memory was being swapped. I have updated these lines in each of the EC2 hook code files so that we no longer return a reference to the `desired` object, and can safely modify the `updated` object independently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
