### PR TITLE
Add support for adoption of existing Flow Logs and Security Groups

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-09-18T23:03:44Z"
-  build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
-  go_version: go1.20.3
-  version: v0.27.1
+  build_date: "2023-12-05T11:20:59Z"
+  build_hash: 3653329ceeb20015851b8776a6061a3fb0ec2935
+  go_version: go1.21.4
+  version: v0.27.1-6-g3653329-dirty
 api_directory_checksum: 6e2d850d97f2f72db31c9bef522eca4ab95b3fcd
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: c474e6cdec9622afad4b4cef415483a7bd0eda41
+  file_checksum: e900e7783872dcd15c10fd4efb10d069047e3db4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2023-12-05T11:20:59Z"
+  build_date: "2023-12-05T16:46:52Z"
   build_hash: 3653329ceeb20015851b8776a6061a3fb0ec2935
   go_version: go1.21.4
   version: v0.27.1-6-g3653329-dirty

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -539,6 +539,8 @@ resources:
         template_path: hooks/security_group/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/security_group/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -334,6 +334,8 @@ resources:
         template_path: hooks/flow_log/sdk_read_many_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/flow_log/sdk_file_end.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/flow_log/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateFlowLog
   InternetGateway:

--- a/generator.yaml
+++ b/generator.yaml
@@ -539,6 +539,8 @@ resources:
         template_path: hooks/security_group/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/security_group/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/generator.yaml
+++ b/generator.yaml
@@ -334,6 +334,8 @@ resources:
         template_path: hooks/flow_log/sdk_read_many_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/flow_log/sdk_file_end.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/flow_log/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateFlowLog
   InternetGateway:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -123,7 +123,7 @@ spec:
             readOnly: true
         {{- end }}
         {{- if .Values.deployment.extraVolumeMounts -}}
-          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 12 }}
+          {{ toYaml .Values.deployment.extraVolumeMounts | nindent 10 }}
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
@@ -151,11 +151,11 @@ spec:
       hostNetwork: {{ .Values.deployment.hostNetwork }}
       dnsPolicy: {{ .Values.deployment.dnsPolicy }}
       volumes:
-      {{- if .Values.aws.credentials.secretName -}}
+      {{- if .Values.aws.credentials.secretName }}
         - name: {{ .Values.aws.credentials.secretName }}
           secret:
             secretName: {{ .Values.aws.credentials.secretName }}
-      {{ end -}}
+      {{- end }}
 {{- if .Values.deployment.extraVolumes }}
 {{ toYaml .Values.deployment.extraVolumes | indent 8}}
 {{- end }}

--- a/pkg/resource/flow_log/resource.go
+++ b/pkg/resource/flow_log/resource.go
@@ -90,13 +90,13 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.FlowLogID = &identifier.NameOrID
 
-	f6, f6ok := identifier.AdditionalKeys["resourceID"]
-	if f6ok {
-		r.ko.Spec.ResourceID = &f6
+	identifierResourceID, identifierResourceIDOk := identifier.AdditionalKeys["resourceID"]
+	if identifierResourceIDOk {
+		r.ko.Spec.ResourceID = &identifierResourceID
 	}
-	f7, f7ok := identifier.AdditionalKeys["resourceType"]
-	if f7ok {
-		r.ko.Spec.ResourceType = &f7
+	identifierResourceType, identifierResourceTypeOk := identifier.AdditionalKeys["resourceType"]
+	if identifierResourceTypeOk {
+		r.ko.Spec.ResourceType = &identifierResourceType
 	}
 
 	return nil

--- a/pkg/resource/flow_log/resource.go
+++ b/pkg/resource/flow_log/resource.go
@@ -90,6 +90,15 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.FlowLogID = &identifier.NameOrID
 
+	f6, f6ok := identifier.AdditionalKeys["resourceID"]
+	if f6ok {
+		r.ko.Spec.ResourceID = &f6
+	}
+	f7, f7ok := identifier.AdditionalKeys["resourceType"]
+	if f7ok {
+		r.ko.Spec.ResourceType = &f7
+	}
+
 	return nil
 }
 

--- a/pkg/resource/security_group/resource.go
+++ b/pkg/resource/security_group/resource.go
@@ -90,6 +90,11 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.ID = &identifier.NameOrID
 
+	f6, f6ok := identifier.AdditionalKeys["name"]
+	if f6ok {
+		r.ko.Spec.Name = &f6
+	}
+
 	return nil
 }
 

--- a/pkg/resource/security_group/resource.go
+++ b/pkg/resource/security_group/resource.go
@@ -90,9 +90,9 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.ID = &identifier.NameOrID
 
-	f6, f6ok := identifier.AdditionalKeys["name"]
-	if f6ok {
-		r.ko.Spec.Name = &f6
+	identifierName, identifierNameOk := identifier.AdditionalKeys["name"]
+	if identifierNameOk {
+		r.ko.Spec.Name = &identifierName
 	}
 
 	return nil

--- a/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,8 @@
+	f6, f6ok := identifier.AdditionalKeys["resourceID"]
+	if f6ok {
+		r.ko.Spec.ResourceID = &f6
+	}
+        f7, f7ok := identifier.AdditionalKeys["resourceType"]
+        if f7ok {
+                r.ko.Spec.ResourceType = &f7
+        }

--- a/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
@@ -1,8 +1,8 @@
-	f6, f6ok := identifier.AdditionalKeys["resourceID"]
-	if f6ok {
-		r.ko.Spec.ResourceID = &f6
+	identifierResourceID, identifierResourceIDOk := identifier.AdditionalKeys["resourceID"]
+	if identifierResourceIDOk {
+		r.ko.Spec.ResourceID = &identifierResourceID
 	}
-        f7, f7ok := identifier.AdditionalKeys["resourceType"]
-        if f7ok {
-                r.ko.Spec.ResourceType = &f7
+        identifierResourceType, identifierResourceTypeOk := identifier.AdditionalKeys["resourceType"]
+        if identifierResourceTypeOk {
+                r.ko.Spec.ResourceType = &identifierResourceType
         }

--- a/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
@@ -1,4 +1,4 @@
-	f6, f6ok := identifier.AdditionalKeys["name"]
-	if f6ok {
-		r.ko.Spec.Name = &f6
+	identifierName, identifierNameOk := identifier.AdditionalKeys["name"]
+	if identifierNameOk {
+		r.ko.Spec.Name = &identifierName
 	}

--- a/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,4 @@
+	f6, f6ok := identifier.AdditionalKeys["name"]
+	if f6ok {
+		r.ko.Spec.Name = &f6
+	}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/1946

Description of changes:

This proposed fix add support for additionalKeys needed to support adoption of Security Groups and FlowLogs as requested on the issue linked above.

The following adoption instructions will now work:

```yaml
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: my-flow-log
spec:
  aws:
    nameOrID: fl-xxxxxxx
    additionalKeys:
      resourceID: vpc-xxxxxx
      resourceType: VPC
  kubernetes:
    group: ec2.services.k8s.aws
    kind: FlowLog
---
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: my-sg
spec:
  aws:
    nameOrID: sg-xxxxxx
    additionalKeys:
      name: "My GroupName"
  kubernetes:
    group: ec2.services.k8s.aws
    kind: SecurityGroup
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
