### PR TITLE
Fix flowlog crash

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-09-17T19:14:20Z"
+  build_date: "2024-09-20T17:31:34Z"
   build_hash: f8f98563404066ac3340db0a049d2e530e5c51cc
   go_version: go1.22.6
   version: v0.38.1

--- a/pkg/resource/flow_log/sdk.go
+++ b/pkg/resource/flow_log/sdk.go
@@ -248,7 +248,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
-	if resp.FlowLogIds[0] != nil {
+	if len(resp.FlowLogIds) > 0 && resp.FlowLogIds[0] != nil {
 		ko.Status.FlowLogID = resp.FlowLogIds[0]
 	}
 	return &resource{ko}, nil

--- a/templates/hooks/flow_log/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/flow_log/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,3 @@
-    if resp.FlowLogIds[0] != nil {
+    if len(resp.FlowLogIds) > 0 && resp.FlowLogIds[0] != nil {
 		ko.Status.FlowLogID = resp.FlowLogIds[0]
 	}


### PR DESCRIPTION
Issue #, if available: [#1931](https://github.com/aws-controllers-k8s/community/issues/1931)

Description of changes:
While creating FlowLog, if logDestnation does not exist then CreateFlowLogsWithContext does not return the error. However, Unsuccessful field in the response is set. FlowLog is not created in aws. Due to this, controller crashes while accessing the flow log id from the response (resp.FlowLogIds[0]).
Fixing the issue by checking if FlowLogIds has valid length before accessing it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
