### PR TITLE
add vpcid during adoption

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-04-02T20:13:02Z"
-  build_hash: 980cb1e4734f673d16101cf55206b84ca639ec01
+  build_date: "2025-04-14T02:36:47Z"
+  build_hash: 0909e7f0adb8ffe4120a8c20d5d58b991f2539e9
   go_version: go1.24.1
-  version: v0.44.0
+  version: v0.44.0-3-g0909e7f
 api_directory_checksum: 5e4731f8ab6fa4bafdb863edf0e678e604697103
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/pkg/resource/vpc_peering_connection/sdk.go
+++ b/pkg/resource/vpc_peering_connection/sdk.go
@@ -244,6 +244,11 @@ func (rm *resourceManager) sdkFind(
 
 	rm.setStatusDefaults(ko)
 
+	// This prevents reference resolution errors when adopting existing resources where these fields are not provided in the manifest.
+	if ko.Spec.VPCID == nil && ko.Status.RequesterVPCInfo != nil && ko.Status.RequesterVPCInfo.VPCID != nil {
+		ko.Spec.VPCID = ko.Status.RequesterVPCInfo.VPCID
+	}
+
 	if r.ko.Spec.AccepterPeeringConnectionOptions != nil {
 		f0 := &svcapitypes.PeeringConnectionOptionsRequest{}
 		if r.ko.Spec.AccepterPeeringConnectionOptions.AllowDNSResolutionFromRemoteVPC != nil {
@@ -284,6 +289,7 @@ func (rm *resourceManager) sdkFind(
 	} else if isVPCPeeringConnectionCreating(res) {
 		return res, requeueWaitWhileCreating
 	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/vpc_peering_connection/sdk_read_many_post_set_output.go.tpl
+++ b/templates/hooks/vpc_peering_connection/sdk_read_many_post_set_output.go.tpl
@@ -1,4 +1,8 @@
 
+	// This prevents reference resolution errors when adopting existing resources where these fields are not provided in the manifest.
+	if ko.Spec.VPCID == nil && ko.Status.RequesterVPCInfo != nil && ko.Status.RequesterVPCInfo.VPCID != nil {
+		ko.Spec.VPCID = ko.Status.RequesterVPCInfo.VPCID
+	}
 
 	if r.ko.Spec.AccepterPeeringConnectionOptions != nil {
 		f0 := &svcapitypes.PeeringConnectionOptionsRequest{}


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2419

Description of changes:
add `read_many_post_set_output` hook to populate `vpcid` during adoption of VPC Peering Connection

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
