### PR TITLE
fix: ignore errors when vpc does not have default security groups

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2025-09-25T16:19:07Z"
-  build_hash: 6b4211163dcc34776b01da9a18217bac0f4103fd
-  go_version: go1.24.6
-  version: v0.52.0
+  build_date: "2025-11-03T23:59:47Z"
+  build_hash: eaabefb6bd7b2be8a1baf4478f22b3310e6921c8
+  go_version: go1.25.1
+  version: v0.52.0-6-geaabefb
 api_directory_checksum: 5a5c93e3d4865ea08d8a47b2500551112ea831b9
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6
 generator_config_info:
-  file_checksum: 6d72b2e7d053535b6f6966348d3ac4e4535052cd
+  file_checksum: 220d17205c72ce425824ef99e0a79fbfc7c63ef2
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/config/crd/bases/ec2.services.k8s.aws_capacityreservations.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_capacityreservations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: capacityreservations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_dhcpoptions.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_dhcpoptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dhcpoptions.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_elasticipaddresses.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_elasticipaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: elasticipaddresses.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_flowlogs.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_flowlogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: flowlogs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_instances.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_instances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instances.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_internetgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_internetgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: internetgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: launchtemplates.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_natgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_natgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: natgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_networkacls.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_networkacls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: networkacls.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_routetables.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_routetables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routetables.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_securitygroups.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_securitygroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: securitygroups.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_subnets.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_subnets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnets.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_transitgateways.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_transitgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgatewayvpcattachments.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpoints.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpointserviceconfigurations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcpeeringconnections.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcpeeringconnections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcpeeringconnections.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_capacityreservations.yaml
+++ b/helm/crds/ec2.services.k8s.aws_capacityreservations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: capacityreservations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_dhcpoptions.yaml
+++ b/helm/crds/ec2.services.k8s.aws_dhcpoptions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: dhcpoptions.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_elasticipaddresses.yaml
+++ b/helm/crds/ec2.services.k8s.aws_elasticipaddresses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: elasticipaddresses.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_flowlogs.yaml
+++ b/helm/crds/ec2.services.k8s.aws_flowlogs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: flowlogs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_instances.yaml
+++ b/helm/crds/ec2.services.k8s.aws_instances.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: instances.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_internetgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_internetgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: internetgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: launchtemplates.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_natgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_natgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: natgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_networkacls.yaml
+++ b/helm/crds/ec2.services.k8s.aws_networkacls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: networkacls.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_routetables.yaml
+++ b/helm/crds/ec2.services.k8s.aws_routetables.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: routetables.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_securitygroups.yaml
+++ b/helm/crds/ec2.services.k8s.aws_securitygroups.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: securitygroups.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_subnets.yaml
+++ b/helm/crds/ec2.services.k8s.aws_subnets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: subnets.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_transitgateways.yaml
+++ b/helm/crds/ec2.services.k8s.aws_transitgateways.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgateways.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
+++ b/helm/crds/ec2.services.k8s.aws_transitgatewayvpcattachments.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: transitgatewayvpcattachments.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpoints.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcendpointserviceconfigurations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcendpointserviceconfigurations.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcpeeringconnections.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcpeeringconnections.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcpeeringconnections.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/ec2.services.k8s.aws_vpcs.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: vpcs.ec2.services.k8s.aws
 spec:
   group: ec2.services.k8s.aws

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: adoptedresources.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/helm/crds/services.k8s.aws_fieldexports.yaml
+++ b/helm/crds/services.k8s.aws_fieldexports.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: fieldexports.services.k8s.aws
 spec:
   group: services.k8s.aws

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -153,7 +153,6 @@ func needsRestart(ko *v1alpha1.Instance) bool {
 	return *ko.Status.State.Name == string(svcsdktypes.InstanceStateNameTerminated)
 }
 
-
 func setAdditionalFields(instance svcsdktypes.Instance, ko *v1alpha1.Instance) {
 	ko.Spec.SecurityGroupIDs = []*string{}
 	for _, group := range instance.SecurityGroups {

--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -15,7 +15,6 @@ package vpc
 
 import (
 	"context"
-	"fmt"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
@@ -383,6 +382,9 @@ func (rm *resourceManager) hasSecurityGroupDefaultRules(
 	if err != nil {
 		return false, err
 	}
+	if sgID == nil {
+		return false, nil
+	}
 
 	groupIDFilter := "group-id"
 	input := &svcsdk.DescribeSecurityGroupRulesInput{
@@ -472,6 +474,9 @@ func (rm *resourceManager) deleteSecurityGroupDefaultRules(
 	if err != nil {
 		return err
 	}
+	if sgID == nil {
+		return nil
+	}
 
 	ipRange := svcsdktypes.IpRange{
 		CidrIp: ptr("0.0.0.0/0"),
@@ -560,7 +565,7 @@ func (rm *resourceManager) getDefaultSGId(
 	}
 
 	if len(resp.SecurityGroups) == 0 {
-		return nil, fmt.Errorf("default security group not found")
+		return nil, nil
 	}
 
 	return resp.SecurityGroups[0].GroupId, nil


### PR DESCRIPTION
Issue [#2661](https://github.com/aws-controllers-k8s/community/issues/2661)

Description of changes:
Currently the controller has been returning an error if the VPC
securityGroup is not found. With this change, we will ignore errors if
we can't find the security group

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
