### PR TITLE
fix: add a Describe call with filters before readOne if ID not populated

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-08-28T17:59:00Z"
-  build_hash: 1d9076d0211773ff8ab8682b28b912c7ece10676
+  build_date: "2025-09-11T20:48:05Z"
+  build_hash: 9e29f017d9e942548af133d2f31aecae248a8816
   go_version: go1.25.0
-  version: v0.51.0-2-g1d9076d
+  version: v0.51.0-3-g9e29f01
 api_directory_checksum: b32f97274be98ca3f4cf5cbf559258210c872946
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: d5e0ce1661bd55bd3c0a8c4316de6885c8039ea0
+  file_checksum: 381d3f31a88cd00e07717b8957ffb5141218130a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -750,6 +750,8 @@ resources:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/security_group/sdk_delete_pre_build_request.go.tpl
+      sdk_read_many_pre_build_request:
+        template_path: hooks/security_group/sdk_read_many_pre_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/generator.yaml
+++ b/generator.yaml
@@ -750,6 +750,8 @@ resources:
         template_path: hooks/security_group/sdk_read_many_post_set_output.go.tpl
       sdk_delete_pre_build_request:
         template_path: hooks/security_group/sdk_delete_pre_build_request.go.tpl
+      sdk_read_many_pre_build_request:
+        template_path: hooks/security_group/sdk_read_many_pre_build_request.go.tpl
     update_operation:
       custom_method_name: customUpdateSecurityGroup
   NetworkAcl:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -10,6 +10,9 @@ metadata:
     app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
     k8s-app: {{ include "ack-ec2-controller.app.name" . }}
     helm.sh/chart: {{ include "ack-ec2-controller.chart.name-version" . }}
+{{- range $key, $value := .Values.deployment.labels }}
+    {{ $key }}: {{ $value | quote }}
+{{- end }}
 spec:
   replicas: {{ .Values.deployment.replicas }}
   selector:

--- a/pkg/resource/security_group/sdk.go
+++ b/pkg/resource/security_group/sdk.go
@@ -64,6 +64,15 @@ func (rm *resourceManager) sdkFind(
 	defer func() {
 		exit(err)
 	}()
+	if rm.requiredFieldsMissingFromReadManyInput(r) {
+		id, err := rm.getSecurityGroupID(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if id != nil {
+			r.ko.Status.ID = id
+		}
+	}
 	// If any required fields in the input shape are missing, AWS resource is
 	// not created yet. Return NotFound here to indicate to callers that the
 	// resource isn't yet created.

--- a/templates/hooks/security_group/sdk_read_many_pre_build_request.go.tpl
+++ b/templates/hooks/security_group/sdk_read_many_pre_build_request.go.tpl
@@ -1,0 +1,9 @@
+	if rm.requiredFieldsMissingFromReadManyInput(r) {
+		id, err := rm.getSecurityGroupID(ctx, r)
+		if err != nil {
+			return nil, err
+		}
+		if id != nil {
+			r.ko.Status.ID = id
+		}
+	}


### PR DESCRIPTION
fixes https://github.com/aws-controllers-k8s/community/issues/2561

Description of changes:
Controller assumes a security group does not exist if the `Status.ID` is empty. During adoption, users might want to adopt the resource by its name, as the ID is not trivial to guess (the security group ID is generated by AWS).

These changes are adding one API call only when the `Status.ID` is empty. Here we would make a single `DescribeSecurityGroups` call filtering by `name` and `VPC ID`, and populate the resource ID, to be used in subsequent API calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
