### PR TITLE
Avoid SG rules reordering by returning a copy of desired resource when custom update triggers a requeue

### DIFF
--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -382,9 +382,9 @@ func (rm *resourceManager) customUpdateSecurityGroup(
 	updated = rm.concreteResource(desired.DeepCopy())
 
 	if delta.DifferentAt("Spec.IngressRules") || delta.DifferentAt("Spec.EgressRules") {
-		if !rm.referencesResolved(desired) {
-			ackcondition.SetSynced(latest, corev1.ConditionFalse, nil, nil)
-			return latest, nil
+		if !rm.referencesResolved(updated) {
+			ackcondition.SetSynced(updated, corev1.ConditionFalse, nil, nil)
+			return updated, nil
 		}
 
 		if err := rm.syncSGRules(ctx, desired, latest); err != nil {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
