### PR TITLE
Fix `AdoptedResource` functionality for `SecurityGroups`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-06T21:43:43Z"
-  build_hash: 892f29d00a4c4ad21a2fa32919921de18190979d
+  build_date: "2023-12-13T07:19:26Z"
+  build_hash: 3653329ceeb20015851b8776a6061a3fb0ec2935
   go_version: go1.21.1
-  version: v0.27.1
-api_directory_checksum: 6e2d850d97f2f72db31c9bef522eca4ab95b3fcd
+  version: v0.27.1-6-g3653329
+api_directory_checksum: d452bf19bfd1496aacdc215bf7cc9ea86c55c122
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: d10a62517f87bacf988184f8c454b90b42dee732
+  file_checksum: ff084526a7037be1c7d08e2c7e742ac0679abc5f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -549,6 +549,8 @@ resources:
         template_path: hooks/security_group/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/security_group/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/generator.yaml
+++ b/generator.yaml
@@ -549,6 +549,8 @@ resources:
         template_path: hooks/security_group/sdk_create_post_set_output.go.tpl
       sdk_read_many_post_set_output:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
+      post_set_resource_identifiers:
+        template_path: hooks/security_group/post_set_resource_identifiers.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/pkg/resource/security_group/resource.go
+++ b/pkg/resource/security_group/resource.go
@@ -90,6 +90,10 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	}
 	r.ko.Status.ID = &identifier.NameOrID
 
+	if name, ok := identifier.AdditionalKeys["name"]; ok {
+		r.ko.Spec.Name = &name
+	}
+
 	return nil
 }
 

--- a/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
+++ b/templates/hooks/security_group/post_set_resource_identifiers.go.tpl
@@ -1,0 +1,3 @@
+	if name, ok := identifier.AdditionalKeys["name"]; ok {
+                r.ko.Spec.Name = &name
+        }


### PR DESCRIPTION
Issue # : https://github.com/aws-controllers-k8s/community/issues/1946

Description of changes:
RCA:
Following CR currently fails to adopt the existing SecurityGroups resource.

```
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: sg1
spec:
  aws:
    nameOrID: sg-07fd54f8e16eec74a
  kubernetes:
    group: ec2.services.k8s.aws
    kind: SecurityGroup
    metadata:
      name: sg-adopted
      namespace: default
```

The error
```
"error": "SecurityGroup.ec2.services.k8s.aws \"my-resource\" is invalid: spec.name: Required value"
```
comes from https://github.com/aws-controllers-k8s/runtime/blob/main/pkg/runtime/adoption_reconciler.go#L157


SetIdentifiers function needs to have code to fill up required values of the CR so as to solve this issue.

Solution:
A new fields is defined as name and it is initialized in SetIdentifiers function. This field needs to be part of additionalKeys field of AdoptedResource CR for SecurityGroups.

The new CR looks like,

```
apiVersion: services.k8s.aws/v1alpha1
kind: AdoptedResource
metadata:
  name: sg1
spec:
  aws:
    nameOrID: sg-xxxxxx
    additionalKeys:
      name: <security-group-name>
  kubernetes:
    group: ec2.services.k8s.aws
    kind: SecurityGroup
    metadata:
      name: sg-adopted
      namespace: default
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
