### PR TITLE
Fix VPC optional DNS attribute handling

### DIFF
--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -310,14 +310,18 @@ func (rm *resourceManager) customUpdateVPC(
 	}
 
 	if delta.DifferentAt("Spec.EnableDNSSupport") {
-		if err := rm.syncDNSSupportAttribute(ctx, desired); err != nil {
-			return nil, err
+		if desired.ko.Spec.EnableDNSSupport != nil {
+			if err := rm.syncDNSSupportAttribute(ctx, desired); err != nil {
+				return nil, err
+			}
 		}
 	}
 
 	if delta.DifferentAt("Spec.EnableDNSHostnames") {
-		if err := rm.syncDNSHostnamesAttribute(ctx, desired); err != nil {
-			return nil, err
+		if desired.ko.Spec.EnableDNSHostnames != nil {
+			if err := rm.syncDNSHostnamesAttribute(ctx, desired); err != nil {
+				return nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Issue #: aws-controllers-k8s/community#1826

Description of changes: Only sync optional fields, if actually configured. More details are in the [commit message](https://github.com/aws-controllers-k8s/ec2-controller/commit/3ebf6f911692ff11a8361bf6239ab67b8fc3652a).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
