### PR TITLE
Fix for Circular dependency while creating RouteTable and a VPCEndpoint

### DIFF
--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -45,8 +45,13 @@ func (rm *resourceManager) syncRoutes(
 	defer exit(err)
 	toAdd := []*svcapitypes.CreateRouteInput{}
 	toDelete := []*svcapitypes.CreateRouteInput{}
-	latest.ko.Spec.Routes = rm.excludeAwsRoute(latest.ko.Spec.Routes)
-	desired.ko.Spec.Routes = rm.excludeAwsRoute(desired.ko.Spec.Routes)
+
+	if latest != nil {
+		latest.ko.Spec.Routes = rm.excludeAwsRoute(latest.ko.Spec.Routes)
+	}
+	if desired != nil {
+		desired.ko.Spec.Routes = rm.excludeAwsRoute(desired.ko.Spec.Routes)
+	}
 
 	for _, desiredRoute := range desired.ko.Spec.Routes {
 		if (*desiredRoute).GatewayID != nil && *desiredRoute.GatewayID == LocalRouteGateway {
@@ -325,6 +330,8 @@ func (rm *resourceManager) excludeAwsRoute(
 			if _, found := awsMpl[*route.DestinationPrefixListID]; !found {
 				ret = append(ret, route)
 			}
+		} else {
+			ret = append(ret, route)
 		}
 	}
 	return ret


### PR DESCRIPTION
Issue: https://github.com/aws-controllers-k8s/community/issues/1817

Description of changes:
This is for fixing circular dependency bug while creating a new RouteTable and a VPCEndpoint. As per the changes in this PR, any route to `DestinationPrefixList` which is owned by "AWS" will be ignored while syncing routes and will be used as is.

Tested via following :

```
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: VPC
metadata:
  name: circular-dependency-vpc
spec:
  cidrBlocks:
  - 10.10.0.0/16
  enableDNSSupport: True
  enableDNSHostnames: True
  tags:
    - key: Name
      value: circular-dependency-vpc
---
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: RouteTable
metadata:
  name: circular-dependency-rtb
spec:
  routes:
    - destinationCIDRBlock: 0.0.0.0/0
      gatewayRef:
        from:
          name: circular-dependency-igw
  vpcRef:
    from:
      name: circular-dependency-vpc
---
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: VPCEndpoint
metadata:
  name:  circular-dependency-vpc-endpoint-s3
spec:
  serviceName: com.amazonaws.us-west-2.s3
  vpcRef:
    from:
      name: circular-dependency-vpc
  routeTableRefs:
  - from:
      name: circular-dependency-rtb
  tags:
    - key: Name
      value:  circular-dependency-vpc-endpoint-s3
---
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: InternetGateway
metadata:
  name: circular-dependency-igw
spec:
  vpcRef:
    from:
      name: circular-dependency-vpc
  tags:
    - key: "Adobe.Owner"
      value: "Ethos"
    - key: Name
      value: circular-dependency-igw
```


Status (before reconciliation i.e. before ACK synced from AWS actual resources):

```
$ kubectl get routetable circular-dependency-rtb -o json | jq .status.routeStatuses
[
  {
    "destinationCIDRBlock": "10.10.0.0/16",
    "gatewayID": "local",
    "origin": "CreateRouteTable",
    "state": "active"
  },
  {
    "destinationCIDRBlock": "0.0.0.0/0",
    "gatewayID": "igw-06d5825a3e9ba9dee",
    "origin": "CreateRoute",
    "state": "active"
  }
]
```

Status (after reconciliation i.e. after ACK synced from AWS actual resources):

```
[
  {
    "destinationCIDRBlock": "10.10.0.0/16",
    "gatewayID": "local",
    "origin": "CreateRouteTable",
    "state": "active"
  },
  {
    "destinationCIDRBlock": "0.0.0.0/0",
    "gatewayID": "igw-06d5825a3e9ba9dee",
    "origin": "CreateRoute",
    "state": "active"
  },
  {
    "destinationPrefixListID": "pl-68a54001",
    "gatewayID": "vpce-017f902c0d2c007e3",
    "origin": "CreateRoute",
    "state": "active"
  }
]
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
