### PR TITLE
Generate controller with order tags function

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-02-26T00:29:35Z"
-  build_hash: a326346bd3a6973254d247c9ab2dc76790c36241
+  build_date: "2025-03-10T20:08:48Z"
+  build_hash: cfbd9fc8a32a564e2f05252b60248053ff09e744
   go_version: go1.24.0
-  version: v0.43.2
+  version: v0.43.2-4-gcfbd9fc
 api_directory_checksum: b31faecf6092fab9677498f3624e624fee4cbaed
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/capacity_reservation/manager.go
+++ b/pkg/resource/capacity_reservation/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/capacity_reservation/tags.go
+++ b/pkg/resource/capacity_reservation/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/dhcp_options/manager.go
+++ b/pkg/resource/dhcp_options/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/dhcp_options/tags.go
+++ b/pkg/resource/dhcp_options/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/elastic_ip_address/manager.go
+++ b/pkg/resource/elastic_ip_address/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/elastic_ip_address/tags.go
+++ b/pkg/resource/elastic_ip_address/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/flow_log/manager.go
+++ b/pkg/resource/flow_log/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/flow_log/tags.go
+++ b/pkg/resource/flow_log/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/instance/manager.go
+++ b/pkg/resource/instance/manager.go
@@ -319,9 +319,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -343,10 +343,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/instance/tags.go
+++ b/pkg/resource/instance/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/internet_gateway/manager.go
+++ b/pkg/resource/internet_gateway/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/internet_gateway/tags.go
+++ b/pkg/resource/internet_gateway/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/nat_gateway/manager.go
+++ b/pkg/resource/nat_gateway/manager.go
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/nat_gateway/tags.go
+++ b/pkg/resource/nat_gateway/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/network_acl/manager.go
+++ b/pkg/resource/network_acl/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/network_acl/tags.go
+++ b/pkg/resource/network_acl/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/route_table/manager.go
+++ b/pkg/resource/route_table/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/route_table/tags.go
+++ b/pkg/resource/route_table/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/security_group/manager.go
+++ b/pkg/resource/security_group/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/security_group/tags.go
+++ b/pkg/resource/security_group/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/subnet/manager.go
+++ b/pkg/resource/subnet/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/subnet/tags.go
+++ b/pkg/resource/subnet/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/transit_gateway/manager.go
+++ b/pkg/resource/transit_gateway/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/transit_gateway/tags.go
+++ b/pkg/resource/transit_gateway/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/vpc/manager.go
+++ b/pkg/resource/vpc/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc/tags.go
+++ b/pkg/resource/vpc/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/vpc_endpoint/manager.go
+++ b/pkg/resource/vpc_endpoint/manager.go
@@ -319,9 +319,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -343,10 +343,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_endpoint/tags.go
+++ b/pkg/resource/vpc_endpoint/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/vpc_endpoint_service_configuration/manager.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/manager.go
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_endpoint_service_configuration/tags.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 

--- a/pkg/resource/vpc_peering_connection/manager.go
+++ b/pkg/resource/vpc_peering_connection/manager.go
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = FromACKTags(resourceTags)
+	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags := ToACKTags(existingDesiredTags)
-	latestTags := ToACKTags(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
+	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = FromACKTags(desiredTags)
+	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_peering_connection/tags.go
+++ b/pkg/resource/vpc_peering_connection/tags.go
@@ -52,6 +52,27 @@ func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
 	return result
 }
 
+// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
+// This method helps in creating the hub(acktags.Tags) for merging
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
+	result := acktags.NewTags()
+	keyOrder := []string{}
+	if tags == nil || len(tags) == 0 {
+		return result, keyOrder
+	}
+
+	for _, t := range tags {
+		if t.Key != nil {
+			keyOrder = append(keyOrder, *t.Key)
+		}
+	}
+	result = ToACKTags(tags)
+
+	return result, keyOrder
+}
+
 // FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags.
@@ -63,6 +84,24 @@ func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
 		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
 		result = append(result, &tag)
 	}
+	return result
+}
+
+// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// This method helps in setting the tags back inside AWSResource after merging
+// default controller tags with existing resource tags. When a list,
+// it maintains the order from original
+func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+	result := []*svcapitypes.Tag{}
+	for _, k := range keyOrder {
+		v, ok := tags[k]
+		if ok {
+			tag := svcapitypes.Tag{Key: &k, Value: &v}
+			result = append(result, &tag)
+			delete(tags, k)
+		}
+	}
+	result = append(result, FromACKTags(tags)...)
 	return result
 }
 


### PR DESCRIPTION
Description of changes:
This change introduces two new generated functions that order preserve 
order of tags during conversion from and to ACK Tags type

More info in code-gen PR [#572](https://github.com/aws-controllers-k8s/code-generator/pull/572)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
