### PR TITLE
Deleted default egress rule upon SG creation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-02-09T23:51:42Z"
+  build_date: "2023-04-25T13:24:38Z"
   build_hash: d0f3d78cbea8061f822cbceac3786128f091efe6
-  go_version: go1.19
+  go_version: go1.19.6
   version: v0.24.2
 api_directory_checksum: 6e86aa4f26729ce014485b1096286db654459af7
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: d9d0156fc1156be66ef8542caa31686764629ad7
+  file_checksum: cc2c6590c6e77a6125d5eec82ff5f693109d4f99
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -419,7 +419,6 @@ resources:
         custom_field:
           list_of: IpPermission
       EgressRules:
-        late_initialize: {}
         custom_field:
           list_of: IpPermission
       Rules:

--- a/generator.yaml
+++ b/generator.yaml
@@ -419,7 +419,6 @@ resources:
         custom_field:
           list_of: IpPermission
       EgressRules:
-        late_initialize: {}
         custom_field:
           list_of: IpPermission
       Rules:

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,7 +145,10 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. Defaults
+                                key-value store until this reference is removed. See
+                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
+                                for how the garbage collector interacts with this
+                                field and enforces the foreground deletion. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/pkg/resource/security_group/manager.go
+++ b/pkg/resource/security_group/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=securitygroups/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"EgressRules"}
+var lateInitializeFieldNames = []string{}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -248,10 +248,6 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
-	ko := rm.concreteResource(res).ko.DeepCopy()
-	if ko.Spec.EgressRules == nil {
-		return true
-	}
 	return false
 }
 
@@ -261,12 +257,7 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	observedKo := rm.concreteResource(observed).ko.DeepCopy()
-	latestKo := rm.concreteResource(latest).ko.DeepCopy()
-	if observedKo.Spec.EgressRules != nil && latestKo.Spec.EgressRules == nil {
-		latestKo.Spec.EgressRules = observedKo.Spec.EgressRules
-	}
-	return &resource{latestKo}
+	return latest
 }
 
 // IsSynced returns true if the resource is synced.

--- a/pkg/resource/security_group/sdk.go
+++ b/pkg/resource/security_group/sdk.go
@@ -219,11 +219,9 @@ func (rm *resourceManager) sdkCreate(
 		return nil, ackerr.NotFound
 	}
 
-	// if user defines any egress rule, then remove the default egress rule
-	if len(desired.ko.Spec.EgressRules) > 0 {
-		if err = rm.deleteDefaultSecurityGroupRule(ctx, &resource{ko}); err != nil {
-			return nil, err
-		}
+	// Delete the default egress rule
+	if err = rm.deleteDefaultSecurityGroupRule(ctx, &resource{ko}); err != nil {
+		return nil, err
 	}
 
 	if err = rm.syncSGRules(ctx, &resource{ko}, nil); err != nil {

--- a/templates/hooks/security_group/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/security_group/sdk_create_post_set_output.go.tpl
@@ -3,11 +3,9 @@
 		return nil, ackerr.NotFound
 	}
 
-	// if user defines any egress rule, then remove the default egress rule
-	if len(desired.ko.Spec.EgressRules) > 0 {
-		if err = rm.deleteDefaultSecurityGroupRule(ctx, &resource{ko}); err != nil {
-			return nil, err
-		}
+	// Delete the default egress rule
+	if err = rm.deleteDefaultSecurityGroupRule(ctx, &resource{ko}); err != nil {
+		return nil, err
 	}
 
 	if err = rm.syncSGRules(ctx, &resource{ko}, nil); err != nil {


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1766

Description of changes:

As per the current functionality, default Egress Rule is attached automatically upon creation of Security Group. Modified code to delete the default egress rule that's created even if user doesn't specify any egress rule. Modified the e2e tests to match this requirement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
