### PR TITLE
Add custom update support for `VPCEndpoint` resource to handle `ModifyVpcEndpoint` calls

### DIFF
--- a/test/e2e/resources/vpc_endpoint_modify.yaml
+++ b/test/e2e/resources/vpc_endpoint_modify.yaml
@@ -5,6 +5,9 @@ metadata:
 spec:
   serviceName: $SERVICE_NAME
   vpcID: $VPC_ID
+  vpcEndpointType: Interface
+  subnetIDs:
+    - $SUBNET_ID
   tags:
     - key: $TAG_KEY
       value: $TAG_VALUE

--- a/test/e2e/service_bootstrap.py
+++ b/test/e2e/service_bootstrap.py
@@ -26,7 +26,11 @@ def service_bootstrap() -> Resources:
     logging.getLogger().setLevel(logging.INFO)
 
     resources = BootstrapResources(
-        SharedTestVPC=VPC(name_prefix="e2e-test-vpc", num_public_subnet=1, num_private_subnet=0),
+        SharedTestVPC=VPC(
+            name_prefix="e2e-test-vpc", 
+            num_public_subnet=2,
+            num_private_subnet=0
+        ),
         FlowLogsBucket=Bucket(
             "ack-ec2-controller-flow-log-tests",
         ),


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2296

Description of changes:

Handle updates that require the `ModifyVpcEndpoint` API. Ensure that when fields such as `SubnetIDs`, `RouteTableIDs`, `PolicyDocument`, `PrivateDNSEnabled`, `SecurityGroupIDs`, `DNSOptions`, or `IPAddressType` change, the controller constructs and sends the corresponding Modify calls to AWS. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
