### PR TITLE
Improve the DNS attribute default handling

### DIFF
--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -734,6 +734,8 @@ resources:
         type: bool
         is_read_only: true
     hooks:
+      delta_pre_compare:
+          code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:

--- a/generator.yaml
+++ b/generator.yaml
@@ -734,6 +734,8 @@ resources:
         type: bool
         is_read_only: true
     hooks:
+      delta_pre_compare:
+          code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/vpc/sdk_create_post_build_request.go.tpl
       sdk_create_post_set_output:

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -310,18 +310,14 @@ func (rm *resourceManager) customUpdateVPC(
 	}
 
 	if delta.DifferentAt("Spec.EnableDNSSupport") {
-		if desired.ko.Spec.EnableDNSSupport != nil {
-			if err := rm.syncDNSSupportAttribute(ctx, desired); err != nil {
-				return nil, err
-			}
+		if err := rm.syncDNSSupportAttribute(ctx, desired); err != nil {
+			return nil, err
 		}
 	}
 
 	if delta.DifferentAt("Spec.EnableDNSHostnames") {
-		if desired.ko.Spec.EnableDNSHostnames != nil {
-			if err := rm.syncDNSHostnamesAttribute(ctx, desired); err != nil {
-				return nil, err
-			}
+		if err := rm.syncDNSHostnamesAttribute(ctx, desired); err != nil {
+			return nil, err
 		}
 	}
 
@@ -570,4 +566,29 @@ func (rm *resourceManager) getDefaultSGId(
 
 func ptr[T any](t T) *T {
 	return &t
+}
+
+var (
+	// Defaults for DNS related attributes as defined in https://docs.aws.amazon.com/vpc/latest/userguide/AmazonDNS-concepts.html#vpc-dns-support
+	defaultEnableDNSHostnames = false
+	defaultEnableDNSSupport   = true
+)
+
+// customPreCompare ensures that default values of nil-able types are
+// appropriately replaced with empty maps or structs depending on the default
+// output of the SDK.
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if a.ko.Spec.EnableDNSHostnames == nil {
+		a.ko.Spec.EnableDNSHostnames = &defaultEnableDNSHostnames
+	}
+	if a.ko.Spec.EnableDNSSupport == nil {
+		a.ko.Spec.EnableDNSSupport = &defaultEnableDNSSupport
+	}
+	if a.ko.Spec.DisallowSecurityGroupDefaultRules == nil {
+		a.ko.Spec.DisallowSecurityGroupDefaultRules = ptr(false)
+	}
 }


### PR DESCRIPTION
This improves #225.

Using a custom pre-compare function the defaults can be set accordingly. This is now added with the defaults set to what the VPC defaults are. The `disallowSecurityGroupDefaultRules` option is also handled here, as it also has the issue describe in aws-controllers-k8s/community#1826.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
