### PR TITLE
feat(NetworkACL): Filter Default Rules from Delta

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-03-10T20:08:48Z"
-  build_hash: cfbd9fc8a32a564e2f05252b60248053ff09e744
+  build_date: "2025-03-25T22:26:20Z"
+  build_hash: 3722729cebe6d3c03c7e442655ef0846f91566a2
   go_version: go1.24.0
-  version: v0.43.2-4-gcfbd9fc
+  version: v0.43.2-7-g3722729
 api_directory_checksum: b31faecf6092fab9677498f3624e624fee4cbaed
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 4f9d21bd7c46b495cd9374e454a3a0e1e6de5d08
+  file_checksum: 33b2c8e790a68bd28b5efe9faa3b8e5fb980d1f4
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -707,6 +707,8 @@ resources:
           input_fields:
             NetworkAclId: Id    
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/network_acl/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/generator.yaml
+++ b/generator.yaml
@@ -707,6 +707,8 @@ resources:
           input_fields:
             NetworkAclId: Id    
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/network_acl/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/pkg/resource/capacity_reservation/delta.go
+++ b/pkg/resource/capacity_reservation/delta.go
@@ -155,7 +155,9 @@ func newResourceDelta(
 			delta.Add("Spec.StartDate", a.ko.Spec.StartDate, b.ko.Spec.StartDate)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Tenancy, b.ko.Spec.Tenancy) {

--- a/pkg/resource/capacity_reservation/manager.go
+++ b/pkg/resource/capacity_reservation/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/capacity_reservation/tags.go
+++ b/pkg/resource/capacity_reservation/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/dhcp_options/delta.go
+++ b/pkg/resource/dhcp_options/delta.go
@@ -50,7 +50,9 @@ func newResourceDelta(
 			delta.Add("Spec.DHCPConfigurations", a.ko.Spec.DHCPConfigurations, b.ko.Spec.DHCPConfigurations)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if len(a.ko.Spec.VPC) != len(b.ko.Spec.VPC) {

--- a/pkg/resource/dhcp_options/manager.go
+++ b/pkg/resource/dhcp_options/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/dhcp_options/tags.go
+++ b/pkg/resource/dhcp_options/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/elastic_ip_address/delta.go
+++ b/pkg/resource/elastic_ip_address/delta.go
@@ -71,7 +71,9 @@ func newResourceDelta(
 			delta.Add("Spec.PublicIPv4Pool", a.ko.Spec.PublicIPv4Pool, b.ko.Spec.PublicIPv4Pool)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 

--- a/pkg/resource/elastic_ip_address/manager.go
+++ b/pkg/resource/elastic_ip_address/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/elastic_ip_address/tags.go
+++ b/pkg/resource/elastic_ip_address/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/flow_log/delta.go
+++ b/pkg/resource/flow_log/delta.go
@@ -124,7 +124,9 @@ func newResourceDelta(
 			delta.Add("Spec.ResourceType", a.ko.Spec.ResourceType, b.ko.Spec.ResourceType)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TrafficType, b.ko.Spec.TrafficType) {

--- a/pkg/resource/flow_log/manager.go
+++ b/pkg/resource/flow_log/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/flow_log/tags.go
+++ b/pkg/resource/flow_log/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/instance/delta.go
+++ b/pkg/resource/instance/delta.go
@@ -516,7 +516,9 @@ func newResourceDelta(
 			delta.Add("Spec.SubnetID", a.ko.Spec.SubnetID, b.ko.Spec.SubnetID)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.UserData, b.ko.Spec.UserData) {

--- a/pkg/resource/instance/manager.go
+++ b/pkg/resource/instance/manager.go
@@ -300,9 +300,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -319,9 +319,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -343,10 +343,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/instance/tags.go
+++ b/pkg/resource/instance/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/internet_gateway/delta.go
+++ b/pkg/resource/internet_gateway/delta.go
@@ -53,7 +53,9 @@ func newResourceDelta(
 			delta.Add("Spec.RouteTables", a.ko.Spec.RouteTables, b.ko.Spec.RouteTables)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPC, b.ko.Spec.VPC) {

--- a/pkg/resource/internet_gateway/manager.go
+++ b/pkg/resource/internet_gateway/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/internet_gateway/tags.go
+++ b/pkg/resource/internet_gateway/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/nat_gateway/delta.go
+++ b/pkg/resource/nat_gateway/delta.go
@@ -70,7 +70,9 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef) {
 		delta.Add("Spec.SubnetRef", a.ko.Spec.SubnetRef, b.ko.Spec.SubnetRef)
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 

--- a/pkg/resource/nat_gateway/manager.go
+++ b/pkg/resource/nat_gateway/manager.go
@@ -299,9 +299,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/nat_gateway/tags.go
+++ b/pkg/resource/nat_gateway/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/network_acl/delta.go
+++ b/pkg/resource/network_acl/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if len(a.ko.Spec.Associations) != len(b.ko.Spec.Associations) {
 		delta.Add("Spec.Associations", a.ko.Spec.Associations, b.ko.Spec.Associations)
@@ -57,7 +58,9 @@ func newResourceDelta(
 			delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {

--- a/pkg/resource/network_acl/hooks.go
+++ b/pkg/resource/network_acl/hooks.go
@@ -88,10 +88,10 @@ func (rm *resourceManager) requiredFieldsMissingForCreateNetworkAcl(
 
 func (rm *resourceManager) createEntries(
 	ctx context.Context,
-	r *resource,
+	desired *resource,
 ) error {
-	if r.ko.Spec.Entries != nil {
-		if err := rm.syncEntries(ctx, r, nil); err != nil {
+	if desired.ko.Spec.Entries != nil {
+		if err := rm.syncEntries(ctx, desired, nil); err != nil {
 			return err
 		}
 	}
@@ -351,7 +351,6 @@ func (rm *resourceManager) syncEntries(
 			toAdd = append(toAdd, desiredEntry)
 		}
 	}
-
 	if latest != nil {
 		// Filter out AWS default rules from latest entries before comparison
 		// to ensure consistent state management between desired and actual
@@ -380,6 +379,11 @@ func (rm *resourceManager) syncEntries(
 				toAdd[index] = nil
 			}
 		}
+	}
+
+	// During create latest is nil, just add the entries when sync is called via createEntries
+	if latest == nil {
+		toAdd = append(toAdd, desired.ko.Spec.Entries...)
 	}
 
 	for _, entry := range toAdd {

--- a/pkg/resource/network_acl/hooks.go
+++ b/pkg/resource/network_acl/hooks.go
@@ -90,8 +90,9 @@ func (rm *resourceManager) createEntries(
 	ctx context.Context,
 	desired *resource,
 ) error {
-	if desired.ko.Spec.Entries != nil {
-		if err := rm.syncEntries(ctx, desired, nil); err != nil {
+	filteredEntries := filterDefaultRules(desired.ko.Spec.Entries)
+	for _, entry := range filteredEntries {
+		if err := rm.createEntry(ctx, desired, *entry); err != nil {
 			return err
 		}
 	}
@@ -324,18 +325,6 @@ func (rm *resourceManager) syncEntries(
 	toDelete := []*svcapitypes.NetworkACLEntry{}
 	toUpdate := []*svcapitypes.NetworkACLEntry{}
 
-	// Filter out AWS default rules (rule #32767) from desired entries to ensure
-	// they don't interfere with GitOps workflows. These rules are automatically
-	// managed by AWS and should not be included in the desired state.
-	filteredDesiredEntries := []*svcapitypes.NetworkACLEntry{}
-	for _, entry := range desired.ko.Spec.Entries {
-		if entry.RuleNumber != nil && *entry.RuleNumber == int64(DefaultRuleNumber) {
-			continue
-		}
-		filteredDesiredEntries = append(filteredDesiredEntries, entry)
-	}
-	desired.ko.Spec.Entries = filteredDesiredEntries
-
 	// Check for duplicate rule numbers within the same direction (egress/ingress)
 	uniqEntries := lo.UniqBy(desired.ko.Spec.Entries, func(entry *svcapitypes.NetworkACLEntry) string {
 		return strconv.FormatBool(*entry.Egress) + strconv.Itoa(int(*entry.RuleNumber))
@@ -352,18 +341,8 @@ func (rm *resourceManager) syncEntries(
 		}
 	}
 	if latest != nil {
-		// Filter out AWS default rules from latest entries before comparison
-		// to ensure consistent state management between desired and actual
-		filteredLatestEntries := []*svcapitypes.NetworkACLEntry{}
-		for _, entry := range latest.ko.Spec.Entries {
-			if entry.RuleNumber != nil && *entry.RuleNumber == int64(DefaultRuleNumber) {
-				continue
-			}
-			filteredLatestEntries = append(filteredLatestEntries, entry)
-		}
-
 		// Identify entries that need to be deleted (exist in latest but not in desired)
-		for _, latestEntry := range filteredLatestEntries {
+		for _, latestEntry := range latest.ko.Spec.Entries {
 			if !containsEntry(desired.ko.Spec.Entries, latestEntry) {
 				// entry is in latest resource, but not in desired resource; therefore, delete
 				toDelete = append(toDelete, latestEntry)
@@ -379,11 +358,6 @@ func (rm *resourceManager) syncEntries(
 				toAdd[index] = nil
 			}
 		}
-	}
-
-	// During create latest is nil, just add the entries when sync is called via createEntries
-	if latest == nil {
-		toAdd = append(toAdd, desired.ko.Spec.Entries...)
 	}
 
 	for _, entry := range toAdd {
@@ -614,4 +588,27 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 		desiredTagSpecs.Tags = requestedTags
 		input.TagSpecifications = []svcsdktypes.TagSpecification{desiredTagSpecs}
 	}
+}
+
+// Filter out AWS default rules from latest entries before comparison
+// to ensure consistent state management between desired and actual
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	a.ko.Spec.Entries = filterDefaultRules(a.ko.Spec.Entries)
+	b.ko.Spec.Entries = filterDefaultRules(b.ko.Spec.Entries)
+}
+
+// filter default rules 32767
+func filterDefaultRules(entries []*svcapitypes.NetworkACLEntry) []*svcapitypes.NetworkACLEntry {
+	filteredEntries := []*svcapitypes.NetworkACLEntry{}
+	for _, entry := range entries {
+		if entry.RuleNumber != nil && *entry.RuleNumber == int64(DefaultRuleNumber) {
+			continue
+		}
+		filteredEntries = append(filteredEntries, entry)
+	}
+	return filteredEntries
 }

--- a/pkg/resource/network_acl/manager.go
+++ b/pkg/resource/network_acl/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/network_acl/tags.go
+++ b/pkg/resource/network_acl/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/route_table/delta.go
+++ b/pkg/resource/route_table/delta.go
@@ -44,7 +44,9 @@ func newResourceDelta(
 	}
 	customPreCompare(delta, a, b)
 
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {

--- a/pkg/resource/route_table/manager.go
+++ b/pkg/resource/route_table/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/route_table/tags.go
+++ b/pkg/resource/route_table/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -71,7 +71,9 @@ func newResourceDelta(
 			delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {

--- a/pkg/resource/security_group/manager.go
+++ b/pkg/resource/security_group/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/security_group/tags.go
+++ b/pkg/resource/security_group/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/subnet/delta.go
+++ b/pkg/resource/subnet/delta.go
@@ -144,7 +144,9 @@ func newResourceDelta(
 			delta.Add("Spec.RouteTables", a.ko.Spec.RouteTables, b.ko.Spec.RouteTables)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {

--- a/pkg/resource/subnet/manager.go
+++ b/pkg/resource/subnet/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/subnet/tags.go
+++ b/pkg/resource/subnet/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/transit_gateway/delta.go
+++ b/pkg/resource/transit_gateway/delta.go
@@ -110,7 +110,9 @@ func newResourceDelta(
 			}
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 

--- a/pkg/resource/transit_gateway/manager.go
+++ b/pkg/resource/transit_gateway/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/transit_gateway/tags.go
+++ b/pkg/resource/transit_gateway/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/vpc/delta.go
+++ b/pkg/resource/vpc/delta.go
@@ -135,7 +135,9 @@ func newResourceDelta(
 			delta.Add("Spec.IPv6Pool", a.ko.Spec.IPv6Pool, b.ko.Spec.IPv6Pool)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 

--- a/pkg/resource/vpc/manager.go
+++ b/pkg/resource/vpc/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc/tags.go
+++ b/pkg/resource/vpc/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -112,7 +112,9 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs) {
 		delta.Add("Spec.SubnetRefs", a.ko.Spec.SubnetRefs, b.ko.Spec.SubnetRefs)
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCEndpointType, b.ko.Spec.VPCEndpointType) {

--- a/pkg/resource/vpc_endpoint/manager.go
+++ b/pkg/resource/vpc_endpoint/manager.go
@@ -300,9 +300,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -319,9 +319,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -343,10 +343,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_endpoint/tags.go
+++ b/pkg/resource/vpc_endpoint/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/vpc_endpoint_service_configuration/delta.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/delta.go
@@ -85,7 +85,9 @@ func newResourceDelta(
 			delta.Add("Spec.SupportedIPAddressTypes", a.ko.Spec.SupportedIPAddressTypes, b.ko.Spec.SupportedIPAddressTypes)
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 

--- a/pkg/resource/vpc_endpoint_service_configuration/manager.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/manager.go
@@ -299,9 +299,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -318,9 +318,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -342,10 +342,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_endpoint_service_configuration/tags.go
+++ b/pkg/resource/vpc_endpoint_service_configuration/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 

--- a/pkg/resource/vpc_peering_connection/delta.go
+++ b/pkg/resource/vpc_peering_connection/delta.go
@@ -124,7 +124,9 @@ func newResourceDelta(
 			}
 		}
 	}
-	if !ackcompare.MapStringStringEqual(ToACKTags(a.ko.Spec.Tags), ToACKTags(b.ko.Spec.Tags)) {
+	desiredACKTags, _ := convertToOrderedACKTags(a.ko.Spec.Tags)
+	latestACKTags, _ := convertToOrderedACKTags(b.ko.Spec.Tags)
+	if !ackcompare.MapStringStringEqual(desiredACKTags, latestACKTags) {
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.VPCID, b.ko.Spec.VPCID) {

--- a/pkg/resource/vpc_peering_connection/manager.go
+++ b/pkg/resource/vpc_peering_connection/manager.go
@@ -291,9 +291,9 @@ func (rm *resourceManager) EnsureTags(
 	defaultTags := ackrt.GetDefaultTags(&rm.cfg, r.ko, md)
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags := ToACKTags(existingTags)
+	resourceTags, keyOrder := convertToOrderedACKTags(existingTags)
 	tags := acktags.Merge(resourceTags, defaultTags)
-	r.ko.Spec.Tags = FromACKTags(tags)
+	r.ko.Spec.Tags = fromACKTags(tags, keyOrder)
 	return nil
 }
 
@@ -310,9 +310,9 @@ func (rm *resourceManager) FilterSystemTags(res acktypes.AWSResource) {
 	}
 	var existingTags []*svcapitypes.Tag
 	existingTags = r.ko.Spec.Tags
-	resourceTags, tagKeyOrder := toACKTagsWithKeyOrder(existingTags)
+	resourceTags, tagKeyOrder := convertToOrderedACKTags(existingTags)
 	ignoreSystemTags(resourceTags)
-	r.ko.Spec.Tags = fromACKTagsWithKeyOrder(resourceTags, tagKeyOrder)
+	r.ko.Spec.Tags = fromACKTags(resourceTags, tagKeyOrder)
 }
 
 // mirrorAWSTags ensures that AWS tags are included in the desired resource
@@ -334,10 +334,10 @@ func mirrorAWSTags(a *resource, b *resource) {
 	var existingDesiredTags []*svcapitypes.Tag
 	existingDesiredTags = a.ko.Spec.Tags
 	existingLatestTags = b.ko.Spec.Tags
-	desiredTags, desiredTagKeyOrder := toACKTagsWithKeyOrder(existingDesiredTags)
-	latestTags, _ := toACKTagsWithKeyOrder(existingLatestTags)
+	desiredTags, desiredTagKeyOrder := convertToOrderedACKTags(existingDesiredTags)
+	latestTags, _ := convertToOrderedACKTags(existingLatestTags)
 	syncAWSTags(desiredTags, latestTags)
-	a.ko.Spec.Tags = fromACKTagsWithKeyOrder(desiredTags, desiredTagKeyOrder)
+	a.ko.Spec.Tags = fromACKTags(desiredTags, desiredTagKeyOrder)
 }
 
 // newResourceManager returns a new struct implementing

--- a/pkg/resource/vpc_peering_connection/tags.go
+++ b/pkg/resource/vpc_peering_connection/tags.go
@@ -30,69 +30,38 @@ var (
 	ACKSystemTags = []string{"services.k8s.aws/namespace", "services.k8s.aws/controller-version"}
 )
 
-// ToACKTags converts the tags parameter into 'acktags.Tags' shape.
+// convertToOrderedACKTags converts the tags parameter into 'acktags.Tags' shape.
 // This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags.
-func ToACKTags(tags []*svcapitypes.Tag) acktags.Tags {
+// default controller tags with existing resource tags. It also returns a slice
+// of keys maintaining the original key Order when the tags are a list
+func convertToOrderedACKTags(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
 	result := acktags.NewTags()
-	if tags == nil || len(tags) == 0 {
-		return result
-	}
+	keyOrder := []string{}
 
+	if len(tags) == 0 {
+		return result, keyOrder
+	}
 	for _, t := range tags {
 		if t.Key != nil {
-			if t.Value == nil {
-				result[*t.Key] = ""
-			} else {
+			keyOrder = append(keyOrder, *t.Key)
+			if t.Value != nil {
 				result[*t.Key] = *t.Value
+			} else {
+				result[*t.Key] = ""
 			}
 		}
 	}
 
-	return result
-}
-
-// toACKTagsWithKeyOrder converts the tags parameter into 'acktags.Tags' shape.
-// This method helps in creating the hub(acktags.Tags) for merging
-// default controller tags with existing resource tags. It also returns a slice
-// of keys maintaining the original key Order when the tags are a list
-func toACKTagsWithKeyOrder(tags []*svcapitypes.Tag) (acktags.Tags, []string) {
-	result := acktags.NewTags()
-	keyOrder := []string{}
-	if tags == nil || len(tags) == 0 {
-		return result, keyOrder
-	}
-
-	for _, t := range tags {
-		if t.Key != nil {
-			keyOrder = append(keyOrder, *t.Key)
-		}
-	}
-	result = ToACKTags(tags)
-
 	return result, keyOrder
 }
 
-// FromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
-// This method helps in setting the tags back inside AWSResource after merging
-// default controller tags with existing resource tags.
-func FromACKTags(tags acktags.Tags) []*svcapitypes.Tag {
-	result := []*svcapitypes.Tag{}
-	for k, v := range tags {
-		kCopy := k
-		vCopy := v
-		tag := svcapitypes.Tag{Key: &kCopy, Value: &vCopy}
-		result = append(result, &tag)
-	}
-	return result
-}
-
-// fromACKTagsWithTagKeys converts the tags parameter into []*svcapitypes.Tag shape.
+// fromACKTags converts the tags parameter into []*svcapitypes.Tag shape.
 // This method helps in setting the tags back inside AWSResource after merging
 // default controller tags with existing resource tags. When a list,
 // it maintains the order from original
-func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
+func fromACKTags(tags acktags.Tags, keyOrder []string) []*svcapitypes.Tag {
 	result := []*svcapitypes.Tag{}
+
 	for _, k := range keyOrder {
 		v, ok := tags[k]
 		if ok {
@@ -101,7 +70,11 @@ func fromACKTagsWithKeyOrder(tags acktags.Tags, keyOrder []string) []*svcapitype
 			delete(tags, k)
 		}
 	}
-	result = append(result, FromACKTags(tags)...)
+	for k, v := range tags {
+		tag := svcapitypes.Tag{Key: &k, Value: &v}
+		result = append(result, &tag)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2374

Description of changes:
- Add a precompare hook for Delta to filter out default rules from desired and latest objects
- Move create resource logic to `createEntries` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
