### PR TITLE
Issue 2090/route table order dependence

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-02-20T17:55:49Z"
+  build_date: "2025-02-24T08:32:50Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
-  go_version: go1.24.0
+  go_version: go1.23.5
   version: v0.43.2
 api_directory_checksum: b31faecf6092fab9677498f3624e624fee4cbaed
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: b3d6924c2a4a2252ea9a7fa775eb86bd1660eeef
+  file_checksum: 4f9d21bd7c46b495cd9374e454a3a0e1e6de5d08
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -535,6 +535,8 @@ resources:
       Routes:
         custom_field:
           list_of: CreateRouteInput
+        compare:
+          is_ignored: true
       RouteTableID:
         print:
           path: Status.RouteTableID

--- a/generator.yaml
+++ b/generator.yaml
@@ -535,6 +535,8 @@ resources:
       Routes:
         custom_field:
           list_of: CreateRouteInput
+        compare:
+          is_ignored: true
       RouteTableID:
         print:
           path: Status.RouteTableID

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/samber/lo v1.37.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.9.0
 	k8s.io/api v0.31.0
 	k8s.io/apimachinery v0.31.0
 	k8s.io/client-go v0.31.0
@@ -61,6 +62,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.19.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect

--- a/pkg/resource/route_table/delta.go
+++ b/pkg/resource/route_table/delta.go
@@ -44,13 +44,6 @@ func newResourceDelta(
 	}
 	customPreCompare(delta, a, b)
 
-	if len(a.ko.Spec.Routes) != len(b.ko.Spec.Routes) {
-		delta.Add("Spec.Routes", a.ko.Spec.Routes, b.ko.Spec.Routes)
-	} else if len(a.ko.Spec.Routes) > 0 {
-		if !reflect.DeepEqual(a.ko.Spec.Routes, b.ko.Spec.Routes) {
-			delta.Add("Spec.Routes", a.ko.Spec.Routes, b.ko.Spec.Routes)
-		}
-	}
 	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -15,7 +15,6 @@ package route_table
 
 import (
 	"context"
-	"reflect"
 	"strings"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
@@ -229,8 +228,9 @@ func getRoutesDifference(desired, latest []*svcapitypes.CreateRouteInput) (toAdd
 	for _, routeA := range desired {
 		found := false
 		for idx, routeB := range toDelete {
-			if found = reflect.DeepEqual(routeA, routeB); found {
+			if delta := compareCreateRouteInput(routeA, routeB); len(delta.Differences) == 0 {
 				toDelete = remove(toDelete, idx)
+				found = true
 				break
 			}
 		}

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -66,7 +66,7 @@ func (rm *resourceManager) syncRoutes(
 
 	switch {
 	case delta == nil:
-		toAdd = desired.ko.Spec.Routes
+		toAdd = removeLocalRoute(desired.ko.Spec.Routes)
 	case delta.DifferentAt("Spec.Routes"):
 		for _, diff := range delta.Differences {
 			if diff.Path.Contains("Spec.Routes") {

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -62,7 +62,14 @@ func (rm *resourceManager) syncRoutes(
 
 	// Get the routes that need to be added and deleted, by checking for
 	// differences between desired and latest.
-	toAdd, toDelete := getRoutesDifference(desired.ko.Spec.Routes, latest.ko.Spec.Routes)
+	var toAdd, toDelete []*svcapitypes.CreateRouteInput
+	if latest != nil {
+		toAdd, toDelete = getRoutesDifference(desired.ko.Spec.Routes, latest.ko.Spec.Routes)
+	} else {
+		// If method is called from the createRoutes method, then latest is nil
+		// and all routes must be added, as non exist yet.
+		toAdd = desired.ko.Spec.Routes
+	}
 
 	// Delete and add the routes that were found to be different between desired
 	// and latest.

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -48,12 +48,14 @@ func (rm *resourceManager) syncRoutes(
 	defer func(err error) { exit(err) }(err)
 
 	if latest != nil {
+		latest.ko.Spec.Routes = removeLocalRoute(latest.ko.Spec.Routes)
 		latest.ko.Spec.Routes, err = rm.excludeAWSRoute(ctx, latest.ko.Spec.Routes)
 		if err != nil {
 			return err
 		}
 	}
 	if desired != nil {
+		desired.ko.Spec.Routes = removeLocalRoute(desired.ko.Spec.Routes)
 		desired.ko.Spec.Routes, err = rm.excludeAWSRoute(ctx, desired.ko.Spec.Routes)
 		if err != nil {
 			return err

--- a/pkg/resource/route_table/hooks.go
+++ b/pkg/resource/route_table/hooks.go
@@ -224,8 +224,7 @@ func customPreCompare(
 	b.ko.Spec.Routes = removeLocalRoute(b.ko.Spec.Routes)
 
 	toAdd := []*svcapitypes.CreateRouteInput{}
-	toDelete := make([]*svcapitypes.CreateRouteInput, len(b.ko.Spec.Routes))
-	copy(toDelete, b.ko.Spec.Routes) // Copy of the routes from b, that will be reduced while iterating
+	toDelete := b.ko.Spec.DeepCopy().Routes
 
 	remove := func(s []*svcapitypes.CreateRouteInput, i int) []*svcapitypes.CreateRouteInput {
 		if i < len(s)-1 { // if not last element just copy the last element to where the removed element was
@@ -246,7 +245,7 @@ func customPreCompare(
 			}
 		}
 		if !found {
-			toAdd = append(toAdd, routeA)
+			toAdd = append(toAdd, routeA.DeepCopy())
 		}
 	}
 

--- a/pkg/resource/route_table/hooks_test.go
+++ b/pkg/resource/route_table/hooks_test.go
@@ -97,7 +97,7 @@ func TestCustomerPreCompare(t *testing.T) {
 				assert.ElementsMatch(t, tti.latestRoutes, diffB)
 
 				// Check the different routes are identified correctly
-				toAdd, toDelete := filterDifferentRoutes(tti.desiredRoutes, tti.latestRoutes)
+				toAdd, toDelete := getRoutesDifference(tti.desiredRoutes, tti.latestRoutes)
 				assertRoutesIdentical(t, tti.toAdd, toAdd)
 				assertRoutesIdentical(t, tti.toDelete, toDelete)
 			}

--- a/pkg/resource/route_table/hooks_test.go
+++ b/pkg/resource/route_table/hooks_test.go
@@ -1,0 +1,101 @@
+package route_table
+
+import (
+	"testing"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomerPreCompare(t *testing.T) {
+	type Routes []*svcapitypes.CreateRouteInput
+
+	peeringRoute := func(pcxID string, cidr string) *svcapitypes.CreateRouteInput {
+		return &svcapitypes.CreateRouteInput{
+			DestinationCIDRBlock:   aws.String(cidr),
+			VPCPeeringConnectionID: aws.String(pcxID),
+		}
+	}
+
+	createRouteTableTestResource := func(routes []*svcapitypes.CreateRouteInput) *resource {
+		return &resource{
+			ko: &svcapitypes.RouteTable{
+				Spec: svcapitypes.RouteTableSpec{
+					Routes: routes,
+				},
+			},
+		}
+	}
+
+	tt := []struct {
+		id            string
+		desiredRoutes Routes
+		latestRoutes  Routes
+		toAdd         Routes
+		toDelete      Routes
+	}{
+		{"all identical",
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			nil, nil,
+		},
+		{"add route",
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			nil,
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			nil,
+		},
+		{"delete route",
+			nil,
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			nil,
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+		},
+		{"keep one delete one",
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24"), peeringRoute("pcx-123", "172.30.2.0/24")},
+			nil,
+			Routes{peeringRoute("pcx-123", "172.30.2.0/24")},
+		},
+		{"keep one add one",
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24"), peeringRoute("pcx-123", "172.30.2.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.2.0/24")},
+			nil,
+		},
+		{"keep one add one delete one",
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24"), peeringRoute("pcx-123", "172.30.2.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.1.0/24"), peeringRoute("pcx-123", "172.30.3.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.2.0/24")},
+			Routes{peeringRoute("pcx-123", "172.30.3.0/24")},
+		},
+	}
+
+	for _, tti := range tt {
+		t.Run(tti.id, func(t *testing.T) {
+			delta := ackcompare.NewDelta()
+			a := createRouteTableTestResource(tti.desiredRoutes)
+			b := createRouteTableTestResource(tti.latestRoutes)
+			customPreCompare(delta, a, b)
+			if len(tti.toAdd) == 0 && len(tti.toDelete) == 0 {
+				assert.Equal(t, 0, len(delta.Differences))
+			} else {
+				diff := delta.Differences[0]
+				diffA := diff.A.([]*svcapitypes.CreateRouteInput)
+				diffB := diff.B.([]*svcapitypes.CreateRouteInput)
+				assert.True(t, diff.Path.Contains("Spec.Routes"))
+				require.Equal(t, len(tti.toAdd), len(diffA))
+				require.Equal(t, len(tti.toDelete), len(diffB))
+				for i := range tti.toAdd {
+					assert.Equal(t, tti.toAdd[i], diffA[i])
+				}
+				for i := range tti.toDelete {
+					assert.Equal(t, tti.toDelete[i], diffB[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes issue [#2090](https://github.com/aws-controllers-k8s/community/issues/2090)

Description of changes:
- Configure generator for RouteTable to ignore the Routes from the generated delta code.
- Extend the `customPreCompare` code to take care of the routes (computing the delta ignoring the order of routes).
- Added unit test for the custom code.
- Change the `syncRoutes` code to use the delta from the compare phase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
