### PR TITLE
Add tests to ensure resource reference is not replaced by controller

### DIFF
--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -236,7 +236,9 @@ func (rm *resourceManager) customUpdateRouteTable(
 		}
 	}
 
-	return updated, nil
+	newDesired := rm.concreteResource(desired.DeepCopy())
+	newDesired.ko.Status = updated.ko.Status
+	return newDesired, nil
 }
 
 func (rm *resourceManager) requiredFieldsMissingForCreateRoute(

--- a/test/e2e/resources/internet_gateway_ref.yaml
+++ b/test/e2e/resources/internet_gateway_ref.yaml
@@ -1,0 +1,8 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: InternetGateway
+metadata:
+  name: $INTERNET_GATEWAY_NAME
+spec:
+  vpcRef:
+    from:
+      name: $VPC_NAME

--- a/test/e2e/resources/route_table_ref.yaml
+++ b/test/e2e/resources/route_table_ref.yaml
@@ -1,0 +1,16 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: RouteTable
+metadata:
+  name: $ROUTE_TABLE_NAME
+spec:
+  routes:
+    - destinationCIDRBlock: $DEST_CIDR_BLOCK
+      gatewayRef:
+        from:
+          name: $INTERNET_GATEWAY_NAME
+  vpcRef:
+    from:
+      name: $VPC_NAME
+  tags:
+    - key: $TAG_KEY
+      value: $TAG_VALUE


### PR DESCRIPTION
Issue [#1880](https://github.com/aws-controllers-k8s/community/issues/1880)

Description of changes:
These tests ensure that after an update, 
the controller won't replace the resource 
reference with the ID itself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
