### PR TITLE
fix: only force syncing a VPC endpoint when in pending state

### DIFF
--- a/pkg/resource/vpc_endpoint/hooks.go
+++ b/pkg/resource/vpc_endpoint/hooks.go
@@ -35,12 +35,12 @@ const (
 	StatusFailed            = "failed"
 )
 
-func vpcEndpointAvailable(r *resource) bool {
+func vpcEndpointPending(r *resource) bool {
 	if r.ko.Status.State == nil {
 		return false
 	}
 	cs := *r.ko.Status.State
-	return cs == StatusAvailable
+	return cs == StatusPending
 }
 
 // addIDToDeleteRequest adds resource's Vpc Endpoint ID to DeleteRequest.

--- a/pkg/resource/vpc_endpoint/sdk.go
+++ b/pkg/resource/vpc_endpoint/sdk.go
@@ -254,7 +254,7 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 
-	if !vpcEndpointAvailable(&resource{ko}) {
+	if vpcEndpointPending(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)

--- a/pkg/resource/vpc_endpoint/sdk.go
+++ b/pkg/resource/vpc_endpoint/sdk.go
@@ -258,8 +258,6 @@ func (rm *resourceManager) sdkFind(
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-	} else {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}
 
 	return &resource{ko}, nil

--- a/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
@@ -3,6 +3,4 @@
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)
-	} else {
-		ackcondition.SetSynced(&resource{ko}, corev1.ConditionTrue, nil, nil)
 	}

--- a/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/vpc_endpoint/sdk_read_many_post_set_output.go.tpl
@@ -1,5 +1,5 @@
 
-	if !vpcEndpointAvailable(&resource{ko}) {
+	if vpcEndpointPending(&resource{ko}) {
 		// Setting resource synced condition to false will trigger a requeue of
 		// the resource. No need to return a requeue error here.
 		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, nil, nil)


### PR DESCRIPTION
Context: https://github.com/aws-controllers-k8s/ec2-controller/pull/191#discussion_r1627514799

A synced VPC endpoint should only be forced to re-sync when it's in `pending` state. For other states like `pendingAcceptance`, `rejected`, `failed`, `expired`, it could be the final state of the endpoint and the sync should be considered completed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
