### PR TITLE
Remove subnet `UserIDGroupPairs.GroupID` references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-05-22T16:42:26Z"
+  build_date: "2024-05-31T06:34:31Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
-  go_version: go1.21.1
+  go_version: go1.22.3
   version: v0.34.0
-api_directory_checksum: 1b53401670898ce50e6d6cc8bfba6b63ea7d5683
+api_directory_checksum: 7fd395ceb7d5d8e35906991c7348d3498f384741
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: 75820b9d685b38976cd9723a9435f119ab913245
+  file_checksum: ae36cc7af80031c6de1461fa5fafad17631dbc99
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -552,10 +552,6 @@ resources:
         references:
           resource: VPC
           path: Status.VPCID
-      IngressRules.UserIDGroupPairs.GroupID:
-        references:
-          resource: SecurityGroup
-          path: Status.ID
       IngressRules.UserIDGroupPairs.GroupName:
         references:
           resource: SecurityGroup

--- a/generator.yaml
+++ b/generator.yaml
@@ -552,10 +552,6 @@ resources:
         references:
           resource: VPC
           path: Status.VPCID
-      IngressRules.UserIDGroupPairs.GroupID:
-        references:
-          resource: SecurityGroup
-          path: Status.ID
       IngressRules.UserIDGroupPairs.GroupName:
         references:
           resource: SecurityGroup

--- a/pkg/resource/security_group/references.go
+++ b/pkg/resource/security_group/references.go
@@ -40,14 +40,6 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 	for f0idx, f0iter := range ko.Spec.IngressRules {
 		for f1idx, f1iter := range f0iter.UserIDGroupPairs {
 			if f1iter.GroupRef != nil {
-				ko.Spec.IngressRules[f0idx].UserIDGroupPairs[f1idx].GroupID = nil
-			}
-		}
-	}
-
-	for f0idx, f0iter := range ko.Spec.IngressRules {
-		for f1idx, f1iter := range f0iter.UserIDGroupPairs {
-			if f1iter.GroupRef != nil {
 				ko.Spec.IngressRules[f0idx].UserIDGroupPairs[f1idx].GroupName = nil
 			}
 		}
@@ -85,12 +77,6 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
-	if fieldHasReferences, err := rm.resolveReferenceForIngressRules_UserIDGroupPairs_GroupID(ctx, apiReader, namespace, ko); err != nil {
-		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
-	} else {
-		resourceHasReferences = resourceHasReferences || fieldHasReferences
-	}
-
 	if fieldHasReferences, err := rm.resolveReferenceForIngressRules_UserIDGroupPairs_GroupName(ctx, apiReader, namespace, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -115,14 +101,6 @@ func (rm *resourceManager) ResolveReferences(
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.SecurityGroup) error {
-
-	for _, f0iter := range ko.Spec.IngressRules {
-		for _, f1iter := range f0iter.UserIDGroupPairs {
-			if f1iter.GroupRef != nil && f1iter.GroupID != nil {
-				return ackerr.ResourceReferenceAndIDNotSupportedFor("IngressRules.UserIDGroupPairs.GroupID", "IngressRules.UserIDGroupPairs.GroupRef")
-			}
-		}
-	}
 
 	for _, f0iter := range ko.Spec.IngressRules {
 		for _, f1iter := range f0iter.UserIDGroupPairs {
@@ -152,11 +130,11 @@ func validateReferenceFields(ko *svcapitypes.SecurityGroup) error {
 	return nil
 }
 
-// resolveReferenceForIngressRules_UserIDGroupPairs_GroupID reads the resource referenced
-// from IngressRules.UserIDGroupPairs.GroupRef field and sets the IngressRules.UserIDGroupPairs.GroupID
+// resolveReferenceForIngressRules_UserIDGroupPairs_GroupName reads the resource referenced
+// from IngressRules.UserIDGroupPairs.GroupRef field and sets the IngressRules.UserIDGroupPairs.GroupName
 // from referenced resource. Returns a boolean indicating whether a reference
 // contains references, or an error
-func (rm *resourceManager) resolveReferenceForIngressRules_UserIDGroupPairs_GroupID(
+func (rm *resourceManager) resolveReferenceForIngressRules_UserIDGroupPairs_GroupName(
 	ctx context.Context,
 	apiReader client.Reader,
 	namespace string,
@@ -174,7 +152,7 @@ func (rm *resourceManager) resolveReferenceForIngressRules_UserIDGroupPairs_Grou
 				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
 					return hasReferences, err
 				}
-				ko.Spec.IngressRules[f0idx].UserIDGroupPairs[f1idx].GroupID = (*string)(obj.Status.ID)
+				ko.Spec.IngressRules[f0idx].UserIDGroupPairs[f1idx].GroupName = (*string)(obj.Spec.Name)
 			}
 		}
 	}
@@ -224,43 +202,13 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	if obj.Status.ID == nil {
+	if obj.Spec.Name == nil {
 		return ackerr.ResourceReferenceMissingTargetFieldFor(
 			"SecurityGroup",
 			namespace, name,
-			"Status.ID")
+			"Spec.Name")
 	}
 	return nil
-}
-
-// resolveReferenceForIngressRules_UserIDGroupPairs_GroupName reads the resource referenced
-// from IngressRules.UserIDGroupPairs.GroupRef field and sets the IngressRules.UserIDGroupPairs.GroupName
-// from referenced resource. Returns a boolean indicating whether a reference
-// contains references, or an error
-func (rm *resourceManager) resolveReferenceForIngressRules_UserIDGroupPairs_GroupName(
-	ctx context.Context,
-	apiReader client.Reader,
-	namespace string,
-	ko *svcapitypes.SecurityGroup,
-) (hasReferences bool, err error) {
-	for f0idx, f0iter := range ko.Spec.IngressRules {
-		for f1idx, f1iter := range f0iter.UserIDGroupPairs {
-			if f1iter.GroupRef != nil && f1iter.GroupRef.From != nil {
-				hasReferences = true
-				arr := f1iter.GroupRef.From
-				if arr.Name == nil || *arr.Name == "" {
-					return hasReferences, fmt.Errorf("provided resource reference is nil or empty: IngressRules.UserIDGroupPairs.GroupRef")
-				}
-				obj := &svcapitypes.SecurityGroup{}
-				if err := getReferencedResourceState_SecurityGroup(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
-					return hasReferences, err
-				}
-				ko.Spec.IngressRules[f0idx].UserIDGroupPairs[f1idx].GroupName = (*string)(obj.Spec.Name)
-			}
-		}
-	}
-
-	return hasReferences, nil
 }
 
 // resolveReferenceForIngressRules_UserIDGroupPairs_VPCID reads the resource referenced


### PR DESCRIPTION
Partial revert of https://github.com/aws-controllers-k8s/ec2-controller/commit/cd75ad971e604ba0e1f05a4e2f7838cd20baea79

Initially our intention was to generate code to reference for both `GroupName`
and `GroupID` fields in the `UserIDGroupPairs`. However what we (I) missed was
that the code-generator processes the references fields, omits "ID" and "Name"
name fields, and infers names for the referenced fields (e.g `GroupName` ->
`GroupRef` and `GroupID` -> `GroupRef`. This confused the ACK code
generator since both `GroupName` and `GroupID` needed a reference field called
`GroupRef`. This caused some confusion at the code generation level, triggering some
validation issues and introduced a regression in our references code.

In a attempt to address the regression, we will first omit one of the references
(GroupID), regenerate the code and address this in the code-generator later on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
