### PR TITLE
Fix critical error in flowlogs pkg

### DIFF
--- a/pkg/resource/flow_log/sdk.go
+++ b/pkg/resource/flow_log/sdk.go
@@ -248,8 +248,8 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	if resp.FlowLogIds[0] != nil {
-		ko.Status.FlowLogID = resp.FlowLogIds[0]
+	if resp.FlowLogs[0] != nil {
+		ko.Status.FlowLogID = resp.FlowLogs[0].FlowLogID
 	}
 	return &resource{ko}, nil
 }


### PR DESCRIPTION
Issue #, if available: [1931](https://github.com/aws-controllers-k8s/community/issues/1931)

Description of changes:
https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#DescribeFlowLogsOutput

FlowLogID is not a field defined in DescribeFlowlogsOutput. Need to go inside the resp.FlowLog[] to get the FlowLogID. This is causing a crash any time FlowLog resource is created because it is always going to return index out of bounds. 
