### PR TITLE
fix Helm template include reference

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -44,7 +44,7 @@ If release name contains chart name it will be used as a full name.
 
 {{/* The path the shared credentials file is mounted */}}
 {{- define "ack-ec2-controller.aws.credentials.path" -}}
-{{- printf "%s/%s" (include "aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
+{{- printf "%s/%s" (include "ack-ec2-controller.aws.credentials.secret_mount_path" .) .Values.aws.credentials.secretKey -}}
 {{- end -}}
 
 {{/* The rules a of ClusterRole or Role */}}


### PR DESCRIPTION
Issue #, if available: https://github.com/aws-controllers-k8s/community/issues/2029

Description of changes:
Fixed the reference by adding the prefix `ack-ec2-controller`, which was introduced with version 1.2.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
