### PR TITLE
tests: Ready condition rename for ec2-controller

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-09-19T17:24:00Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-09-26T00:39:49Z"
+  build_hash: 9c388d9668ea19d0b1b65566d492c4f67c6e64c8
+  go_version: go1.24.7
+  version: 9c388d9-dirty
 api_directory_checksum: b32f97274be98ca3f4cf5cbf559258210c872946
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/crd/bases/ec2.services.k8s.aws_capacityreservations.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_capacityreservations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: capacityreservations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_dhcpoptions.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_dhcpoptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dhcpoptions.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_elasticipaddresses.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_elasticipaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: elasticipaddresses.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_flowlogs.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_flowlogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: flowlogs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_instances.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_instances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instances.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_internetgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_internetgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: internetgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: launchtemplates.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_natgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_natgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: natgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_networkacls.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_networkacls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: networkacls.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_routetables.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_routetables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routetables.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_securitygroups.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_securitygroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: securitygroups.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_subnets.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_subnets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnets.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_transitgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_transitgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgatewayvpcattachments.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpoints.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpointserviceconfigurations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcpeeringconnections.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcpeeringconnections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcpeeringconnections.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/go.mod
+++ b/go.mod
@@ -90,3 +90,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
+
+replace github.com/aws-controllers-k8s/runtime => github.com/gustavodiaz7722/ack-runtime v0.57.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/aws-controllers-k8s/runtime v0.52.0 h1:Q5UIAn6SSBr60t/DiU/zr6NLBlUuK2AG3yy2ma/9gDU=
-github.com/aws-controllers-k8s/runtime v0.52.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.35.0 h1:jTPxEJyzjSuuz0wB+302hr8Eu9KUI+Zv8zlujMGJpVI=
@@ -84,6 +82,8 @@ github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db h1:097atOisP2aRj7vFgY
 github.com/google/pprof v0.0.0-20241029153458-d1b30febd7db/go.mod h1:vavhavw2zAxS5dIdcRluK6cSGGPlZynqzFM8NdvU144=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gustavodiaz7722/ack-runtime v0.57.0 h1:85zJyvdPpzOTaWE0icljJcMRf0qlP0oWdOT05hMZ6Z0=
+github.com/gustavodiaz7722/ack-runtime v0.57.0/go.mod h1:OkUJN+Ds799JLYZsMJrO2vDJ4snxUeHK2MgrQHbU+Qc=
 github.com/itchyny/gojq v0.12.6 h1:VjaFn59Em2wTxDNGcrRkDK9ZHMNa8IksOgL13sLL4d0=
 github.com/itchyny/gojq v0.12.6/go.mod h1:ZHrkfu7A+RbZLy5J1/JKpS4poEqrzItSTGDItqsfP0A=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=

--- a/helm/crds/ec2.services.k8s.aws_capacityreservations.yaml
+++ b/helm/crds/ec2.services.k8s.aws_capacityreservations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: capacityreservations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_dhcpoptions.yaml
+++ b/helm/crds/ec2.services.k8s.aws_dhcpoptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dhcpoptions.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_elasticipaddresses.yaml
+++ b/helm/crds/ec2.services.k8s.aws_elasticipaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: elasticipaddresses.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_flowlogs.yaml
+++ b/helm/crds/ec2.services.k8s.aws_flowlogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: flowlogs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_instances.yaml
+++ b/helm/crds/ec2.services.k8s.aws_instances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instances.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_internetgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_internetgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: internetgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: launchtemplates.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_natgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_natgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: natgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_networkacls.yaml
+++ b/helm/crds/ec2.services.k8s.aws_networkacls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: networkacls.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_routetables.yaml
+++ b/helm/crds/ec2.services.k8s.aws_routetables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routetables.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_securitygroups.yaml
+++ b/helm/crds/ec2.services.k8s.aws_securitygroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: securitygroups.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_subnets.yaml
+++ b/helm/crds/ec2.services.k8s.aws_subnets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnets.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_transitgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_transitgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
+++ b/helm/crds/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgatewayvpcattachments.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpoints.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpointserviceconfigurations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcpeeringconnections.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcpeeringconnections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcpeeringconnections.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcs.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/dhcp_options/references.go
+++ b/pkg/resource/dhcp_options/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -134,8 +135,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -146,14 +149,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/instance/references.go
+++ b/pkg/resource/instance/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -149,8 +150,10 @@ func getReferencedResourceState_LaunchTemplate(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"LaunchTemplate",
 				namespace, name)
@@ -161,14 +164,14 @@ func getReferencedResourceState_LaunchTemplate(
 			"LaunchTemplate",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"LaunchTemplate",
 			namespace, name)
@@ -232,8 +235,10 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -244,14 +249,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)

--- a/pkg/resource/internet_gateway/references.go
+++ b/pkg/resource/internet_gateway/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -148,8 +149,10 @@ func getReferencedResourceState_RouteTable(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"RouteTable",
 				namespace, name)
@@ -160,14 +163,14 @@ func getReferencedResourceState_RouteTable(
 			"RouteTable",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"RouteTable",
 			namespace, name)
@@ -231,8 +234,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -243,14 +248,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/nat_gateway/references.go
+++ b/pkg/resource/nat_gateway/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -146,8 +147,10 @@ func getReferencedResourceState_ElasticIPAddress(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"ElasticIPAddress",
 				namespace, name)
@@ -158,14 +161,14 @@ func getReferencedResourceState_ElasticIPAddress(
 			"ElasticIPAddress",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"ElasticIPAddress",
 			namespace, name)
@@ -229,8 +232,10 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -241,14 +246,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)

--- a/pkg/resource/network_acl/references.go
+++ b/pkg/resource/network_acl/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -152,8 +153,10 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -164,14 +167,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)
@@ -235,8 +238,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -247,14 +252,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/route_table/references.go
+++ b/pkg/resource/route_table/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -224,8 +225,10 @@ func getReferencedResourceState_InternetGateway(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"InternetGateway",
 				namespace, name)
@@ -236,14 +239,14 @@ func getReferencedResourceState_InternetGateway(
 			"InternetGateway",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"InternetGateway",
 			namespace, name)
@@ -309,8 +312,10 @@ func getReferencedResourceState_NATGateway(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"NATGateway",
 				namespace, name)
@@ -321,14 +326,14 @@ func getReferencedResourceState_NATGateway(
 			"NATGateway",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"NATGateway",
 			namespace, name)
@@ -394,8 +399,10 @@ func getReferencedResourceState_TransitGateway(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"TransitGateway",
 				namespace, name)
@@ -406,14 +413,14 @@ func getReferencedResourceState_TransitGateway(
 			"TransitGateway",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"TransitGateway",
 			namespace, name)
@@ -479,8 +486,10 @@ func getReferencedResourceState_VPCEndpoint(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPCEndpoint",
 				namespace, name)
@@ -491,14 +500,14 @@ func getReferencedResourceState_VPCEndpoint(
 			"VPCEndpoint",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPCEndpoint",
 			namespace, name)
@@ -564,8 +573,10 @@ func getReferencedResourceState_VPCPeeringConnection(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPCPeeringConnection",
 				namespace, name)
@@ -576,14 +587,14 @@ func getReferencedResourceState_VPCPeeringConnection(
 			"VPCPeeringConnection",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPCPeeringConnection",
 			namespace, name)
@@ -647,8 +658,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -659,14 +672,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/security_group/references.go
+++ b/pkg/resource/security_group/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -224,8 +225,10 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -294,8 +297,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -306,14 +311,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/subnet/references.go
+++ b/pkg/resource/subnet/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -151,8 +152,10 @@ func getReferencedResourceState_RouteTable(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"RouteTable",
 				namespace, name)
@@ -163,14 +166,14 @@ func getReferencedResourceState_RouteTable(
 			"RouteTable",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"RouteTable",
 			namespace, name)
@@ -234,8 +237,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -246,14 +251,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/transit_gateway_vpc_attachment/references.go
+++ b/pkg/resource/transit_gateway_vpc_attachment/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -171,8 +172,10 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -183,14 +186,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)
@@ -254,8 +257,10 @@ func getReferencedResourceState_TransitGateway(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"TransitGateway",
 				namespace, name)
@@ -266,14 +271,14 @@ func getReferencedResourceState_TransitGateway(
 			"TransitGateway",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"TransitGateway",
 			namespace, name)
@@ -337,8 +342,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -349,14 +356,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/pkg/resource/vpc_endpoint/references.go
+++ b/pkg/resource/vpc_endpoint/references.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
@@ -179,8 +180,10 @@ func getReferencedResourceState_RouteTable(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"RouteTable",
 				namespace, name)
@@ -191,14 +194,14 @@ func getReferencedResourceState_RouteTable(
 			"RouteTable",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"RouteTable",
 			namespace, name)
@@ -267,8 +270,10 @@ func getReferencedResourceState_SecurityGroup(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"SecurityGroup",
 				namespace, name)
@@ -279,14 +284,14 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"SecurityGroup",
 			namespace, name)
@@ -355,8 +360,10 @@ func getReferencedResourceState_Subnet(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"Subnet",
 				namespace, name)
@@ -367,14 +374,14 @@ func getReferencedResourceState_Subnet(
 			"Subnet",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"Subnet",
 			namespace, name)
@@ -438,8 +445,10 @@ func getReferencedResourceState_VPC(
 	}
 	var refResourceTerminal bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
-			cond.Status == corev1.ConditionTrue {
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
+			cond.Status == corev1.ConditionFalse &&
+			cond.Reason != nil &&
+			*cond.Reason == ackcondition.TerminalReason {
 			return ackerr.ResourceReferenceTerminalFor(
 				"VPC",
 				namespace, name)
@@ -450,14 +459,14 @@ func getReferencedResourceState_VPC(
 			"VPC",
 			namespace, name)
 	}
-	var refResourceSynced bool
+	var refResourceReady bool
 	for _, cond := range obj.Status.Conditions {
-		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+		if cond.Type == ackv1alpha1.ConditionTypeReady &&
 			cond.Status == corev1.ConditionTrue {
-			refResourceSynced = true
+			refResourceReady = true
 		}
 	}
-	if !refResourceSynced {
+	if !refResourceReady {
 		return ackerr.ResourceReferenceNotSyncedFor(
 			"VPC",
 			namespace, name)

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@e7adf679cc3b78f7bc907fa7c11a13ce0d9c41a7
+acktest @ git+https://github.com/gustavodiaz7722/ack-test-infra.git@1adb046336bb1876db55d5a40d317e73b74251d8

--- a/test/e2e/tests/test_capacity_reservation.py
+++ b/test/e2e/tests/test_capacity_reservation.py
@@ -97,7 +97,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)
         assert capacity_reservation['TotalInstanceCount'] == 2
         
@@ -161,7 +161,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)
@@ -191,7 +191,7 @@ class TestCapacityReservation:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         capacity_reservation = ec2_validator.get_capacity_reservation(resource_id)

--- a/test/e2e/tests/test_dhcp_options.py
+++ b/test/e2e/tests/test_dhcp_options.py
@@ -20,7 +20,7 @@ import logging
 
 from acktest import tags
 from acktest.resources import random_suffix_name
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
@@ -121,12 +121,7 @@ class TestDhcpOptions:
         (ref, _) = simple_dhcp_options
 
         expected_msg = "InvalidParameterValue: Value (InvalidValue) for parameter name is invalid. Unknown DHCP option"
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # An error occurred (InvalidParameterValue) when calling the CreateDhcpOptions operation:
-        # Value (InvalidValue) for parameter value is invalid.
-        # Unknown DHCP option
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)
     
     @pytest.mark.resource_data({'tag_key': 'initialtagkey', 'tag_value': 'initialtagvalue'})
     def test_crud_tags(self, ec2_client, simple_dhcp_options):
@@ -176,7 +171,7 @@ class TestDhcpOptions:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         dhcp_options = ec2_validator.get_dhcp_options(resource_id)
@@ -206,7 +201,7 @@ class TestDhcpOptions:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         dhcp_options = ec2_validator.get_dhcp_options(resource_id)

--- a/test/e2e/tests/test_flow_logs.py
+++ b/test/e2e/tests/test_flow_logs.py
@@ -20,7 +20,7 @@ import logging
 
 from acktest import tags
 from acktest.resources import random_suffix_name
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
@@ -133,18 +133,11 @@ class TestFlowLogs:
         (ref, cr) = simple_flow_log
 
         expected_msg = "InvalidParameterValue: "
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # InvalidParameterValue: 1 validation error detected: Value 'S3' at 'resourceType'
-        # has an invalid format
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)
 
     @pytest.mark.resource_data({'resource_file': 'invalid/flow_log_invalid_parameter'})
     def test_terminal_condition_invalid_parameter(self, simple_flow_log):
         (ref, cr) = simple_flow_log
 
         expected_msg = "InvalidParameter: "
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # InvalidParameter: LogDestination can't be empty if LogGroupName is not provided.
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)

--- a/test/e2e/tests/test_instance.py
+++ b/test/e2e/tests/test_instance.py
@@ -212,7 +212,7 @@ class TestInstance:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         instance = get_instance(ec2_client, resource_id)
@@ -242,7 +242,7 @@ class TestInstance:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         instance = get_instance(ec2_client, resource_id)

--- a/test/e2e/tests/test_internet_gateway.py
+++ b/test/e2e/tests/test_internet_gateway.py
@@ -231,7 +231,7 @@ class TestInternetGateway:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         internet_gateway = ec2_validator.get_internet_gateway(resource_id)
@@ -261,7 +261,7 @@ class TestInternetGateway:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         internet_gateway = ec2_validator.get_internet_gateway(resource_id)

--- a/test/e2e/tests/test_launch_template.py
+++ b/test/e2e/tests/test_launch_template.py
@@ -107,7 +107,7 @@ class TestLaunchTemplate:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
 
@@ -140,7 +140,7 @@ class TestLaunchTemplate:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
 
@@ -196,7 +196,7 @@ class TestLaunchTemplate:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         cr = k8s.get_resource(ref)
         assert 'tags' in cr['spec']

--- a/test/e2e/tests/test_network_acl.py
+++ b/test/e2e/tests/test_network_acl.py
@@ -234,7 +234,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # assert patched state
         resource = k8s.get_resource(ref)
@@ -249,7 +249,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Delete Network ACL 
         _, deleted = k8s.delete_custom_resource(ref)
@@ -325,7 +325,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         network_acl = ec2_validator.get_network_acl(resource_id)
@@ -349,7 +349,7 @@ class TestNetworkACLs:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         network_acl = ec2_validator.get_network_acl(resource_id)

--- a/test/e2e/tests/test_references.py
+++ b/test/e2e/tests/test_references.py
@@ -116,14 +116,12 @@ class TestEC2References:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resources sync & resolve
-        assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(sg_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(subnet_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(sg_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(subnet_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(vpc_endpoint_ref, "Ready", "True", wait_periods=10)
 
-        assert k8s.wait_on_condition(sg_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
-        assert k8s.wait_on_condition(subnet_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
-        assert k8s.wait_on_condition(vpc_endpoint_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Acquire resource IDs
         vpc_endpoint_cr = k8s.get_resource(vpc_endpoint_ref)
@@ -224,12 +222,11 @@ class TestEC2References:
 
         # Wait a few seconds so resources are synced
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(vpc_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(gateway_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ResourceSynced", "True", wait_periods=10)
+        assert k8s.wait_on_condition(vpc_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(gateway_ref, "Ready", "True", wait_periods=5)
+        assert k8s.wait_on_condition(route_table_ref, "Ready", "True", wait_periods=10)
 
-        assert k8s.wait_on_condition(gateway_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ReferencesResolved", "True", wait_periods=10)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Acquire Internet Gateway ID
         gateway_cr = k8s.get_resource(gateway_ref)
@@ -265,8 +262,8 @@ class TestEC2References:
         }
         k8s.patch_custom_resource(route_table_ref, route_table_update)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ResourceSynced", "True", wait_periods=5)
-        assert k8s.wait_on_condition(route_table_ref, "ACK.ReferencesResolved", "True", wait_periods=5)
+        assert k8s.wait_on_condition(route_table_ref, "Ready", "True", wait_periods=5)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
         
         # Ensure that the reference has not changed
         route_table_cr = k8s.get_resource(route_table_ref)

--- a/test/e2e/tests/test_route_table.py
+++ b/test/e2e/tests/test_route_table.py
@@ -202,7 +202,7 @@ class TestRouteTable:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         route_table = ec2_validator.get_route_table(resource_id)
@@ -232,7 +232,7 @@ class TestRouteTable:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         route_table = ec2_validator.get_route_table(resource_id)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -238,7 +238,7 @@ class TestSecurityGroup:
         resource_id = cr["status"]["id"]
 
         # Check resource is synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Security Group exists in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -260,7 +260,7 @@ class TestSecurityGroup:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource gets into synced state
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # assert patched state
         cr = k8s.get_resource(ref)
@@ -303,7 +303,7 @@ class TestSecurityGroup:
         resource_id = cr["status"]["id"]
 
         # Check resource is synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Security Group exists in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -345,7 +345,7 @@ class TestSecurityGroup:
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
         # Check resource gets into synced state
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check ingress and egress rules exist
         sg_group = ec2_validator.get_security_group(resource_id)
@@ -450,7 +450,7 @@ class TestSecurityGroup:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         security_group = ec2_validator.get_security_group(resource_id)
@@ -478,7 +478,7 @@ class TestSecurityGroup:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         security_group = ec2_validator.get_security_group(resource_id)
@@ -521,13 +521,13 @@ class TestSecurityGroup:
 
         # Check resources are synced successfully
         assert k8s.wait_on_condition(
-            ref_1, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_1, "Ready", "True", wait_periods=5
         )
         assert k8s.wait_on_condition(
-            ref_2, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_2, "Ready", "True", wait_periods=5
         )
         assert k8s.wait_on_condition(
-            ref_3, "ACK.ResourceSynced", "True", wait_periods=5
+            ref_3, "Ready", "True", wait_periods=5
         )
 
         sg_group_1 = ec2_validator.get_security_group(resource_id_1)

--- a/test/e2e/tests/test_subnet.py
+++ b/test/e2e/tests/test_subnet.py
@@ -20,7 +20,7 @@ import logging
 
 from acktest import tags
 from acktest.resources import random_suffix_name
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
@@ -130,7 +130,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -156,7 +156,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         subnet = ec2_validator.get_subnet(resource_id)
         assert subnet['MapPublicIpOnLaunch'] == True
 
@@ -201,7 +201,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -246,7 +246,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         subnet = ec2_validator.get_subnet(resource_id)
@@ -277,7 +277,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         subnet = ec2_validator.get_subnet(resource_id)
@@ -334,7 +334,7 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         resource = k8s.get_resource(ref)
         resource_id = resource["status"]["subnetID"]
@@ -357,7 +357,7 @@ class TestSubnet:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         assert ec2_validator.get_route_table_association(initial_rt_cr["status"]["routeTableID"], resource_id) is None
         assert ec2_validator.get_route_table_association(default_route_tables[1][1]["status"]["routeTableID"], resource_id) is not None
@@ -400,9 +400,4 @@ class TestSubnet:
         assert k8s.get_resource_exists(ref)
 
         expected_msg = "InvalidParameterValue: Value (InvalidCidrBlock) for parameter cidrBlock is invalid. This is not a valid CIDR block."
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # An error occurred (InvalidParameterValue) when calling the CreateSubnet operation:
-        # Value (InvalidCidrBlock) for parameter cidrBlock is invalid.
-        # This is not a valid CIDR block.
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)

--- a/test/e2e/tests/test_subnet_adoption.py
+++ b/test/e2e/tests/test_subnet_adoption.py
@@ -89,6 +89,6 @@ class TestSubnetAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         subnet = ec2_validator.get_subnet(resource_id)
         assert subnet['MapPublicIpOnLaunch'] == mapPublicIPOnLaunch

--- a/test/e2e/tests/test_transit_gateway.py
+++ b/test/e2e/tests/test_transit_gateway.py
@@ -147,7 +147,7 @@ class TestTGW:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         transit_gateway = ec2_validator.get_transit_gateway(resource_id)
@@ -177,7 +177,7 @@ class TestTGW:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         transit_gateway = ec2_validator.get_transit_gateway(resource_id)

--- a/test/e2e/tests/test_transitgateway_vpc_attachment.py
+++ b/test/e2e/tests/test_transitgateway_vpc_attachment.py
@@ -99,7 +99,7 @@ class TestTransitGatewayVPCAttachment:
 
         assert k8s.wait_on_condition(
             ref,
-            "ACK.ResourceSynced",
+            "Ready",
             "True",
             wait_periods=WAIT_PERIOD,
         )
@@ -162,7 +162,7 @@ class TestTransitGatewayVPCAttachment:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=WAIT_PERIOD)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=WAIT_PERIOD)
 
         # Verify the update in AWS
         ec2_validator = EC2Validator(ec2_client)
@@ -182,7 +182,7 @@ class TestTransitGatewayVPCAttachment:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=WAIT_PERIOD)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=WAIT_PERIOD)
 
         # Verify the update in AWS
         ec2_validator = EC2Validator(ec2_client)

--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -20,7 +20,7 @@ import logging
 
 from acktest import tags
 from acktest.resources import random_suffix_name
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
 from e2e.conftest import simple_vpc
 from e2e.replacement_values import REPLACEMENT_VALUES
@@ -184,7 +184,7 @@ class TestVpc:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         vpc = ec2_validator.get_vpc(resource_id)
@@ -214,7 +214,7 @@ class TestVpc:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         vpc = ec2_validator.get_vpc(resource_id)
@@ -230,7 +230,7 @@ class TestVpc:
         resource = k8s.get_resource(ref)
         assert len(resource["spec"]["tags"]) == 0
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True
@@ -269,7 +269,7 @@ class TestVpc:
 
         time.sleep(CREATE_WAIT_AFTER_SECONDS)
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Check VPC exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc(resource_id)
@@ -284,7 +284,7 @@ class TestVpc:
         }
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Make sure default security group rule is deleted
         assert not contains_default_sg_rule(ec2_client, resource_id)
 
@@ -380,12 +380,7 @@ class TestVpc:
         assert k8s.get_resource_exists(ref)
 
         expected_msg = "InvalidParameterValue: Value (InvalidValue) for parameter cidrBlock is invalid. This is not a valid CIDR block."
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # An error occurred (InvalidParameterValue) when calling the CreateVpc operation:
-        # Value (dsfre) for parameter cidrBlock is invalid.
-        # This is not a valid CIDR block.
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)
     
     def test_vpc_creation_multiple_cidr(self,ec2_client):
         resource_name = random_suffix_name("vpc-ack-multicidr", 24)
@@ -482,7 +477,7 @@ class TestVpc:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
-        k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         # Re-Validate CIDR Blocks State
         vpc = ec2_validator.get_vpc(resource_id)
         assert vpc['CidrBlockAssociationSet'][0]['CidrBlockState']['State'] == "associated"

--- a/test/e2e/tests/test_vpc_adoption.py
+++ b/test/e2e/tests/test_vpc_adoption.py
@@ -92,7 +92,7 @@ class TestVpcAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         vpc = ec2_validator.get_vpc(resource_id)
         assert len(vpc['CidrBlockAssociationSet']) == 2

--- a/test/e2e/tests/test_vpc_endpoint.py
+++ b/test/e2e/tests/test_vpc_endpoint.py
@@ -21,7 +21,7 @@ import logging
 
 from acktest import tags
 from acktest.resources import random_suffix_name
-from acktest.k8s import resource as k8s
+from acktest.k8s import resource as k8s, condition
 from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
 from e2e.replacement_values import REPLACEMENT_VALUES
 from e2e.bootstrap_resources import get_bootstrap_resources
@@ -204,7 +204,7 @@ class TestVpcEndpoint:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for updated user tags; system tags should persist
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
@@ -234,7 +234,7 @@ class TestVpcEndpoint:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
         
         # Check for removed user tags; system tags should persist
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)
@@ -285,13 +285,7 @@ class TestVpcEndpoint:
         assert k8s.get_resource_exists(ref)
 
         expected_msg = "InvalidVpcId.Malformed: Invalid Id: 'MalformedVpcId'"
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        # Example condition message:
-        # InvalidVpcId.Malformed: Invalid Id: 'MalformedVpcId'
-        # (expecting 'vpc-...; the Id may only contain lowercase alphanumeric characters and a single dash')
-        # status code: 400, request id: dc3595c5-4e6e-48db-abf7-9bdcc76ad2a8
-        # This check only verifies the error message; the request hash is irrelevant and therefore can be ignored.
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)
 
     def test_terminal_condition_invalid_service(self):
         test_resource_values = REPLACEMENT_VALUES.copy()
@@ -322,8 +316,7 @@ class TestVpcEndpoint:
         assert k8s.get_resource_exists(ref)
 
         expected_msg = "InvalidServiceName: The Vpc Endpoint Service 'InvalidService' does not exist"
-        terminal_condition = k8s.get_resource_condition(ref, "ACK.Terminal")
-        assert expected_msg in terminal_condition['message']
+        condition.assert_terminal(ref, expected_msg)
 
     def test_update_subnets(self, ec2_client, modify_vpc_endpoint):
         (ref, cr) = modify_vpc_endpoint
@@ -357,7 +350,7 @@ class TestVpcEndpoint:
 
         # Check resource synced successfully
         assert k8s.wait_on_condition(
-            ref, "ACK.ResourceSynced", "True", wait_periods=5)
+            ref, "Ready", "True", wait_periods=5)
 
         # Verify the update in AWS
         vpc_endpoint = ec2_validator.get_vpc_endpoint(resource_id)

--- a/test/e2e/tests/test_vpc_endpoint_service_configuration.py
+++ b/test/e2e/tests/test_vpc_endpoint_service_configuration.py
@@ -100,7 +100,7 @@ class TestVpcEndpointServiceConfiguration:
         # Check VPC Endpoint Service exists in AWS
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc_endpoint_service_configuration(resource_id)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
 
         # Check that the allowedPrincipal is properly set

--- a/test/e2e/tests/test_vpc_endpoint_service_configuration_adoption.py
+++ b/test/e2e/tests/test_vpc_endpoint_service_configuration_adoption.py
@@ -111,7 +111,7 @@ class TestVpcAdoption:
         k8s.patch_custom_resource(ref, updates)
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
     
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         updated_endpoint_service_config = ec2_validator.get_vpc_endpoint_service_configuration(resource_id)
         assert updated_endpoint_service_config is not None

--- a/test/e2e/tests/test_vpc_peering_connection.py
+++ b/test/e2e/tests/test_vpc_peering_connection.py
@@ -451,7 +451,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated user tags; system tags should persist
         vpc_peering_connection = ec2_validator.get_vpc_peering_connection(resource_id)
@@ -475,7 +475,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for removed user tags; system tags should persist
         vpc_peering_connection = ec2_validator.get_vpc_peering_connection(resource_id)
@@ -515,7 +515,7 @@ class TestVPCPeeringConnections:
 
         # Check resource synced successfully, after waiting for requeue after Patch Peering Options to True
         time.sleep(PATCH_WAIT_AFTER_SECONDS)
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check Peering Options in AWS
         aws_res = wait_for_vpc_peering_connection_peering_options(ec2_client, True, vpc_peering_connection_id)
@@ -539,7 +539,7 @@ class TestVPCPeeringConnections:
         time.sleep(MODIFY_WAIT_AFTER_SECONDS)
 
         # Check resource synced successfully
-        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert k8s.wait_on_condition(ref, "Ready", "True", wait_periods=5)
 
         # Check for updated peering options
         latest_aws_res = wait_for_vpc_peering_connection_peering_options(ec2_client, False, vpc_peering_connection_id)


### PR DESCRIPTION
This PR updates controller src and test files to the Ready condition:

- Run code generation 
- Update test infra commit id 
- Replace `ACK.ResourceSynced` → `Ready`
- Replace `assert_synced` → `assert_ready`
- Replace `assert_not_synced` → `assert_not_ready`

Generated by helper script.

_No manual changes were made to the controller source; all changes were made via automated script._