### PR TITLE
fix(networkacl): Correct update order and entries/associations handlers

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2024-06-04T06:39:17Z"
+  build_date: "2024-06-19T08:11:53Z"
   build_hash: 14cef51778d471698018b6c38b604181a6948248
-  go_version: go1.22.3
+  go_version: go1.22.4
   version: v0.34.0
 api_directory_checksum: 7fd395ceb7d5d8e35906991c7348d3498f384741
 api_version: v1alpha1

--- a/pkg/resource/network_acl/sdk.go
+++ b/pkg/resource/network_acl/sdk.go
@@ -363,7 +363,8 @@ func (rm *resourceManager) sdkCreate(
 
 	if len(desired.ko.Spec.Associations) > 0 {
 		ko.Spec.Associations = desired.ko.Spec.Associations
-		if err := rm.createAssociation(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createAssociation(ctx, &resource{copy}); err != nil {
 			rlog.Debug("Error while syncing Association", err)
 		}
 	}
@@ -371,7 +372,8 @@ func (rm *resourceManager) sdkCreate(
 	if len(desired.ko.Spec.Entries) > 0 {
 		//desired rules are overwritten by NetworkACL's default rules
 		ko.Spec.Entries = append(ko.Spec.Entries, desired.ko.Spec.Entries...)
-		if err := rm.createEntries(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createEntries(ctx, &resource{copy}); err != nil {
 			rlog.Debug("Error while syncing routes", err)
 		}
 	}

--- a/templates/hooks/network_acl/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/network_acl/sdk_create_post_set_output.go.tpl
@@ -4,7 +4,8 @@
 
 	if len(desired.ko.Spec.Associations) > 0 {
 		ko.Spec.Associations = desired.ko.Spec.Associations
-		if err := rm.createAssociation(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createAssociation(ctx, &resource{copy}); err != nil {
 			rlog.Debug("Error while syncing Association", err)
 		}
 	}
@@ -12,7 +13,8 @@
 	if len(desired.ko.Spec.Entries) > 0 {
 		//desired rules are overwritten by NetworkACL's default rules
 		ko.Spec.Entries = append(ko.Spec.Entries, desired.ko.Spec.Entries...)
-		if err := rm.createEntries(ctx, &resource{ko}); err != nil {
+		copy := ko.DeepCopy()
+		if err := rm.createEntries(ctx, &resource{copy}); err != nil {
 			rlog.Debug("Error while syncing routes", err)
 		}
 	}


### PR DESCRIPTION
The custom update logic for `NetworkACL` resources was syncing the `Entries` before
the `Tags`. This could lead to issues if the `Entries` sync failed as the Tags
would not be updated..

This change also updates the order to sync `Tags` before `Entries`. It also uses
`DeepCopy` when passing the resource to `createAssociation` and `createEntries
to avoid modifying the original desired state.

Additionally, the exit functions in `hooks.go` were fixed to properly
handle the error return value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
