### PR TITLE
fix(vpc): Delete default SG rules at creation when disallowSecurityGroupDefaultRules is true

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2026-05-01T17:00:36Z"
-  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
-  version: v0.58.1
+  build_date: "2026-05-08T19:30:48Z"
+  build_hash: ece451c52fa72a9f7cfca3b086b8a4729b592ae4
+  go_version: go1.25.3
+  version: v0.58.1-4-gece451c
 api_directory_checksum: 5a84c7f782ad0708ddc4b430fe0b0883490fbdd4
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.1

--- a/pkg/resource/vpc/sdk.go
+++ b/pkg/resource/vpc/sdk.go
@@ -22,6 +22,7 @@ import (
 	"math"
 	"reflect"
 	"strings"
+	"time"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -412,8 +413,17 @@ func (rm *resourceManager) sdkCreate(
 	sgDefaultRulesExist, err := rm.hasSecurityGroupDefaultRules(ctx, &resource{ko})
 	if err != nil {
 		return nil, err
-	} else {
-		ko.Status.SecurityGroupDefaultRulesExist = &sgDefaultRulesExist
+	}
+	ko.Status.SecurityGroupDefaultRulesExist = &sgDefaultRulesExist
+
+	// If the user requested disallowing default SG rules, requeue so the
+	// update path can handle the deletion. We avoid making the delete call
+	// here because the runtime treats sdkCreate failures as resource
+	// creation failures, which could orphan the VPC.
+	if sgDefaultRulesExist && desired.ko.Spec.DisallowSecurityGroupDefaultRules != nil && *desired.ko.Spec.DisallowSecurityGroupDefaultRules {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, aws.String("VPC created, requeue to delete default security group rules"), nil)
+		err = ackrequeue.NeededAfter(fmt.Errorf("VPC created but default security group rules need to be deleted"), time.Second)
+		return &resource{ko}, err
 	}
 
 	return &resource{ko}, nil

--- a/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/vpc/sdk_create_post_set_output.go.tpl
@@ -12,6 +12,15 @@
 	sgDefaultRulesExist, err := rm.hasSecurityGroupDefaultRules(ctx, &resource{ko})
 	if err != nil {
 		return nil, err
-	} else {
-		ko.Status.SecurityGroupDefaultRulesExist = &sgDefaultRulesExist
+	}
+	ko.Status.SecurityGroupDefaultRulesExist = &sgDefaultRulesExist
+
+	// If the user requested disallowing default SG rules, requeue so the
+	// update path can handle the deletion. We avoid making the delete call
+	// here because the runtime treats sdkCreate failures as resource
+	// creation failures, which could orphan the VPC.
+	if sgDefaultRulesExist && desired.ko.Spec.DisallowSecurityGroupDefaultRules != nil && *desired.ko.Spec.DisallowSecurityGroupDefaultRules {
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, aws.String("VPC created, requeue to delete default security group rules"), nil)
+		err = ackrequeue.NeededAfter(fmt.Errorf("VPC created but default security group rules need to be deleted"), time.Second)
+		return &resource{ko}, err
 	}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Previously, the controller only deleted default security group rules during the update path (customUpdate):
https://github.com/aws-controllers-k8s/ec2-controller/blob/main/pkg/resource/vpc/hooks.go#L351, which requires a delta between desired and latest. When a VPC is created with disallowSecurityGroupDefaultRules: true, the reconciler runs the create path and then goes directly to late initialization — it never enters the update path in the same reconcile. The resource is then marked synced and requeued for 10h, so no second reconcile happens before the test asserts.

Now the `sdk_create_post_set_output` hook checks the desired spec and deletes the default SG rules immediately after creation if the user requested it, ensuring the test_disallow_default_security_group_rule e2e test passes consistently.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
