### PR TITLE
feat: Recreate TransitGateway if resource has deleted status

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2025-04-02T00:53:09Z"
+  build_date: "2025-04-02T20:13:02Z"
   build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
   go_version: go1.24.1
   version: v0.44.0
@@ -7,7 +7,7 @@ api_directory_checksum: 5e4731f8ab6fa4bafdb863edf0e678e604697103
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: e698ea1f155660431146b92e305118d58ee80a76
+  file_checksum: 91537a111710acf9c1f9c7c6c451ca017568ecb7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -598,6 +598,8 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/nat_gateway/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/nat_gateway/sdk_file_end.go.tpl
     update_operation:
@@ -877,6 +879,8 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/transit_gateway/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/transit_gateway/sdk_file_end.go.tpl
     update_operation:

--- a/generator.yaml
+++ b/generator.yaml
@@ -598,6 +598,8 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/nat_gateway/sdk_create_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/nat_gateway/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/nat_gateway/sdk_file_end.go.tpl
     update_operation:
@@ -877,6 +879,8 @@ resources:
     hooks:
       sdk_create_post_build_request:
         template_path: hooks/transit_gateway/sdk_create_post_build_request.go.tpl
+      sdk_read_many_post_set_output:
+        template_path: hooks/transit_gateway/sdk_read_many_post_set_output.go.tpl
       sdk_file_end:
         template_path: hooks/transit_gateway/sdk_file_end.go.tpl
     update_operation:

--- a/pkg/resource/nat_gateway/sdk.go
+++ b/pkg/resource/nat_gateway/sdk.go
@@ -203,6 +203,13 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if isResourceDeleted(&resource{ko}) {
+		return nil, ackerr.NotFound
+	}
+	if isResourcePending(&resource{ko}) {
+		return nil, ackrequeue.Needed(fmt.Errorf("resource is pending"))
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/transit_gateway/hooks.go
+++ b/pkg/resource/transit_gateway/hooks.go
@@ -24,6 +24,22 @@ import (
 	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
 )
 
+func isResourceDeleted(r *resource) bool {
+	if r.ko.Status.State == nil {
+		return true
+	}
+	status := *r.ko.Status.State
+	return status == string(svcsdktypes.TransitGatewayStateDeleted)
+}
+
+func isResourcePending(r *resource) bool {
+	if r.ko.Status.State == nil {
+		return false
+	}
+	status := *r.ko.Status.State
+	return status == string(svcsdktypes.TransitGatewayStatePending)
+}
+
 func (rm *resourceManager) customUpdateTransitGateway(
 	ctx context.Context,
 	desired *resource,

--- a/pkg/resource/transit_gateway/sdk.go
+++ b/pkg/resource/transit_gateway/sdk.go
@@ -177,6 +177,13 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	if isResourceDeleted(&resource{ko}) {
+		return nil, ackerr.NotFound
+	}
+	if isResourcePending(&resource{ko}) {
+		return nil, ackrequeue.Needed(fmt.Errorf("resource is pending"))
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/nat_gateway/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/nat_gateway/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,6 @@
+	if isResourceDeleted(&resource{ko}) {
+		return nil, ackerr.NotFound
+	}
+	if isResourcePending(&resource{ko}) {
+		return nil, ackrequeue.Needed(fmt.Errorf("resource is pending"))
+	}

--- a/templates/hooks/transit_gateway/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/transit_gateway/sdk_read_many_post_set_output.go.tpl
@@ -1,0 +1,6 @@
+	if isResourceDeleted(&resource{ko}) {
+		return nil, ackerr.NotFound
+	}
+	if isResourcePending(&resource{ko}) {
+		return nil, ackrequeue.Needed(fmt.Errorf("resource is pending"))
+	}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Currently if a TransitGateway is deleted on accident by calling the API 
or console, it still dangles with a `deleted` state.

With this change, the controller will recreate the TransitGateway if the 
resource has `deleted` state

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
