### PR TITLE
Refactor and uniform tags comparison/update logic

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2024-06-03T07:09:57Z"
+  build_date: "2024-06-04T06:39:17Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
   go_version: go1.22.3
   version: v0.34.0
@@ -7,7 +7,7 @@ api_directory_checksum: 7fd395ceb7d5d8e35906991c7348d3498f384741
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93
 generator_config_info:
-  file_checksum: b38071cec6cdb8156420ad489b68841fd9b30726
+  file_checksum: 50dfb186094519e9534c5774690536b3e2474428
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -241,11 +241,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/dhcp_options/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -277,11 +273,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -311,14 +303,10 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     list_operation:
       match_fields:
       - AllocationId
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
@@ -348,11 +336,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/flow_log/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -375,8 +359,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VPC:
         from:
           operation: AttachInternetGateway
@@ -395,8 +377,6 @@ resources:
           path: Status.internetGatewayID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/internet_gateway/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -436,16 +416,12 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     synced:
       when:
       - path: Status.State
         in:
         - available
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -479,8 +455,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -541,8 +515,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -573,8 +545,6 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -603,8 +573,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -632,8 +600,6 @@ resources:
           input_fields:
             NetworkAclId: Id    
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/network_acl/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -682,8 +648,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -693,8 +657,6 @@ resources:
         - InvalidParameterValue
         - InvalidCustomerOwnedIpv4PoolID.Malformed
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/subnet/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -711,8 +673,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       State:
         print:
           path: Status.state
@@ -722,8 +682,6 @@ resources:
           path: Status.transitGatewayID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -760,15 +718,11 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcID:
         print:
           path: Status.vpcID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -785,8 +739,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -816,8 +768,6 @@ resources:
         - InvalidVpcId.Malformed
         - InvalidServiceName
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -851,16 +801,12 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: true
     synced:
       when:
       - path: Status.ServiceState
         in:
         - available
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_delete_post_build_request:
         template_path: hooks/vpc_endpoint_service_configuration/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
@@ -893,11 +839,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_peering_connection/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -241,11 +241,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/dhcp_options/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -277,11 +273,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/instance/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -311,14 +303,10 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     list_operation:
       match_fields:
       - AllocationId
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/elastic_ip_address/sdk_create_post_build_request.go.tpl
       sdk_delete_post_build_request:
@@ -348,11 +336,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/flow_log/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -375,8 +359,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VPC:
         from:
           operation: AttachInternetGateway
@@ -395,8 +377,6 @@ resources:
           path: Status.internetGatewayID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/internet_gateway/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -436,16 +416,12 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     synced:
       when:
       - path: Status.State
         in:
         - available
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -479,8 +455,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -541,8 +515,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -573,8 +545,6 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -603,8 +573,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         is_required: true
         references:
@@ -632,8 +600,6 @@ resources:
           input_fields:
             NetworkAclId: Id    
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/network_acl/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -682,8 +648,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -693,8 +657,6 @@ resources:
         - InvalidParameterValue
         - InvalidCustomerOwnedIpv4PoolID.Malformed
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/subnet/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -711,8 +673,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       State:
         print:
           path: Status.state
@@ -722,8 +682,6 @@ resources:
           path: Status.transitGatewayID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -760,15 +718,11 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcID:
         print:
           path: Status.vpcID
           name: ID
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -785,8 +739,6 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
       VpcId:
         references:
           resource: VPC
@@ -816,8 +768,6 @@ resources:
         - InvalidVpcId.Malformed
         - InvalidServiceName
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_endpoint/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:
@@ -851,16 +801,12 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: true
     synced:
       when:
       - path: Status.ServiceState
         in:
         - available
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_delete_post_build_request:
         template_path: hooks/vpc_endpoint_service_configuration/sdk_delete_post_build_request.go.tpl
       sdk_file_end:
@@ -893,11 +839,7 @@ resources:
         from:
           operation: CreateTags
           path: Tags
-        compare:
-          is_ignored: True
     hooks:
-      delta_pre_compare:
-        code: compareTags(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc_peering_connection/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:

--- a/pkg/resource/dhcp_options/delta.go
+++ b/pkg/resource/dhcp_options/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if len(a.ko.Spec.DHCPConfigurations) != len(b.ko.Spec.DHCPConfigurations) {
 		delta.Add("Spec.DHCPConfigurations", a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations)
@@ -50,6 +49,9 @@ func newResourceDelta(
 		if !reflect.DeepEqual(a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations) {
 			delta.Add("Spec.DHCPConfigurations", a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if len(a.ko.Spec.VPC) != len(b.ko.Spec.VPC) {
 		delta.Add("Spec.VPC", a.ko.Spec.VPC, b.ko.Spec.VPC)

--- a/pkg/resource/dhcp_options/hooks.go
+++ b/pkg/resource/dhcp_options/hooks.go
@@ -16,11 +16,12 @@ package dhcp_options
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/samber/lo"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateDHCPOptions(
@@ -51,7 +52,10 @@ func (rm *resourceManager) customUpdateDHCPOptions(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.DHCPOptionsID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -123,122 +127,6 @@ func (rm *resourceManager) getAttachedVPC(
 	}
 
 	return vpcID, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.DHCPOptionsID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from DHCPOptions resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to DHCPOptions resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/elastic_ip_address/delta.go
+++ b/pkg/resource/elastic_ip_address/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Address, b.ko.Spec.Address) {
 		delta.Add("Spec.Address", a.ko.Spec.Address, b.ko.Spec.Address)
@@ -71,6 +70,9 @@ func newResourceDelta(
 		if *a.ko.Spec.PublicIPv4Pool != *b.ko.Spec.PublicIPv4Pool {
 			delta.Add("Spec.PublicIPv4Pool", a.ko.Spec.PublicIPv4Pool, b.ko.Spec.PublicIPv4Pool)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/elastic_ip_address/hooks.go
+++ b/pkg/resource/elastic_ip_address/hooks.go
@@ -16,10 +16,11 @@ package elastic_ip_address
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateElasticIP(
@@ -40,128 +41,15 @@ func (rm *resourceManager) customUpdateElasticIP(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.AllocationID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.AllocationID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from elasticip resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to elasticip resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/flow_log/delta.go
+++ b/pkg/resource/flow_log/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DeliverLogsPermissionARN, b.ko.Spec.DeliverLogsPermissionARN) {
 		delta.Add("Spec.DeliverLogsPermissionARN", a.ko.Spec.DeliverLogsPermissionARN, b.ko.Spec.DeliverLogsPermissionARN)
@@ -124,6 +123,9 @@ func newResourceDelta(
 		if *a.ko.Spec.ResourceType != *b.ko.Spec.ResourceType {
 			delta.Add("Spec.ResourceType", a.ko.Spec.ResourceType, b.ko.Spec.ResourceType)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TrafficType, b.ko.Spec.TrafficType) {
 		delta.Add("Spec.TrafficType", a.ko.Spec.TrafficType, b.ko.Spec.TrafficType)

--- a/pkg/resource/flow_log/hooks.go
+++ b/pkg/resource/flow_log/hooks.go
@@ -16,10 +16,11 @@ package flow_log
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateFlowLog(
@@ -40,128 +41,15 @@ func (rm *resourceManager) customUpdateFlowLog(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.FlowLogID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.FlowLogID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from FlowLog resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to FlowLog resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/instance/delta.go
+++ b/pkg/resource/instance/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if len(a.ko.Spec.BlockDeviceMappings) != len(b.ko.Spec.BlockDeviceMappings) {
 		delta.Add("Spec.BlockDeviceMappings", a.ko.Spec.BlockDeviceMappings, b.ko.Spec.BlockDeviceMappings)
@@ -516,6 +515,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SubnetID != *b.ko.Spec.SubnetID {
 			delta.Add("Spec.SubnetID", a.ko.Spec.SubnetID, b.ko.Spec.SubnetID)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.UserData, b.ko.Spec.UserData) {
 		delta.Add("Spec.UserData", a.ko.Spec.UserData, b.ko.Spec.UserData)

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -17,10 +17,11 @@ import (
 	"context"
 	"errors"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 // addInstanceIDsToTerminateRequest populates the list of InstanceIDs
@@ -53,7 +54,10 @@ func (rm *resourceManager) customUpdateInstance(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.InstanceID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -61,121 +65,7 @@ func (rm *resourceManager) customUpdateInstance(
 	return updated, nil
 }
 
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.InstanceID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from Instance resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to Instance resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
-}
+var computeTagsDelta = tags.ComputeTagsDelta
 
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to RunInstancesInput.TagSpecification

--- a/pkg/resource/internet_gateway/delta.go
+++ b/pkg/resource/internet_gateway/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if !reflect.DeepEqual(a.ko.Spec.RouteTableRefs, b.ko.Spec.RouteTableRefs) {
 		delta.Add("Spec.RouteTableRefs", a.ko.Spec.RouteTableRefs, b.ko.Spec.RouteTableRefs)
@@ -53,6 +52,9 @@ func newResourceDelta(
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.RouteTables, b.ko.Spec.RouteTables) {
 			delta.Add("Spec.RouteTables", a.ko.Spec.RouteTables, b.ko.Spec.RouteTables)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPC, b.ko.Spec.VPC) {
 		delta.Add("Spec.VPC", a.ko.Spec.VPC, b.ko.Spec.VPC)

--- a/pkg/resource/internet_gateway/hooks.go
+++ b/pkg/resource/internet_gateway/hooks.go
@@ -16,11 +16,12 @@ package internet_gateway
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	ackutils "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateInternetGateway(
@@ -62,7 +63,10 @@ func (rm *resourceManager) customUpdateInternetGateway(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err = rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.InternetGatewayID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -147,122 +151,6 @@ func (rm *resourceManager) detachFromVPC(
 	}
 
 	return nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete Tags API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.InternetGatewayID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from InternetGateway resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to InternetGateway resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/nat_gateway/delta.go
+++ b/pkg/resource/nat_gateway/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AllocationID, b.ko.Spec.AllocationID) {
 		delta.Add("Spec.AllocationID", a.ko.Spec.AllocationID, b.ko.Spec.AllocationID)
@@ -70,6 +69,9 @@ func newResourceDelta(
 	}
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef) {
 		delta.Add("Spec.SubnetRef", a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef)
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/nat_gateway/hooks.go
+++ b/pkg/resource/nat_gateway/hooks.go
@@ -16,10 +16,11 @@ package nat_gateway
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateNATGateway(
@@ -40,128 +41,15 @@ func (rm *resourceManager) customUpdateNATGateway(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.NATGatewayID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.NATGatewayID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from NATGateway resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to NATGateway resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/network_acl/delta.go
+++ b/pkg/resource/network_acl/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if len(a.ko.Spec.Associations) != len(b.ko.Spec.Associations) {
 		delta.Add("Spec.Associations", a.ko.Spec.Associations, b.ko.Spec.Associations)
@@ -57,6 +56,9 @@ func newResourceDelta(
 		if !reflect.DeepEqual(a.ko.Spec.Entries, b.ko.Spec.Entries) {
 			delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)

--- a/pkg/resource/network_acl/hooks.go
+++ b/pkg/resource/network_acl/hooks.go
@@ -18,100 +18,18 @@ import (
 	"errors"
 	"strconv"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/samber/lo"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 var DefaultRuleNumber = 32767
 var TypeSubnet = "SubnetID"
 var TypeNaclAssocId = "NetworkACLAssociationID"
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.ID}
-
-	desiredTags := ToACKTags(desired.ko.Spec.Tags)
-	latestTags := ToACKTags(latest.ko.Spec.Tags)
-
-	added, _, removed := ackcompare.GetTagsDifference(latestTags, desiredTags)
-
-	toAdd := FromACKTags(added)
-	toDelete := FromACKTags(removed)
-
-	if len(toDelete) > 0 {
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// // sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
-}
 
 func (rm *resourceManager) customUpdateNetworkAcl(
 	ctx context.Context,
@@ -137,7 +55,10 @@ func (rm *resourceManager) customUpdateNetworkAcl(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.ID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -614,40 +535,6 @@ func (rm *resourceManager) deleteEntry(
 	_, err = rm.sdkapi.DeleteNetworkAclEntryWithContext(ctx, res)
 	rm.metrics.RecordAPICall("UPDATE", "DeleteNetworkAclEntry", err)
 	return err
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/route_table/delta.go
+++ b/pkg/resource/route_table/delta.go
@@ -51,6 +51,9 @@ func newResourceDelta(
 			delta.Add("Spec.Routes", a.ko.Spec.Routes, b.ko.Spec.Routes)
 		}
 	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)
 	} else if a.ko.Spec.VPCID != nil && b.ko.Spec.VPCID != nil {

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
@@ -220,7 +221,10 @@ func (rm *resourceManager) customUpdateRouteTable(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.RouteTableID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -252,22 +256,7 @@ func (rm *resourceManager) addRoutesToStatus(
 	}
 }
 
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
-}
+var computeTagsDelta = tags.ComputeTagsDelta
 
 // customPreCompare ensures that default values of types are initialised and
 // server side defaults are excluded from the delta.
@@ -278,7 +267,6 @@ func customPreCompare(
 ) {
 	a.ko.Spec.Routes = removeLocalRoute(a.ko.Spec.Routes)
 	b.ko.Spec.Routes = removeLocalRoute(b.ko.Spec.Routes)
-	compareTags(delta, a, b)
 }
 
 // removeLocalRoute will filter out any routes that have a gateway ID that
@@ -344,105 +332,6 @@ func (rm *resourceManager) excludeAwsRoute(
 	ret = append(ret, filtered_routes...)
 
 	return ret
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete Tags API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.RouteTableID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from route table resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to route table resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
@@ -71,6 +70,9 @@ func newResourceDelta(
 		if *a.ko.Spec.Name != *b.ko.Spec.Name {
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -16,12 +16,13 @@ package security_group
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
-
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	awserr "github.com/aws/aws-sdk-go/aws/awserr"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 // addRulesToSpec updates a resource's Spec EgressRules and IngressRules
@@ -155,105 +156,6 @@ func (rm *resourceManager) syncSGRules(
 	}
 
 	return nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete Tags API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.ID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from security group resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to security group resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
 }
 
 // updateTagSpecificationsInCreateRequest adds
@@ -469,29 +371,15 @@ func (rm *resourceManager) customUpdateSecurityGroup(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.ID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // containsRule returns true if security group rule

--- a/pkg/resource/subnet/delta.go
+++ b/pkg/resource/subnet/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AssignIPv6AddressOnCreation, b.ko.Spec.AssignIPv6AddressOnCreation) {
 		delta.Add("Spec.AssignIPv6AddressOnCreation", a.ko.Spec.AssignIPv6AddressOnCreation, b.ko.Spec.AssignIPv6AddressOnCreation)
@@ -144,6 +143,9 @@ func newResourceDelta(
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.RouteTables, b.ko.Spec.RouteTables) {
 			delta.Add("Spec.RouteTables", a.ko.Spec.RouteTables, b.ko.Spec.RouteTables)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)

--- a/pkg/resource/subnet/hooks.go
+++ b/pkg/resource/subnet/hooks.go
@@ -16,11 +16,12 @@ package subnet
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	ackutils "github.com/aws-controllers-k8s/runtime/pkg/util"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateSubnet(
@@ -49,7 +50,10 @@ func (rm *resourceManager) customUpdateSubnet(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err = rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.SubnetID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -370,122 +374,6 @@ func inAssociations(
 
 func toStrPtr(str string) *string {
 	return &str
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete Tags API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.SubnetID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from subnet resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to subnet resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/transit_gateway/delta.go
+++ b/pkg/resource/transit_gateway/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
@@ -110,6 +109,9 @@ func newResourceDelta(
 				delta.Add("Spec.Options.VPNECMPSupport", a.ko.Spec.Options.VPNECMPSupport, b.ko.Spec.Options.VPNECMPSupport)
 			}
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/transit_gateway/hooks.go
+++ b/pkg/resource/transit_gateway/hooks.go
@@ -16,10 +16,11 @@ package transit_gateway
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 func (rm *resourceManager) customUpdateTransitGateway(
@@ -40,128 +41,15 @@ func (rm *resourceManager) customUpdateTransitGateway(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.TransitGatewayID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.TransitGatewayID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from TransitGateway resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to TransitGateway resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/vpc/delta.go
+++ b/pkg/resource/vpc/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AmazonProvidedIPv6CIDRBlock, b.ko.Spec.AmazonProvidedIPv6CIDRBlock) {
 		delta.Add("Spec.AmazonProvidedIPv6CIDRBlock", a.ko.Spec.AmazonProvidedIPv6CIDRBlock, b.ko.Spec.AmazonProvidedIPv6CIDRBlock)
@@ -127,6 +126,9 @@ func newResourceDelta(
 		if *a.ko.Spec.IPv6Pool != *b.ko.Spec.IPv6Pool {
 			delta.Add("Spec.IPv6Pool", a.ko.Spec.IPv6Pool, b.ko.Spec.IPv6Pool)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -16,10 +16,12 @@ package vpc
 import (
 	"context"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 type DNSAttrs struct {
@@ -304,7 +306,10 @@ func (rm *resourceManager) customUpdateVPC(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.VPCID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
@@ -319,122 +324,6 @@ func applyPrimaryCIDRBlockInCreateRequest(r *resource,
 	input *svcsdk.CreateVpcInput) {
 	if len(r.ko.Spec.CIDRBlocks) > 0 {
 		input.CidrBlock = r.ko.Spec.CIDRBlocks[0]
-	}
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.VPCID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from vpc resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to vpc resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
 	}
 }
 

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DNSOptions, b.ko.Spec.DNSOptions) {
 		delta.Add("Spec.DNSOptions", a.ko.Spec.DNSOptions, b.ko.Spec.DNSOptions)
@@ -112,6 +111,9 @@ func newResourceDelta(
 	}
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs) {
 		delta.Add("Spec.SubnetRefs", a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs)
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCEndpointType, b.ko.Spec.VPCEndpointType) {
 		delta.Add("Spec.VPCEndpointType", a.ko.Spec.VPCEndpointType, b.ko.Spec.VPCEndpointType)

--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"errors"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -72,128 +72,15 @@ func (rm *resourceManager) customUpdateVPCEndpoint(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
+		if err := tags.Sync(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.VPCEndpointID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
 			return nil, err
 		}
 	}
 
 	return updated, nil
-}
-
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.VPCEndpointID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from VPCEndpoint resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to VPCEndpoint resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
 }
 
 // updateTagSpecificationsInCreateRequest adds

--- a/pkg/resource/vpc_endpoint_service_configuration/delta.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AcceptanceRequired, b.ko.Spec.AcceptanceRequired) {
 		delta.Add("Spec.AcceptanceRequired", a.ko.Spec.AcceptanceRequired, b.ko.Spec.AcceptanceRequired)
@@ -85,6 +84,9 @@ func newResourceDelta(
 		if !ackcompare.SliceStringPEqual(a.ko.Spec.SupportedIPAddressTypes, b.ko.Spec.SupportedIPAddressTypes) {
 			delta.Add("Spec.SupportedIPAddressTypes", a.ko.Spec.SupportedIPAddressTypes, b.ko.Spec.SupportedIPAddressTypes)
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
 	return delta

--- a/pkg/resource/vpc_endpoint_service_configuration/hooks.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/hooks.go
@@ -19,14 +19,14 @@ import (
 	"fmt"
 	"time"
 
-	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
-	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	ackutil "github.com/aws-controllers-k8s/runtime/pkg/util"
-
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
 var (
@@ -157,118 +157,4 @@ func (rm *resourceManager) setAdditionalFields(
 	return &resource{ko}, nil
 }
 
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.ServiceID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from VPCEndpoint resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to VPCEndpoint resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
-}
+var syncTags = tags.Sync

--- a/pkg/resource/vpc_endpoint_service_configuration/sdk.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/sdk.go
@@ -493,10 +493,11 @@ func (rm *resourceManager) sdkUpdate(
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
-			// This causes a requeue and the rest of the fields will be synced on the next reconciliation loop
-			ackcondition.SetSynced(desired, corev1.ConditionFalse, nil, nil)
-			return desired, err
+		if err := syncTags(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.ServiceID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/resource/vpc_peering_connection/delta.go
+++ b/pkg/resource/vpc_peering_connection/delta.go
@@ -42,7 +42,6 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	compareTags(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.AcceptRequest, b.ko.Spec.AcceptRequest) {
 		delta.Add("Spec.AcceptRequest", a.ko.Spec.AcceptRequest, b.ko.Spec.AcceptRequest)
@@ -124,6 +123,9 @@ func newResourceDelta(
 				delta.Add("Spec.RequesterPeeringConnectionOptions.AllowEgressFromLocalVPCToRemoteClassicLink", a.ko.Spec.RequesterPeeringConnectionOptions.AllowEgressFromLocalVPCToRemoteClassicLink, b.ko.Spec.RequesterPeeringConnectionOptions.AllowEgressFromLocalVPCToRemoteClassicLink)
 			}
 		}
+	}
+	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {
 		delta.Add("Spec.VPCID", a.ko.Spec.VPCID, b.ko.Spec.VPCID)

--- a/pkg/resource/vpc_peering_connection/hooks.go
+++ b/pkg/resource/vpc_peering_connection/hooks.go
@@ -14,14 +14,12 @@
 package vpc_peering_connection
 
 import (
-	"context"
 	"fmt"
 	"time"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
-	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
-	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
 )
 
@@ -95,122 +93,6 @@ func isVPCPeeringConnectionPendingAcceptance(r *resource) bool {
 	return status == string(svcapitypes.VPCPeeringConnectionStateReasonCode_pending_acceptance)
 }
 
-// syncTags used to keep tags in sync by calling Create and Delete API's
-func (rm *resourceManager) syncTags(
-	ctx context.Context,
-	desired *resource,
-	latest *resource,
-) (err error) {
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.syncTags")
-	defer func(err error) {
-		exit(err)
-	}(err)
-
-	resourceId := []*string{latest.ko.Status.VPCPeeringConnectionID}
-
-	toAdd, toDelete := computeTagsDelta(
-		desired.ko.Spec.Tags, latest.ko.Spec.Tags,
-	)
-
-	if len(toDelete) > 0 {
-		rlog.Debug("removing tags from vpc peering connection resource", "tags", toDelete)
-		_, err = rm.sdkapi.DeleteTagsWithContext(
-			ctx,
-			&svcsdk.DeleteTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toDelete),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "DeleteTags", err)
-		if err != nil {
-			return err
-		}
-
-	}
-
-	if len(toAdd) > 0 {
-		rlog.Debug("adding tags to vpc peering connection resource", "tags", toAdd)
-		_, err = rm.sdkapi.CreateTagsWithContext(
-			ctx,
-			&svcsdk.CreateTagsInput{
-				Resources: resourceId,
-				Tags:      rm.sdkTags(toAdd),
-			},
-		)
-		rm.metrics.RecordAPICall("UPDATE", "CreateTags", err)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// sdkTags converts *svcapitypes.Tag array to a *svcsdk.Tag array
-func (rm *resourceManager) sdkTags(
-	tags []*svcapitypes.Tag,
-) (sdktags []*svcsdk.Tag) {
-
-	for _, i := range tags {
-		sdktag := rm.newTag(*i)
-		sdktags = append(sdktags, sdktag)
-	}
-
-	return sdktags
-}
-
-// computeTagsDelta returns tags to be added and removed from the resource
-func computeTagsDelta(
-	desired []*svcapitypes.Tag,
-	latest []*svcapitypes.Tag,
-) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
-
-	desiredTags := map[string]string{}
-	for _, tag := range desired {
-		desiredTags[*tag.Key] = *tag.Value
-	}
-
-	latestTags := map[string]string{}
-	for _, tag := range latest {
-		latestTags[*tag.Key] = *tag.Value
-	}
-
-	for _, tag := range desired {
-		val, ok := latestTags[*tag.Key]
-		if !ok || val != *tag.Value {
-			toAdd = append(toAdd, tag)
-		}
-	}
-
-	for _, tag := range latest {
-		_, ok := desiredTags[*tag.Key]
-		if !ok {
-			toDelete = append(toDelete, tag)
-		}
-	}
-
-	return toAdd, toDelete
-
-}
-
-// compareTags is a custom comparison function for comparing lists of Tag
-// structs where the order of the structs in the list is not important.
-func compareTags(
-	delta *ackcompare.Delta,
-	a *resource,
-	b *resource,
-) {
-	if len(a.ko.Spec.Tags) != len(b.ko.Spec.Tags) {
-		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-	} else if len(a.ko.Spec.Tags) > 0 {
-		addedOrUpdated, removed := computeTagsDelta(a.ko.Spec.Tags, b.ko.Spec.Tags)
-		if len(addedOrUpdated) != 0 || len(removed) != 0 {
-			delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
-		}
-	}
-}
-
 // updateTagSpecificationsInCreateRequest adds
 // Tags defined in the Spec to CreateVpcPeeringConnectionInput.TagSpecification
 // and ensures the ResourceType is always set to 'vpc-peering-connection'
@@ -234,3 +116,5 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		input.TagSpecifications = []*svcsdk.TagSpecification{&desiredTagSpecs}
 	}
 }
+
+var syncTags = tags.Sync

--- a/pkg/resource/vpc_peering_connection/sdk.go
+++ b/pkg/resource/vpc_peering_connection/sdk.go
@@ -542,10 +542,11 @@ func (rm *resourceManager) sdkUpdate(
 	// If the VPC Peering Connection is Pending Acceptance or Active, continue
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
-			// This causes a requeue and the rest of the fields will be synced on the next reconciliation loop
-			ackcondition.SetSynced(desired, corev1.ConditionFalse, nil, nil)
-			return desired, err
+		if err := syncTags(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.VPCPeeringConnectionID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/tags/sync.go
+++ b/pkg/tags/sync.go
@@ -1,0 +1,153 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package tags
+
+import (
+	"context"
+
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	svcsdk "github.com/aws/aws-sdk-go/service/ec2"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+)
+
+// TODO(a-hilaly) most of the utility in this package should ideally go to
+// ack runtime repository.
+
+type metricsRecorder interface {
+	RecordAPICall(opType string, opID string, err error)
+}
+
+type tagsClient interface {
+	CreateTagsWithContext(context.Context, *svcsdk.CreateTagsInput, ...request.Option) (*svcsdk.CreateTagsOutput, error)
+	DescribeTagsWithContext(context.Context, *svcsdk.DescribeTagsInput, ...request.Option) (*svcsdk.DescribeTagsOutput, error)
+	DeleteTagsWithContext(context.Context, *svcsdk.DeleteTagsInput, ...request.Option) (*svcsdk.DeleteTagsOutput, error)
+}
+
+// Sync is responsible of taking two arrays of tags (desired and latest), comparing
+// them, then making the appropriate APIs calls to up change the latest state into
+// the desired state.
+func Sync(
+	ctx context.Context,
+	client tagsClient,
+	mr metricsRecorder,
+	resourceID string,
+	latestTags []*svcapitypes.Tag,
+	desiredTags []*svcapitypes.Tag,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("common.Sync")
+	defer func() { exit(err) }()
+
+	addedOrUpdated, removed := ComputeTagsDelta(latestTags, desiredTags)
+
+	if len(removed) > 0 {
+		_, err = client.DeleteTagsWithContext(
+			ctx,
+			&svcsdk.DeleteTagsInput{
+				Resources: []*string{aws.String(resourceID)},
+				Tags:      sdkTagsFromResourceTags(removed),
+			},
+		)
+		mr.RecordAPICall("UPDATE", "DeleteTags", err)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(addedOrUpdated) > 0 {
+		_, err = client.CreateTagsWithContext(
+			ctx,
+			&svcsdk.CreateTagsInput{
+				Resources: []*string{aws.String(resourceID)},
+				Tags:      sdkTagsFromResourceTags(addedOrUpdated),
+			},
+		)
+		mr.RecordAPICall("UPDATE", "CreateTags", err)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// computeTagsDelta compares two Tag arrays and return two different list
+// containing the addedOrupdated and removed tags. The removed tags array
+// only contains the tags Keys.
+func ComputeTagsDelta(
+	desired []*svcapitypes.Tag,
+	latest []*svcapitypes.Tag,
+) (toAdd []*svcapitypes.Tag, toDelete []*svcapitypes.Tag) {
+	desiredTags := map[string]string{}
+	for _, tag := range desired {
+		desiredTags[safeString(tag.Key)] = safeString(tag.Value)
+	}
+
+	latestTags := map[string]string{}
+	for _, tag := range latest {
+		latestTags[safeString(tag.Key)] = safeString(tag.Value)
+	}
+
+	for _, tag := range desired {
+		val, ok := latestTags[safeString(tag.Key)]
+		if !ok || val != safeString(tag.Value) {
+			toAdd = append(toAdd, tag)
+		}
+	}
+
+	for _, tag := range latest {
+		_, ok := desiredTags[safeString(tag.Key)]
+		if !ok {
+			toDelete = append(toDelete, tag)
+		}
+	}
+
+	return toAdd, toDelete
+}
+
+// svcTagsFromResourceTags transforms a *svcapitypes.Tag array to a *svcsdk.Tag array.
+func sdkTagsFromResourceTags(rTags []*svcapitypes.Tag) []*svcsdk.Tag {
+	tags := make([]*svcsdk.Tag, len(rTags))
+	for i := range rTags {
+		if rTags[i] != nil {
+			tags[i] = &svcsdk.Tag{
+				Key:   rTags[i].Key,
+				Value: rTags[i].Value,
+			}
+		}
+	}
+	return tags
+}
+
+func equalStrings(a, b *string) bool {
+	if a == nil {
+		return b == nil || *b == ""
+	}
+
+	if a != nil && b == nil {
+		return false
+	}
+
+	return (*a == "" && b == nil) || *a == *b
+}
+
+func safeString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}

--- a/templates/hooks/vpc_endpoint_service_configuration/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/vpc_endpoint_service_configuration/sdk_update_pre_build_request.go.tpl
@@ -5,10 +5,11 @@
 	}
 
 	if delta.DifferentAt("Spec.Tags") {
-		if err := rm.syncTags(ctx, desired, latest); err != nil {
-			// This causes a requeue and the rest of the fields will be synced on the next reconciliation loop
-			ackcondition.SetSynced(desired, corev1.ConditionFalse, nil, nil)
-			return desired, err
+		if err := syncTags(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.ServiceID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
+			return nil, err
 		}
 	}
 

--- a/templates/hooks/vpc_peering_connection/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/vpc_peering_connection/sdk_update_pre_build_request.go.tpl
@@ -11,12 +11,13 @@
 	// If the VPC Peering Connection is Pending Acceptance or Active, continue
 
 	if delta.DifferentAt("Spec.Tags") {
-			if err := rm.syncTags(ctx, desired, latest); err != nil {
-				// This causes a requeue and the rest of the fields will be synced on the next reconciliation loop
-				ackcondition.SetSynced(desired, corev1.ConditionFalse, nil, nil)
-				return desired, err
-			}
+		if err := syncTags(
+			ctx, rm.sdkapi, rm.metrics, *latest.ko.Status.VPCPeeringConnectionID,
+			desired.ko.Spec.Tags, latest.ko.Spec.Tags,
+		); err != nil {
+			return nil, err
 		}
+	}
 
 	if delta.DifferentAt("Spec.AcceptRequest") {
 		// Throw a Terminal Error, if the field was set to 'true' and is now set to 'false'


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2063

During the early days of ACK, the ec2 controller didn't have a lot of CRDs and most of the work around tag handling was some sort of copy/pasta from resource to resource. Time passed and now ec2-controller has 15 resources each with a slightly different tags handling implementations - making it very hard for us to maintain and bug fix if something goes wrong.

This patch does a few things to simplify the life of an ACK developer:
- Moves a lot of the tags handling logic into a single, simple and maintainable package (`pkg/tags`).
- Rely back on generated tags delta computation (back then this wasn't supported)
- Add type safety around the algorithm that was used to compare two array slices.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
