### PR TITLE
fixing dropping of secondary cidr blocks on first apply of VPC

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2023-06-14T17:05:27Z"
-  build_hash: e04fca8e1fa32e988ff4dd9425d758ecc8a2a178
-  go_version: go1.20.3
-  version: v0.26.1-6-ge04fca8
-api_directory_checksum: a930caa16911411d04c5e7c14b27e077993d93a1
+  build_date: "2023-06-17T15:45:55Z"
+  build_hash: e9b68590da73ce9143ba1e4361cebdc1d876c81e
+  go_version: go1.19
+  version: v0.26.1-7-ge9b6859
+api_directory_checksum: 9452be5c34acba71fcd740b2acf4d053f2eb221b
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -110,7 +110,7 @@ deletionPolicy: delete
 # controller reconciliation configurations
 reconcile:
   # The default duration, in seconds, to wait before resyncing desired state of custom resources.
-  defaultResyncPeriod: 0
+  defaultResyncPeriod: 36000 # 10 Hours
   # An object representing the reconcile resync configuration for each specific resource.
   resourceResyncPeriods: {}
 

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -428,3 +428,48 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
 }
+
+func (rm *resourceManager) attachSecondaryCidrBlocks(ctx context.Context, desired *resource,
+	resp *svcsdk.CreateVpcOutput, ko *svcapitypes.VPC) (err error) {
+	cidrblockassociationset := []*svcapitypes.VPCCIDRBlockAssociation{}
+	if len(desired.ko.Spec.CIDRBlocks) > 1 {
+		for _, cidr := range desired.ko.Spec.CIDRBlocks[1:] {
+			input := &svcsdk.AssociateVpcCidrBlockInput{
+				VpcId:     resp.Vpc.VpcId,
+				CidrBlock: cidr,
+			}
+			var res *svcsdk.AssociateVpcCidrBlockOutput
+			cidrblockassociation := &svcapitypes.VPCCIDRBlockAssociation{}
+			res, err := rm.sdkapi.AssociateVpcCidrBlockWithContext(ctx, input)
+			// rlog.Debug("adding Secondary CIDR to VPC resource", "cidrs", cidr)
+			rm.metrics.RecordAPICall("UPDATE", "AssociateVpcCidrBlock", err)
+			if err != nil {
+				return err
+			}
+
+			if res.CidrBlockAssociation != nil {
+				if res.CidrBlockAssociation.AssociationId != nil {
+					cidrblockassociation.AssociationID = res.CidrBlockAssociation.AssociationId
+				}
+				if res.CidrBlockAssociation.CidrBlock != nil {
+					cidrblockassociation.CIDRBlock = res.CidrBlockAssociation.CidrBlock
+				}
+				if res.CidrBlockAssociation.CidrBlockState != nil {
+					cidrblockstate := &svcapitypes.VPCCIDRBlockState{}
+					if res.CidrBlockAssociation.CidrBlockState.State != nil {
+						cidrblockstate.State = res.CidrBlockAssociation.CidrBlockState.State
+					}
+					if res.CidrBlockAssociation.CidrBlockState.StatusMessage != nil {
+						cidrblockstate.StatusMessage = res.CidrBlockAssociation.CidrBlockState.StatusMessage
+					}
+				}
+				cidrblockassociationset = append(cidrblockassociationset, cidrblockassociation)
+			}
+		}
+
+	}
+	if cidrblockassociationset != nil {
+		ko.Status.CIDRBlockAssociationSet = append(ko.Status.CIDRBlockAssociationSet, cidrblockassociationset...)
+	}
+	return nil
+}

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -374,7 +374,12 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	rm.attachSecondaryCidrBlocks(ctx, desired, resp, ko)
+	if resp.Vpc.CidrBlock != nil {
+		ko.Spec.CIDRBlocks = make([]*string, 1)
+		ko.Spec.CIDRBlocks[0] = resp.Vpc.CidrBlock
+	}
+	rm.syncCIDRBlocks(ctx, desired, &resource{ko})
+
 	rm.setSpecCIDRs(ko)
 	err = rm.createAttributes(ctx, &resource{ko})
 	if err != nil {

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -373,6 +373,47 @@ func (rm *resourceManager) sdkCreate(
 		ko.Status.VPCID = nil
 	}
 
+	cidrblockassociationset := []*svcapitypes.VPCCIDRBlockAssociation{}
+	if len(desired.ko.Spec.CIDRBlocks) > 1 {
+		for _, cidr := range desired.ko.Spec.CIDRBlocks[1:] {
+			input := &svcsdk.AssociateVpcCidrBlockInput{
+				VpcId:     resp.Vpc.VpcId,
+				CidrBlock: cidr,
+			}
+			var res *svcsdk.AssociateVpcCidrBlockOutput
+			cidrblockassociation := &svcapitypes.VPCCIDRBlockAssociation{}
+			res, err := rm.sdkapi.AssociateVpcCidrBlockWithContext(ctx, input)
+			rlog.Debug("adding Secondary CIDR to VPC resource", "cidrs", cidr)
+			rm.metrics.RecordAPICall("UPDATE", "AssociateVpcCidrBlock", err)
+			if err != nil {
+				return nil, err
+			}
+
+			if res.CidrBlockAssociation != nil{
+				if res.CidrBlockAssociation.AssociationId != nil {
+					cidrblockassociation.AssociationID = res.CidrBlockAssociation.AssociationId
+				}
+				if res.CidrBlockAssociation.CidrBlock != nil {
+					cidrblockassociation.CIDRBlock = res.CidrBlockAssociation.CidrBlock
+				}
+				if res.CidrBlockAssociation.CidrBlockState != nil {
+					cidrblockstate := &svcapitypes.VPCCIDRBlockState{}
+					if res.CidrBlockAssociation.CidrBlockState.State != nil {
+						cidrblockstate.State = res.CidrBlockAssociation.CidrBlockState.State
+					}
+					if res.CidrBlockAssociation.CidrBlockState.StatusMessage != nil {
+						cidrblockstate.StatusMessage = res.CidrBlockAssociation.CidrBlockState.StatusMessage
+					}
+				}
+				cidrblockassociationset = append(cidrblockassociationset, cidrblockassociation)
+			}
+		}
+
+	}
+	if cidrblockassociationset != nil {
+		ko.Status.CIDRBlockAssociationSet = append(ko.Status.CIDRBlockAssociationSet,cidrblockassociationset...)
+	}
+
 	rm.setStatusDefaults(ko)
 	rm.setSpecCIDRs(ko)
 	err = rm.createAttributes(ctx, &resource{ko})

--- a/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
@@ -1,4 +1,9 @@
-    rm.attachSecondaryCidrBlocks(ctx, desired, resp, ko)
+    if resp.Vpc.CidrBlock != nil {
+    ko.Spec.CIDRBlocks = make([]*string, 1)
+    ko.Spec.CIDRBlocks[0] = resp.Vpc.CidrBlock
+    }
+    rm.syncCIDRBlocks(ctx, desired, &resource{ko})
+
     rm.setSpecCIDRs(ko)
     err = rm.createAttributes(ctx, &resource{ko})
     if err != nil {

--- a/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,4 @@
+    rm.attachSecondaryCidrBlocks(ctx, desired, resp, ko)
     rm.setSpecCIDRs(ko)
     err = rm.createAttributes(ctx, &resource{ko})
     if err != nil {

--- a/test/e2e/resources/vpc_multicidr.yaml
+++ b/test/e2e/resources/vpc_multicidr.yaml
@@ -1,0 +1,13 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: VPC
+metadata:
+  name: $VPC_NAME
+spec:
+  cidrBlocks: 
+  - $PRIMARY_CIDR_BLOCK
+  - $SECONDARY_CIDR_BLOCK
+  enableDNSSupport: $ENABLE_DNS_SUPPORT
+  enableDNSHostnames: $ENABLE_DNS_HOSTNAMES
+  tags:
+    - key: $TAG_KEY
+      value: $TAG_VALUE

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -364,8 +364,8 @@ class TestVpc:
 
         # Re-Validate CIDR Blocks State
         vpc = ec2_validator.get_vpc(resource_id)
-        assert vpc['CidrBlockAssociationSet'][0]['CidrBlockState'] == "associated"
-        assert vpc['CidrBlockAssociationSet'][0]['CidrBlockState'] == "disassociated"
+        assert vpc['CidrBlockAssociationSet'][0]['CidrBlockState']['State'] == "associated"
+        assert vpc['CidrBlockAssociationSet'][1]['CidrBlockState']['State'] == "disassociated"
 
 
         # Delete k8s resource

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -357,7 +357,7 @@ class TestVpc:
 
         # Remove SECONDARY_CIDR_BLOCK
         updates = {
-            "spec": {"cidrBlocks": PRIMARY_CIDR_DEFAULT}
+            "spec": {"cidrBlocks": [PRIMARY_CIDR_DEFAULT]}
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -46,7 +46,6 @@ def get_dns_hostnames(ec2_client, vpc_id: str) -> bool:
 
 @service_marker
 @pytest.mark.canary
-@pytest.mark.ntest
 class TestVpc:
     def test_crud(self, ec2_client, simple_vpc):
         (ref, cr) = simple_vpc

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -46,6 +46,7 @@ def get_dns_hostnames(ec2_client, vpc_id: str) -> bool:
 
 @service_marker
 @pytest.mark.canary
+@pytest.mark.ntest
 class TestVpc:
     def test_crud(self, ec2_client, simple_vpc):
         (ref, cr) = simple_vpc
@@ -265,3 +266,51 @@ class TestVpc:
         # Value (dsfre) for parameter cidrBlock is invalid.
         # This is not a valid CIDR block.
         assert expected_msg in terminal_condition['message']
+    
+    def test_vpc_creation_multiple_cidr(self,ec2_client):
+        resource_name = random_suffix_name("vpc-ack-multicidr", 24)
+        replacements = REPLACEMENT_VALUES.copy()
+        replacements["VPC_NAME"] = resource_name
+        replacements["PRIMARY_CIDR_BLOCK"] = PRIMARY_CIDR_DEFAULT
+        replacements["SECONDARY_CIDR_BLOCK"] = "10.2.0.0/16"
+        replacements["ENABLE_DNS_SUPPORT"] = "False"
+        replacements["ENABLE_DNS_HOSTNAMES"] = "False"
+
+        # Load VPC CR
+        resource_data = load_ec2_resource(
+            "vpc_multicidr",
+            additional_replacements=replacements,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+
+        resource_id = cr["status"]["vpcID"]
+
+        # Check VPC exists in AWS
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_vpc(resource_id)
+
+        # Validate CIDR Block
+        vpc = ec2_validator.get_vpc(resource_id)
+        assert len(vpc['CidrBlockAssociationSet']) == 2
+        assert vpc['CidrBlockAssociationSet'][0]['CidrBlock'] == PRIMARY_CIDR_DEFAULT
+        assert vpc['CidrBlockAssociationSet'][1]['CidrBlock'] == "10.2.0.0/16"
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted is True
+
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+        # Check VPC no longer exists in AWS
+        ec2_validator.assert_vpc(resource_id, exists=False)


### PR DESCRIPTION
Issue https://github.com/aws-controllers-k8s/community/issues/1816


Description of changes:
Added the fix for a bug where Secondary VPC CIDR blocks are getting dropped in the first apply of VPC resource.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
