### PR TITLE
fix: remove printf with no constant

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,7 +1,7 @@
 ack_generate_info:
-  build_date: "2025-03-28T15:21:59Z"
+  build_date: "2025-03-31T18:41:05Z"
   build_hash: 3722729cebe6d3c03c7e442655ef0846f91566a2
-  go_version: go1.24.0
+  go_version: go1.24.1
   version: v0.43.2-7-g3722729
 api_directory_checksum: bb3f7a9b3924fdbe63a4082a9134b3f1f653979b
 api_version: v1alpha1

--- a/pkg/resource/vpc_peering_connection/sdk.go
+++ b/pkg/resource/vpc_peering_connection/sdk.go
@@ -556,8 +556,8 @@ func (rm *resourceManager) sdkUpdate(
 	if delta.DifferentAt("Spec.AcceptRequest") {
 		// Throw a Terminal Error, if the field was set to 'true' and is now set to 'false'
 		if desired.ko.Spec.AcceptRequest == nil || !*desired.ko.Spec.AcceptRequest {
-			msg := fmt.Sprintf("You cannot set AcceptRequest to false after setting it to true")
-			return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
+			msg := "you cannot set AcceptRequest to false after setting it to true"
+			return nil, ackerr.NewTerminalError(fmt.Errorf("%s", msg))
 
 			// Accept the VPC Peering Connection Request, if the field is set to 'true' and is still at status Pending Acceptance
 		} else if *latest.ko.Status.Status.Code == "pending-acceptance" {

--- a/templates/hooks/vpc_peering_connection/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/vpc_peering_connection/sdk_update_pre_build_request.go.tpl
@@ -22,8 +22,8 @@
 	if delta.DifferentAt("Spec.AcceptRequest") {
 		// Throw a Terminal Error, if the field was set to 'true' and is now set to 'false'
 		if desired.ko.Spec.AcceptRequest == nil || !*desired.ko.Spec.AcceptRequest {
-			msg := fmt.Sprintf("You cannot set AcceptRequest to false after setting it to true")
-			return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
+			msg := "you cannot set AcceptRequest to false after setting it to true"
+			return nil, ackerr.NewTerminalError(fmt.Errorf("%s", msg))
 
 			// Accept the VPC Peering Connection Request, if the field is set to 'true' and is still at status Pending Acceptance
 		} else if *latest.ko.Status.Status.Code == "pending-acceptance" {


### PR DESCRIPTION
Description of changes:
Go 1.24.1 enforcing `fmt.Sprintf("")` to have constant defined.
More info here: https://github.com/golang/go/issues/60529

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
