### PR TITLE
Fix `AdoptedResource` functionality for `FlowLogs`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-06T21:00:34Z"
-  build_hash: 1cc9b5172d3d1676af578a3411e8672698ec29ce
-  go_version: go1.21.0
-  version: 1cc9b51
-api_directory_checksum: d452bf19bfd1496aacdc215bf7cc9ea86c55c122
+  build_date: "2023-12-06T21:43:43Z"
+  build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
+  go_version: go1.21.1
+  version: v0.27.1
+api_directory_checksum: 6e2d850d97f2f72db31c9bef522eca4ab95b3fcd
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 86b3e3aa1ff4769894d475244d0cc5902bcb258f
+  file_checksum: d10a62517f87bacf988184f8c454b90b42dee732
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -340,6 +340,8 @@ resources:
         template_path: hooks/flow_log/sdk_read_many_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/flow_log/sdk_file_end.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/flow_log/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateFlowLog
   InternetGateway:

--- a/generator.yaml
+++ b/generator.yaml
@@ -340,6 +340,8 @@ resources:
         template_path: hooks/flow_log/sdk_read_many_post_build_request.go.tpl
       sdk_file_end:
         template_path: hooks/flow_log/sdk_file_end.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/flow_log/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateFlowLog
   InternetGateway:

--- a/pkg/resource/flow_log/resource.go
+++ b/pkg/resource/flow_log/resource.go
@@ -90,6 +90,13 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.FlowLogID = &identifier.NameOrID
 
+	if resourceID, ok := identifier.AdditionalKeys["resourceID"]; ok {
+		r.ko.Spec.ResourceID = &resourceID
+	}
+
+	if resourceType, ok := identifier.AdditionalKeys["resourceType"]; ok {
+		r.ko.Spec.ResourceType = &resourceType
+	}
 	return nil
 }
 

--- a/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/flow_log/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,7 @@
+	if resourceID, ok := identifier.AdditionalKeys["resourceID"]; ok {
+                r.ko.Spec.ResourceID = &resourceID
+        }
+
+        if resourceType, ok := identifier.AdditionalKeys["resourceType"]; ok {
+                r.ko.Spec.ResourceType = &resourceType
+        }


### PR DESCRIPTION
Issue # : https://github.com/aws-controllers-k8s/community/issues/1946

RCA:
Following CR currently fails to adopt the existing FlowLog resource.

```
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: flowlog1
spec:
  aws:
    nameOrID: fl-xxxxxx
  kubernetes:
    group: ec2.services.k8s.aws
    kind: FlowLog
    metadata:
      name: flowlog-adopted
      namespace: default
```

The error 
```
"error": "FlowLog.ec2.services.k8s.aws "my-resource" is invalid: [spec.resourceID: Required value, spec.resourceType: Required value]"}
```
comes from https://github.com/aws-controllers-k8s/runtime/blob/main/pkg/runtime/adoption_reconciler.go#L157

`SetIdentifiers` function needs to have code to fill up `required` values of the CR so as to solve this issue.

Solution:
2 new fields are defined as `ResourceID` and `ResourceType` and they are initialized in `SetIdentifiers` function. These fields need to part of `additionalKeys` field of `AdoptedResource` CR for `FlowLog`.

The new CR looks like,
```
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: flowlog1
spec:
  aws:
    nameOrID: fl-xxxxx
    additionalKeys:
      ResourceID: vpc-xxxxxx
      ResourceType: VPC
  kubernetes:
    group: ec2.services.k8s.aws
    kind: FlowLog
    metadata:
      name: flowlog-adopted
      namespace: default
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
