### PR TITLE
fix(test): Fix flaky VPC e2e tests for SG rule deletion

### DIFF
--- a/test/e2e/tests/test_vpc.py
+++ b/test/e2e/tests/test_vpc.py
@@ -249,7 +249,9 @@ class TestVpc:
         (ref, cr) = simple_vpc
         resource_id = cr["status"]["vpcID"]
 
-        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+        # Wait for the controller to finish reconciling (SG rule deletion
+        # happens inline during creation but the controller may be busy)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
 
         # Check VPC exists in AWS
         ec2_validator = EC2Validator(ec2_client)


### PR DESCRIPTION
Issue #, if available:

Description of changes:

The test_crud_tags test failed because the ACK runtime's EnsureTags persist ACK system tags (services.k8s.aws/controller-version, services.k8s.aws/namespace) into spec.tags during reconciliation. Filter out tags with the `services.k8s.aws/` prefix before asserting user tag counts and values.
    
The `test_disallow_default_security_group_rule` test failed because the controller was too busy processing other resources to complete the reconcile within the fixed 10-second sleep. Replace `time.sleep` with `wait_on_condition("ACK.ResourceSynced", "True")` which polls until the controller signals reconciliation is complete.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
