### PR TITLE
Fix: EC2 controller for vpcendpoint does not update status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-05-02T20:55:46Z"
+  build_date: "2024-05-22T16:42:26Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
-  go_version: go1.22.0
+  go_version: go1.21.1
   version: v0.34.0
-api_directory_checksum: 7fd395ceb7d5d8e35906991c7348d3498f384741
+api_directory_checksum: 1b53401670898ce50e6d6cc8bfba6b63ea7d5683
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 21aa2c0035772a834102dcdac81a186fe148212c
+  file_checksum: 75820b9d685b38976cd9723a9435f119ab913245
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -823,8 +823,12 @@ resources:
         code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/vpc_endpoint/sdk_create_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_delete_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/vpc_endpoint/sdk_file_end.go.tpl
     update_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -823,8 +823,12 @@ resources:
         code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
+      sdk_create_post_set_output:
+        template_path: hooks/vpc_endpoint/sdk_create_post_set_output.go.tpl
       sdk_delete_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_delete_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/vpc_endpoint/sdk_file_end.go.tpl
     update_operation:

--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -24,6 +24,25 @@ import (
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 )
 
+// https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/describe_vpc_endpoints.html
+const (
+	StatusPendingAcceptance = "pendingAcceptance"
+	StatusPending           = "pending"
+	StatusAvailable         = "available"
+	StatusDeleting          = "deleting"
+	StatusDeleted           = "deleted"
+	StatusRejected          = "rejected"
+	StatusFailed            = "failed"
+)
+
+func vpcEndpointAvailable(r *resource) bool {
+	if r.ko.Status.State == nil {
+		return false
+	}
+	cs := *r.ko.Status.State
+	return cs == StatusAvailable
+}
+
 // addIDToDeleteRequest adds resource's Vpc Endpoint ID to DeleteRequest.
 // Return error to indicate to callers that the resource is not yet created.
 func addIDToDeleteRequest(r *resource,

--- a/pkg/resource/vpc_endpoint/sdk.go
+++ b/pkg/resource/vpc_endpoint/sdk.go
@@ -253,6 +253,15 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+
+	if !vpcEndpointAvailable(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	} else {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+	}
+
 	return &resource{ko}, nil
 }
 
@@ -470,6 +479,11 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+
+	// Setting resource synced condition to false will trigger a requeue of
+	// the resource. No need to return a requeue error here.
+	ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/vpc_endpoint/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/vpc_endpoint/sdk_create_post_set_output.go.tpl
@@ -1,0 +1,4 @@
+
+	// Setting resource synced condition to false will trigger a requeue of
+	// the resource. No need to return a requeue error here.
+	ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)

--- a/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,8 @@
+
+	if !vpcEndpointAvailable(&resource{ko}) {
+		// Setting resource synced condition to false will trigger a requeue of
+		// the resource. No need to return a requeue error here.
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
+	} else {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
+	}

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -118,11 +118,11 @@ class TestEC2References:
         assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert k8s.wait_on_condition(sg_ref, "ACK.ResourceSynced", "True", wait_periods=5)
         assert k8s.wait_on_condition(subnet_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ResourceSynced", "True", wait_periods=10)
 
         assert k8s.wait_on_condition(sg_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
         assert k8s.wait_on_condition(subnet_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
-        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
+        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
 
         # Acquire resource IDs
         vpc_endpoint_cr = k8s.get_resource(vpc_endpoint_ref)


### PR DESCRIPTION
Issue : https://github.com/aws-controllers-k8s/community/issues/2075

Description of changes:
The issue is that vpce CR status is not updated. This happens because when vpce is created, it takes around a minute for it to be created in aws. Due to this, it's status is kept `pending`. But there is no sync enforced on the reconciler. Due to this, reconciliation happens after 10h default time. At this time, status would be set correctly.

This fix enforces reconciliation to make sure CR is updated correctly when vpce creation in aws is successful. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
