### PR TITLE
Fix NetworkACL default rules duplication during creation

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2025-02-20T17:55:49Z"
+  build_date: "2025-02-24T21:18:33Z"
   build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
-  go_version: go1.24.0
+  go_version: go1.22.5
   version: v0.43.2
 api_directory_checksum: b31faecf6092fab9677498f3624e624fee4cbaed
 api_version: v1alpha1

--- a/templates/hooks/network_acl/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/network_acl/sdk_create_post_set_output.go.tpl
@@ -11,10 +11,17 @@
 	}
 
 	if len(desired.ko.Spec.Entries) > 0 {
-		//desired rules are overwritten by NetworkACL's default rules
-		ko.Spec.Entries = append(ko.Spec.Entries, desired.ko.Spec.Entries...)
+		// Filter out default rules and only keep desired entries
+		filteredEntries := []*svcapitypes.NetworkACLEntry{}
+		for _, entry := range desired.ko.Spec.Entries {
+			if entry.RuleNumber != nil && *entry.RuleNumber == int64(DefaultRuleNumber) {
+				continue
+			}
+			filteredEntries = append(filteredEntries, entry)
+		}
+		ko.Spec.Entries = filteredEntries
 		copy := ko.DeepCopy()
 		if err := rm.createEntries(ctx, &resource{copy}); err != nil {
-			rlog.Debug("Error while syncing routes", err)
+			rlog.Debug("Error while syncing entries", err)
 		}
 	}

--- a/test/e2e/resources/network_acl_with_default_rules.yaml
+++ b/test/e2e/resources/network_acl_with_default_rules.yaml
@@ -1,0 +1,28 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: NetworkACL
+metadata:
+  name: $NETWORK_ACL_NAME
+spec:
+  entries:
+    # Default egress rule
+    - cidrBlock: 0.0.0.0/0
+      egress: true
+      protocol: "-1"
+      ruleAction: deny
+      ruleNumber: 32767
+    # Default ingress rule
+    - cidrBlock: 0.0.0.0/0
+      egress: false
+      protocol: "-1"
+      ruleAction: deny
+      ruleNumber: 32767
+    # Custom rule
+    - cidrBlock: $CIDR_BLOCK
+      egress: true
+      portRange:
+        from: 443
+        to: 443
+      protocol: "6"
+      ruleAction: allow
+      ruleNumber: 100
+  vpcID: $VPC_ID


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2241

Description of changes:

Default Entries are already No-op fields fro the controller but were not filtered during creation(leading to `multiple entries with same number` errors) .

- Modified the NetworkACL resource creation logic to filter out default rules (rule number 32767) when creating entries
- Replaced the approach of appending entries to using a filtered list of entries
- Added a test case that verifies default rules are not duplicated when explicitly included in the creation spec

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
