### PR TITLE
Enhance `RouteTable` CRD sync routes synchronisation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2024-06-04T06:39:17Z"
+  build_date: "2024-06-19T06:55:08Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
-  go_version: go1.22.3
+  go_version: go1.22.4
   version: v0.34.0
 api_directory_checksum: 7fd395ceb7d5d8e35906991c7348d3498f384741
 api_version: v1alpha1

--- a/pkg/resource/route_table/sdk.go
+++ b/pkg/resource/route_table/sdk.go
@@ -234,7 +234,6 @@ func (rm *resourceManager) sdkFind(
 		// then assign resource's tags to maintain tag order
 		ko.Spec.Tags = r.ko.Spec.Tags
 	}
-
 	return &resource{ko}, nil
 }
 
@@ -432,7 +431,8 @@ func (rm *resourceManager) sdkCreate(
 	if len(desired.ko.Spec.Routes) > 0 {
 		//desired routes are overwritten by RouteTable's default route
 		ko.Spec.Routes = append(ko.Spec.Routes, desired.ko.Spec.Routes...)
-		if err := rm.createRoutes(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createRoutes(ctx, &resource{copy}); err != nil {
 			return nil, err
 		}
 	}
@@ -443,6 +443,7 @@ func (rm *resourceManager) sdkCreate(
 		// then assign desired tags to maintain tag order
 		ko.Spec.Tags = desired.ko.Spec.Tags
 	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/route_table/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/route_table/sdk_create_post_set_output.go.tpl
@@ -7,7 +7,8 @@
 	if len(desired.ko.Spec.Routes) > 0 {
 		//desired routes are overwritten by RouteTable's default route
 		ko.Spec.Routes = append(ko.Spec.Routes, desired.ko.Spec.Routes...)
-		if err := rm.createRoutes(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createRoutes(ctx, &resource{copy}); err != nil {
 			return nil, err
 		}
 	}

--- a/templates/hooks/route_table/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/route_table/sdk_read_many_post_set_output.go.tpl
@@ -8,4 +8,3 @@
 		// then assign resource's tags to maintain tag order
 		ko.Spec.Tags = r.ko.Spec.Tags
 	}
-    


### PR DESCRIPTION
- Update `syncRoutes` method to handle errors from `excludeAWSRoute`
- Reorder route deletion and addition in `syncRoutes` for proper sync
- Modify `excludeAWSRoute` to return an error and rename variables for clarity
- Move tags sync before routes sync in `customUpdateRouteTable`
- Update `sdkCreate` to use a copy of the RouteTable for creating routes
- Minor formatting and comment updates in template files

The changes in this commit enhance the synchronization of routes for the
RouteTable Custom Resource Definition (CRD). The `syncRoutes` method now handles
errors returned from the `excludeAWSRoute` function and reorders the deletion
and addition of routes for proper synchronization. The `excludeAWSRoute`
function is modified to return an error and has some variable renaming for
better clarity...

In the `customUpdateRouteTable` method the tags synchronization is moved before
the routes synchronization to ensure tagss are updated before route changes.

The `sdkCreate` method now uses a deep copy of the RouteTable when creating
routes to avoid modifying the original desired state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
