### PR TITLE
Add VPCEndpointService Ref support to VPCEndpoint

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -20,6 +20,7 @@ include an indication of the Open Source License under which that package is
 distributed. For any package *NOT* distributed under the terms of the Apache
 License version 2.0, we include the full text of the package's License below.
 
+* `github.com/aws-controllers-k8s/iam-controller`
 * `github.com/aws-controllers-k8s/runtime`
 * `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
@@ -34,34 +35,26 @@ License version 2.0, we include the full text of the package's License below.
 * `k8s.io/client-go`
 * `sigs.k8s.io/controller-runtime`
 
-### github.com/aws-controllers-k8s/runtime
+### github.com/aws-controllers-k8s/iam-controller
 
 License Identifier: Apache-2.0
 
 Subdependencies:
+* `github.com/aws-controllers-k8s/runtime`
+* `github.com/aws/aws-sdk-go`
 * `github.com/aws/aws-sdk-go-v2`
-* `github.com/aws/aws-sdk-go-v2/config`
-* `github.com/aws/aws-sdk-go-v2/credentials`
-* `github.com/aws/aws-sdk-go-v2/service/sts`
+* `github.com/aws/aws-sdk-go-v2/service/iam`
 * `github.com/aws/smithy-go`
-* `github.com/cenkalti/backoff/v4`
 * `github.com/go-logr/logr`
-* `github.com/go-logr/zapr`
-* `github.com/google/go-cmp`
-* `github.com/itchyny/gojq`
-* `github.com/jaypipes/envutil`
 * `github.com/micahhausler/aws-iam-policy`
-* `github.com/pkg/errors`
-* `github.com/prometheus/client_golang`
+* `github.com/samber/lo`
 * `github.com/spf13/pflag`
-* `github.com/stretchr/testify`
-* `go.uber.org/zap`
 * `k8s.io/api`
 * `k8s.io/apimachinery`
 * `k8s.io/client-go`
-* `k8s.io/klog/v2`
-* `k8s.io/utils`
 * `sigs.k8s.io/controller-runtime`
+* `github.com/aws/aws-sdk-go-v2/config`
+* `github.com/aws/aws-sdk-go-v2/credentials`
 * `github.com/aws/aws-sdk-go-v2/feature/ec2/imds`
 * `github.com/aws/aws-sdk-go-v2/internal/configsources`
 * `github.com/aws/aws-sdk-go-v2/internal/endpoints/v2`
@@ -70,36 +63,45 @@ Subdependencies:
 * `github.com/aws/aws-sdk-go-v2/service/internal/presigned-url`
 * `github.com/aws/aws-sdk-go-v2/service/sso`
 * `github.com/aws/aws-sdk-go-v2/service/ssooidc`
+* `github.com/aws/aws-sdk-go-v2/service/sts`
 * `github.com/beorn7/perks`
+* `github.com/cenkalti/backoff/v4`
 * `github.com/cespare/xxhash/v2`
 * `github.com/davecgh/go-spew`
 * `github.com/emicklei/go-restful/v3`
-* `github.com/evanphx/json-patch`
 * `github.com/evanphx/json-patch/v5`
 * `github.com/fsnotify/fsnotify`
 * `github.com/fxamacker/cbor/v2`
+* `github.com/go-logr/zapr`
 * `github.com/go-openapi/jsonpointer`
 * `github.com/go-openapi/jsonreference`
 * `github.com/go-openapi/swag`
 * `github.com/google/btree`
 * `github.com/google/gnostic-models`
+* `github.com/google/go-cmp`
 * `github.com/google/uuid`
+* `github.com/itchyny/gojq`
 * `github.com/itchyny/timefmt-go`
+* `github.com/jaypipes/envutil`
+* `github.com/jmespath/go-jmespath`
 * `github.com/josharian/intern`
 * `github.com/json-iterator/go`
 * `github.com/mailru/easyjson`
 * `github.com/modern-go/concurrent`
 * `github.com/modern-go/reflect2`
 * `github.com/munnerz/goautoneg`
+* `github.com/pkg/errors`
 * `github.com/pmezard/go-difflib`
+* `github.com/prometheus/client_golang`
 * `github.com/prometheus/client_model`
 * `github.com/prometheus/common`
 * `github.com/prometheus/procfs`
-* `github.com/stretchr/objx`
 * `github.com/x448/float16`
 * `go.uber.org/multierr`
+* `go.uber.org/zap`
 * `go.yaml.in/yaml/v2`
 * `go.yaml.in/yaml/v3`
+* `golang.org/x/exp`
 * `golang.org/x/net`
 * `golang.org/x/oauth2`
 * `golang.org/x/sync`
@@ -113,25 +115,27 @@ Subdependencies:
 * `gopkg.in/inf.v0`
 * `gopkg.in/yaml.v3`
 * `k8s.io/apiextensions-apiserver`
+* `k8s.io/klog/v2`
 * `k8s.io/kube-openapi`
+* `k8s.io/utils`
 * `sigs.k8s.io/json`
 * `sigs.k8s.io/randfill`
 * `sigs.k8s.io/structured-merge-diff/v6`
 * `sigs.k8s.io/yaml`
 
+#### github.com/aws-controllers-k8s/runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go
+
+License Identifier: Apache-2.0
+
 #### github.com/aws/aws-sdk-go-v2
 
 License Identifier: Apache-2.0
 
-#### github.com/aws/aws-sdk-go-v2/config
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/credentials
-
-License Identifier: Apache-2.0
-
-#### github.com/aws/aws-sdk-go-v2/service/sts
+#### github.com/aws/aws-sdk-go-v2/service/iam
 
 License Identifier: Apache-2.0
 
@@ -139,78 +143,31 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### github.com/cenkalti/backoff/v4
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2014 Cenk Altı
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software is furnished to do so,
-subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
-FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
-COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
 #### github.com/go-logr/logr
 
 License Identifier: Apache-2.0
 
-#### github.com/go-logr/zapr
-
-License Identifier: Apache-2.0
-
-#### github.com/google/go-cmp
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2017 The Go Authors. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/itchyny/gojq
+#### github.com/micahhausler/aws-iam-policy
 
 License Identifier: MIT
 
 The MIT License (MIT)
 
-Copyright (c) 2019-2021 itchyny
+Copyright (c) 2023, Micah Hausler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### github.com/samber/lo
+
+License Identifier: MIT
+
+MIT License
+
+Copyright (c) 2022 Samuel Berthe
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -229,56 +186,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-#### github.com/jaypipes/envutil
-
-License Identifier: Apache-2.0
-
-#### github.com/micahhausler/aws-iam-policy
-
-License Identifier: MIT
-
-The MIT License (MIT)
-
-Copyright (c) 2023, Micah Hausler
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#### github.com/pkg/errors
-
-License Identifier: BSD-2-Clause
-
-Copyright (c) 2015, Dave Cheney <dave@cheney.net>
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-#### github.com/prometheus/client_golang
-
-License Identifier: Apache-2.0
 
 #### github.com/spf13/pflag
 
@@ -313,54 +220,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#### github.com/stretchr/testify
-
-License Identifier: MIT
-
-MIT License
-
-Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-#### go.uber.org/zap
-
-Copyright (c) 2016-2017 Uber Technologies, Inc.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
 #### k8s.io/api
 
 License Identifier: Apache-2.0
@@ -373,15 +232,15 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-#### k8s.io/klog/v2
-
-License Identifier: Apache-2.0
-
-#### k8s.io/utils
-
-License Identifier: Apache-2.0
-
 #### sigs.k8s.io/controller-runtime
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/config
+
+License Identifier: Apache-2.0
+
+#### github.com/aws/aws-sdk-go-v2/credentials
 
 License Identifier: Apache-2.0
 
@@ -417,6 +276,10 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+#### github.com/aws/aws-sdk-go-v2/service/sts
+
+License Identifier: Apache-2.0
+
 #### github.com/beorn7/perks
 
 Copyright (C) 2013 Blake Mizerany
@@ -439,6 +302,31 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+#### github.com/cenkalti/backoff/v4
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #### github.com/cespare/xxhash/v2
 
@@ -513,36 +401,6 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-#### github.com/evanphx/json-patch
-
-License Identifier: BSD-3-Clause
-
-Copyright (c) 2014, Evan Phoenix
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without 
-modification, are permitted provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-* Neither the name of the Evan Phoenix nor the names of its contributors 
-  may be used to endorse or promote products derived from this software 
-  without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE 
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/evanphx/json-patch/v5
 
@@ -630,6 +488,10 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+#### github.com/go-logr/zapr
+
+License Identifier: Apache-2.0
+
 #### github.com/go-openapi/jsonpointer
 
 License Identifier: Apache-2.0
@@ -649,6 +511,38 @@ License Identifier: Apache-2.0
 #### github.com/google/gnostic-models
 
 License Identifier: Apache-2.0
+
+#### github.com/google/go-cmp
+
+License Identifier: BSD-3-Clause
+
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### github.com/google/uuid
 
@@ -682,6 +576,32 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/itchyny/gojq
+
+License Identifier: MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2019-2021 itchyny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 #### github.com/itchyny/timefmt-go
 
 License Identifier: MIT
@@ -707,6 +627,14 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+#### github.com/jaypipes/envutil
+
+License Identifier: Apache-2.0
+
+#### github.com/jmespath/go-jmespath
+
+License Identifier: Apache-2.0
 
 #### github.com/josharian/intern
 
@@ -814,6 +742,34 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/pkg/errors
+
+License Identifier: BSD-2-Clause
+
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 #### github.com/pmezard/go-difflib
 
 License Identifier: BSD-3-Clause
@@ -846,6 +802,10 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+#### github.com/prometheus/client_golang
+
+License Identifier: Apache-2.0
+
 #### github.com/prometheus/client_model
 
 License Identifier: Apache-2.0
@@ -857,33 +817,6 @@ License Identifier: Apache-2.0
 #### github.com/prometheus/procfs
 
 License Identifier: Apache-2.0
-
-#### github.com/stretchr/objx
-
-License Identifier: MIT
-
-The MIT License
-
-Copyright (c) 2014 Stretchr, Inc.
-Copyright (c) 2017-2018 objx contributors
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
 
 #### github.com/x448/float16
 
@@ -933,6 +866,28 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
+#### go.uber.org/zap
+
+Copyright (c) 2016-2017 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
 #### go.yaml.in/yaml/v2
 
 License Identifier: Apache-2.0
@@ -940,6 +895,38 @@ License Identifier: Apache-2.0
 #### go.yaml.in/yaml/v3
 
 License Identifier: Apache-2.0
+
+#### golang.org/x/exp
+
+License Identifier: BSD-3-Clause
+
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #### golang.org/x/net
 
@@ -1272,7 +1259,15 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
+#### k8s.io/klog/v2
+
+License Identifier: Apache-2.0
+
 #### k8s.io/kube-openapi
+
+License Identifier: Apache-2.0
+
+#### k8s.io/utils
 
 License Identifier: Apache-2.0
 
@@ -1531,18 +1526,9 @@ License Identifier: Apache-2.0
 
 License Identifier: Apache-2.0
 
-### github.com/aws/aws-sdk-go
 
-License Identifier: Apache-2.0
 
-Subdependencies:
-* `github.com/jmespath/go-jmespath`
-* `golang.org/x/net`
-* `golang.org/x/text`
 
-#### github.com/jmespath/go-jmespath
-
-License Identifier: Apache-2.0
 
 ### github.com/aws/aws-sdk-go-v2
 
@@ -1571,13 +1557,17 @@ Subdependencies:
 
 
 
-### github.com/samber/lo
+
+
+
+
+### github.com/stretchr/testify
 
 License Identifier: MIT
 
 MIT License
 
-Copyright (c) 2022 Samuel Berthe
+Copyright (c) 2012-2020 Mat Ryer, Tyler Bunnell and contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -1599,43 +1589,41 @@ SOFTWARE.
 
 
 Subdependencies:
-* `golang.org/x/exp`
-
-#### golang.org/x/exp
-
-License Identifier: BSD-3-Clause
-
-Copyright 2009 The Go Authors.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-
-   * Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-   * Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-   * Neither the name of Google LLC nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* `github.com/davecgh/go-spew`
+* `github.com/pmezard/go-difflib`
+* `github.com/stretchr/objx`
+* `gopkg.in/yaml.v3`
 
 
 
 
+
+#### github.com/stretchr/objx
+
+License Identifier: MIT
+
+The MIT License
+
+Copyright (c) 2014 Stretchr, Inc.
+Copyright (c) 2017-2018 objx contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-03-31T20:49:31Z"
+  build_date: "2026-04-10T13:50:44Z"
   build_hash: a9e2ceaadfc00a742e2ea2b6d6c68348f03e52a5
   go_version: go1.26.1
   version: v0.58.0-3-ga9e2cea
-api_directory_checksum: 3dca3992dafa3c55cf11ec49bf1b3084c01ae8d6
+api_directory_checksum: fdcd3e30ee779a5bb5a32821f71f03c4b892e0db
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.1
 generator_config_info:
-  file_checksum: 7d17e806218e4f31db5006de1aa270afb85e867e
+  file_checksum: 9cbf3a7602db9b48cf77cb59ee770aa71bef281e
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1168,6 +1168,11 @@ resources:
       ServiceNetworkARN:
         # ServiceNetworkARN is not supported in ModifyVpcEndpoint's input.
         is_immutable: true
+      ServiceName:
+        type: 'string'
+        references:
+          resource: VPCEndpointServiceConfiguration
+          path: Status.ServiceName
     exceptions:
       terminal_codes:
         - InvalidVpcId.Malformed

--- a/apis/v1alpha1/vpc_endpoint.go
+++ b/apis/v1alpha1/vpc_endpoint.go
@@ -54,12 +54,12 @@ type VPCEndpointSpec struct {
 	// default security group for the VPC.
 	SecurityGroupIDs  []*string                                  `json:"securityGroupIDs,omitempty"`
 	SecurityGroupRefs []*ackv1alpha1.AWSResourceReferenceWrapper `json:"securityGroupRefs,omitempty"`
-	// The name of the endpoint service.
-	ServiceName *string `json:"serviceName,omitempty"`
+	ServiceName       *string                                    `json:"serviceName,omitempty"`
 	// The Amazon Resource Name (ARN) of a service network that will be associated
 	// with the VPC endpoint of type service-network.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
-	ServiceNetworkARN *string `json:"serviceNetworkARN,omitempty"`
+	ServiceNetworkARN *string                                  `json:"serviceNetworkARN,omitempty"`
+	ServiceRef        *ackv1alpha1.AWSResourceReferenceWrapper `json:"serviceRef,omitempty"`
 	// The Region where the service is hosted. The default is the current Region.
 	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	ServiceRegion *string `json:"serviceRegion,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -30274,6 +30274,11 @@ func (in *VPCEndpointSpec) DeepCopyInto(out *VPCEndpointSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ServiceRef != nil {
+		in, out := &in.ServiceRef, &out.ServiceRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ServiceRegion != nil {
 		in, out := &in.ServiceRegion, &out.ServiceRegion
 		*out = new(string)

--- a/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -131,7 +131,6 @@ spec:
                   type: object
                 type: array
               serviceName:
-                description: The name of the endpoint service.
                 type: string
               serviceNetworkARN:
                 description: |-
@@ -141,6 +140,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              serviceRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               serviceRegion:
                 description: The Region where the service is hosted. The default is
                   the current Region.

--- a/generator.yaml
+++ b/generator.yaml
@@ -1168,6 +1168,11 @@ resources:
       ServiceNetworkARN:
         # ServiceNetworkARN is not supported in ModifyVpcEndpoint's input.
         is_immutable: true
+      ServiceName:
+        type: 'string'
+        references:
+          resource: VPCEndpointServiceConfiguration
+          path: Status.ServiceName
     exceptions:
       terminal_codes:
         - InvalidVpcId.Malformed

--- a/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
+++ b/helm/crds/ec2.services.k8s.aws_vpcendpoints.yaml
@@ -131,7 +131,6 @@ spec:
                   type: object
                 type: array
               serviceName:
-                description: The name of the endpoint service.
                 type: string
               serviceNetworkARN:
                 description: |-
@@ -141,6 +140,23 @@ spec:
                 x-kubernetes-validations:
                 - message: Value is immutable once set
                   rule: self == oldSelf
+              serviceRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               serviceRegion:
                 description: The Region where the service is hosted. The default is
                   the current Region.

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -108,6 +108,9 @@ func newResourceDelta(
 			delta.Add("Spec.ServiceNetworkARN", a.ko.Spec.ServiceNetworkARN, b.ko.Spec.ServiceNetworkARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ServiceRef, b.ko.Spec.ServiceRef) {
+		delta.Add("Spec.ServiceRef", a.ko.Spec.ServiceRef, b.ko.Spec.ServiceRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ServiceRegion, b.ko.Spec.ServiceRegion) {
 		delta.Add("Spec.ServiceRegion", a.ko.Spec.ServiceRegion, b.ko.Spec.ServiceRegion)
 	} else if a.ko.Spec.ServiceRegion != nil && b.ko.Spec.ServiceRegion != nil {

--- a/pkg/resource/vpc_endpoint/references.go
+++ b/pkg/resource/vpc_endpoint/references.go
@@ -45,6 +45,10 @@ func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) ack
 		ko.Spec.SecurityGroupIDs = nil
 	}
 
+	if ko.Spec.ServiceRef != nil {
+		ko.Spec.ServiceName = nil
+	}
+
 	if len(ko.Spec.SubnetRefs) > 0 {
 		ko.Spec.SubnetIDs = nil
 	}
@@ -84,6 +88,12 @@ func (rm *resourceManager) ResolveReferences(
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForServiceName(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForSubnetIDs(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -109,6 +119,10 @@ func validateReferenceFields(ko *svcapitypes.VPCEndpoint) error {
 
 	if len(ko.Spec.SecurityGroupRefs) > 0 && len(ko.Spec.SecurityGroupIDs) > 0 {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("SecurityGroupIDs", "SecurityGroupRefs")
+	}
+
+	if ko.Spec.ServiceRef != nil && ko.Spec.ServiceName != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ServiceName", "ServiceRef")
 	}
 
 	if len(ko.Spec.SubnetRefs) > 0 && len(ko.Spec.SubnetIDs) > 0 {
@@ -296,6 +310,89 @@ func getReferencedResourceState_SecurityGroup(
 			"SecurityGroup",
 			namespace, name,
 			"Status.ID")
+	}
+	return nil
+}
+
+// resolveReferenceForServiceName reads the resource referenced
+// from ServiceRef field and sets the ServiceName
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForServiceName(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.VPCEndpoint,
+) (hasReferences bool, err error) {
+	if ko.Spec.ServiceRef != nil && ko.Spec.ServiceRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ServiceRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ServiceRef")
+		}
+		namespace := ko.ObjectMeta.GetNamespace()
+		if arr.Namespace != nil && *arr.Namespace != "" {
+			namespace = *arr.Namespace
+		}
+		obj := &svcapitypes.VPCEndpointServiceConfiguration{}
+		if err := getReferencedResourceState_VPCEndpointServiceConfiguration(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ServiceName = (*string)(obj.Status.ServiceName)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_VPCEndpointServiceConfiguration looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_VPCEndpointServiceConfiguration(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.VPCEndpointServiceConfiguration,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"VPCEndpointServiceConfiguration",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"VPCEndpointServiceConfiguration",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"VPCEndpointServiceConfiguration",
+			namespace, name)
+	}
+	if obj.Status.ServiceName == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"VPCEndpointServiceConfiguration",
+			namespace, name,
+			"Status.ServiceName")
 	}
 	return nil
 }


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
Adding a VPCEndpointService and to the VPCEndpoint crd,
referencing ec2 VPCEndpointService by ServiceName

Structure:
```
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: VPCEndpoint
metadata:
  name: test
spec:
  serviceRef:
    from:
      name: test
...
```
Tested locally, everything works as intended, and existing functionality is not impacted.

Thanks for taking the time to review! 
I appreciate any feedback on this PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.