### PR TITLE
Release artifacts for release v1.12.0

### DIFF
--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/ec2-controller
-  newTag: 1.11.1
+  newTag: 1.12.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: ec2-chart
 description: A Helm chart for the ACK service controller for Amazon Elastic Cloud Compute (EC2)
-version: 1.11.1
-appVersion: 1.11.1
+version: 1.12.0
+appVersion: 1.12.0
 home: https://github.com/aws-controllers-k8s/ec2-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/ec2-controller:1.11.1".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/ec2-controller:1.12.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/ec2-controller
-  tag: 1.11.1
+  tag: 1.12.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:
Release version bump for v1.12.0 which includes EgressOnlyInternetGateway support (#326).

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.