### PR TITLE
tests: Ready condition rename for ec2-controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.51.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.51.0 h1:dgf25lfg5r1kjJtHzdbNrMtQVloYn77WLYi1X41NXhw=
+github.com/gustavodiaz7722/ack-runtime v0.51.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@e7adf679cc3b78f7bc907fa7c11a13ce0d9c41a7
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@075991b980ffbc9177f0427270be707359240f89

--- a/test/e2e/tests/test_capacity_reservation.py
+++ b/test/e2e/tests/test_capacity_reservation.py
@@ -97,7 +97,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)
         assert capacity_reservation['TotalInstanceCount'] == 2
         
@@ -161,7 +161,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)
@@ -191,7 +191,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)

--- a/test/e2e/tests/test_dhcp_options.py
+++ b/test/e2e/tests/test_dhcp_options.py
@@ -176,7 +176,7 @@ class TestDhcpOptions:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         dhcp_options = ec2_validator.get_dhcp_options(resource_id)
@@ -206,7 +206,7 @@ class TestDhcpOptions:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         dhcp_options = ec2_validator.get_dhcp_options(resource_id)

--- a/test/e2e/tests/test_elastic_ip_address.py
+++ b/test/e2e/tests/test_elastic_ip_address.py
@@ -191,7 +191,7 @@ class TestElasticIPAddress:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         elastic_ip = get_address(ec2_client, resource_id)
@@ -221,7 +221,7 @@ class TestElasticIPAddress:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         elastic_ip = get_address(ec2_client, resource_id)

--- a/test/e2e/tests/test_instance.py
+++ b/test/e2e/tests/test_instance.py
@@ -212,7 +212,7 @@ class TestInstance:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         instance = get_instance(ec2_client, resource_id)
@@ -242,7 +242,7 @@ class TestInstance:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         instance = get_instance(ec2_client, resource_id)

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -231,7 +231,7 @@ class TestInternetGateway:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         internet_gateway = ec2_validator.get_internet_gateway(resource_id)
@@ -261,7 +261,7 @@ class TestInternetGateway:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         internet_gateway = ec2_validator.get_internet_gateway(resource_id)

--- a/test/e2e/tests/test_launch_template.py
+++ b/test/e2e/tests/test_launch_template.py
@@ -107,7 +107,7 @@ class TestLaunchTemplate:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
 
@@ -140,7 +140,7 @@ class TestLaunchTemplate:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
 
@@ -196,7 +196,7 @@ class TestLaunchTemplate:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
         assert 'tags' in cr['spec']

--- a/test/e2e/tests/test_nat_gateway.py
+++ b/test/e2e/tests/test_nat_gateway.py
@@ -59,7 +59,7 @@ def standard_elastic_address():
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
     # Check resource synced successfully
-    assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+    assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=10)
 
     assert cr is not None
     assert k8s.get_resource_exists(ref)
@@ -115,7 +115,7 @@ def simple_nat_gateway(standard_elastic_address, request):
     time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
     # Check resource synced successfully
-    assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+    assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
     assert cr is not None
     assert k8s.get_resource_exists(ref)
@@ -227,7 +227,7 @@ class TestNATGateway:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         nat_gateway = ec2_validator.get_nat_gateway(resource_id)

--- a/test/e2e/tests/test_network_acl.py
+++ b/test/e2e/tests/test_network_acl.py
@@ -234,7 +234,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # assert patched state
         resource = k8s.get_resource(ref)
@@ -249,7 +249,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Delete Network ACL 
         _, deleted = k8s.delete_custom_resource(ref)
@@ -325,7 +325,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         network_acl = ec2_validator.get_network_acl(resource_id)
@@ -349,7 +349,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         network_acl = ec2_validator.get_network_acl(resource_id)

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -116,10 +116,10 @@ class TestEC2References:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resources sync & resolve
-        assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(sg_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(subnet_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(sg_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(subnet_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(vpc_endpoint_ref, "Ready", "True", wait_periods=10)
 
         assert k8s.wait_on_condition(sg_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
         assert k8s.wait_on_condition(subnet_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
@@ -224,9 +224,9 @@ class TestEC2References:
 
         # Wait a few seconds so resources are synced
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(gateway_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(gateway_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(route_table_ref, "Ready", "True", wait_periods=10)
 
         assert k8s.wait_on_condition(gateway_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
         assert k8s.wait_on_condition(route_table_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
@@ -265,7 +265,7 @@ class TestEC2References:
         }
         k8s.patch_custom_resource(route_table_ref, route_table_update)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(route_table_ref, "Ready", "True", wait_periods=5)
         assert k8s.wait_on_condition(route_table_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
         
         # Ensure that the reference has not changed

--- a/test/e2e/tests/test_route_table.py
+++ b/test/e2e/tests/test_route_table.py
@@ -202,7 +202,7 @@ class TestRouteTable:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         route_table = ec2_validator.get_route_table(resource_id)
@@ -232,7 +232,7 @@ class TestRouteTable:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         route_table = ec2_validator.get_route_table(resource_id)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -238,7 +238,7 @@ class TestSecurityGroup:
         resource_id = cr["status"]["id"]
 
         # Check resource is synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Security Group exists in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -260,7 +260,7 @@ class TestSecurityGroup:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource gets into synced state
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # assert patched state
         cr = k8s.get_resource(ref)
@@ -303,7 +303,7 @@ class TestSecurityGroup:
         resource_id = cr["status"]["id"]
 
         # Check resource is synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Security Group exists in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -345,7 +345,7 @@ class TestSecurityGroup:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource gets into synced state
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check ingress and egress rules exist
         sg_group = ec2_validator.get_security_group(resource_id)
@@ -450,7 +450,7 @@ class TestSecurityGroup:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         security_group = ec2_validator.get_security_group(resource_id)
@@ -478,7 +478,7 @@ class TestSecurityGroup:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         security_group = ec2_validator.get_security_group(resource_id)
@@ -521,13 +521,13 @@ class TestSecurityGroup:
 
         # Check resources are synced successfully
         assert k8s.wait_on_condition(
-            ref_1, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_1, "Ready", "True", wait_periods=5
         )
         assert k8s.wait_on_condition(
-            ref_2, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_2, "Ready", "True", wait_periods=5
         )
         assert k8s.wait_on_condition(
-            ref_3, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_3, "Ready", "True", wait_periods=5
         )
 
         sg_group_1 = ec2_validator.get_security_group(resource_id_1)

--- a/test/e2e/tests/test_subnet.py
+++ b/test/e2e/tests/test_subnet.py
@@ -130,7 +130,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -156,7 +156,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         subnet = ec2_validator.get_subnet(resource_id)
         assert subnet['MapPublicIpOnLaunch'] == True
 
@@ -201,7 +201,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -246,7 +246,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         subnet = ec2_validator.get_subnet(resource_id)
@@ -277,7 +277,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         subnet = ec2_validator.get_subnet(resource_id)
@@ -334,7 +334,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -357,7 +357,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         assert ec2_validator.get_route_table_association(initial_rt_cr["status"]["routeTableID"], resource_id) is None
         assert ec2_validator.get_route_table_association(default_route_tables[1][1]["status"]["routeTableID"], resource_id) is not None

--- a/test/e2e/tests/test_subnet_adoption.py
+++ b/test/e2e/tests/test_subnet_adoption.py
@@ -89,6 +89,6 @@ class TestSubnetAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         subnet = ec2_validator.get_subnet(resource_id)
         assert subnet['MapPublicIpOnLaunch'] == mapPublicIPOnLaunch

--- a/test/e2e/tests/test_transit_gateway.py
+++ b/test/e2e/tests/test_transit_gateway.py
@@ -147,7 +147,7 @@ class TestTGW:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         transit_gateway = ec2_validator.get_transit_gateway(resource_id)
@@ -177,7 +177,7 @@ class TestTGW:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         transit_gateway = ec2_validator.get_transit_gateway(resource_id)

--- a/test/e2e/tests/test_transitgateway_vpc_attachment.py
+++ b/test/e2e/tests/test_transitgateway_vpc_attachment.py
@@ -99,7 +99,7 @@ class TestTransitGatewayVPCAttachment:
 
         assert k8s.wait_on_condition(
             ref,
-            "ACK.ResourceSynced",
+            "Ready",
             "True",
             wait_periods=WAIT_PERIOD,
         )
@@ -162,7 +162,7 @@ class TestTransitGatewayVPCAttachment:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=WAIT_PERIOD)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=WAIT_PERIOD)
 
         # Verify the update in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -182,7 +182,7 @@ class TestTransitGatewayVPCAttachment:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=WAIT_PERIOD)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=WAIT_PERIOD)
 
         # Verify the update in AWS
         ec2_validator = EC2Validator(ec2_client)

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -184,7 +184,7 @@ class TestVpc:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         vpc = ec2_validator.get_vpc(resource_id)
@@ -214,7 +214,7 @@ class TestVpc:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         vpc = ec2_validator.get_vpc(resource_id)
@@ -230,7 +230,7 @@ class TestVpc:
         resource = k8s.get_resource(ref)
         assert len(resource["spec"]["tags"]) == 0
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True
@@ -269,7 +269,7 @@ class TestVpc:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Check VPC exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc(resource_id)
@@ -284,7 +284,7 @@ class TestVpc:
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Make sure default security group rule is deleted
         assert not contains_default_sg_rule(ec2_client, resource_id)
 
@@ -482,7 +482,7 @@ class TestVpc:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Re-Validate CIDR Blocks State
         vpc = ec2_validator.get_vpc(resource_id)
         assert vpc['CidrBlockAssociationSet'][0]['CidrBlockState']['State'] == "associated"

--- a/test/e2e/tests/test_vpc_adoption.py
+++ b/test/e2e/tests/test_vpc_adoption.py
@@ -92,7 +92,7 @@ class TestVpcAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         vpc = ec2_validator.get_vpc(resource_id)
         assert len(vpc['CidrBlockAssociationSet']) == 2

--- a/test/e2e/tests/test_vpc_endpoint.py
+++ b/test/e2e/tests/test_vpc_endpoint.py
@@ -204,7 +204,7 @@ class TestVpcEndpoint:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
@@ -234,7 +234,7 @@ class TestVpcEndpoint:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
@@ -357,7 +357,7 @@ class TestVpcEndpoint:
 
         # Check resource synced successfully
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=5)
+            ref, "Ready", "True", wait_periods=5)
 
         # Verify the update in AWS
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)

--- a/test/e2e/tests/test_vpc_endpoint_service_configuration.py
+++ b/test/e2e/tests/test_vpc_endpoint_service_configuration.py
@@ -100,7 +100,7 @@ class TestVpcEndpointServiceConfiguration:
         # Check VPC Endpoint Service exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc_endpoint_service_configuration(resource_id)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
 
         # Check that the allowedPrincipal is properly set

--- a/test/e2e/tests/test_vpc_endpoint_service_configuration_adoption.py
+++ b/test/e2e/tests/test_vpc_endpoint_service_configuration_adoption.py
@@ -111,7 +111,7 @@ class TestVpcAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         updated_endpoint_service_config = ec2_validator.get_vpc_endpoint_service_configuration(resource_id)
         assert updated_endpoint_service_config is not None

--- a/test/e2e/tests/test_vpc_peering_connection.py
+++ b/test/e2e/tests/test_vpc_peering_connection.py
@@ -451,7 +451,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         vpc_peering_connection = ec2_validator.get_vpc_peering_connection(resource_id)
@@ -475,7 +475,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         vpc_peering_connection = ec2_validator.get_vpc_peering_connection(resource_id)
@@ -515,7 +515,7 @@ class TestVPCPeeringConnections:
 
         # Check resource synced successfully, after waiting for requeue after Patch Peering Options to True
         time.sleep(PATCH_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Peering Options in AWS
         aws_res = wait_for_vpc_peering_connection_peering_options(ec2_client, True, vpc_peering_connection_id)
@@ -539,7 +539,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated peering options
         latest_aws_res = wait_for_vpc_peering_connection_peering_options(ec2_client, False, vpc_peering_connection_id)


### PR DESCRIPTION
This PR updates test files to the Ready condition:

- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.