### PR TITLE
fix: prevent false drift in VPCEndpoint and SecurityGroup resources

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:06:17Z"
+  build_date: "2026-06-26T00:28:30Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
   go_version: go1.26.4
   version: v0.60.0
@@ -7,7 +7,7 @@ api_directory_checksum: dead0af9d288ce1313d7213fd1a7b2b2bbd293bc
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: a50caae859bf5df3e86b4c706fc0bedbab997890
+  file_checksum: 356fef026d8d9ae2f06f5a15a400933e7264b7c6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -884,9 +884,13 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       EgressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       Rules:
         from:
           operation: DescribeSecurityGroupRules
@@ -937,6 +941,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        template_path: hooks/security_group/delta_pre_compare.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -1189,8 +1195,9 @@ resources:
   VpcEndpoint:
     fields:
       PolicyDocument:
-        late_initialize: {}
         is_iam_policy: true
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         from:
           operation: CreateTags
@@ -1220,6 +1227,8 @@ resources:
       ServiceRegion:
         # ServiceRegion is not supported in ModifyVpcEndpoint's input.
         is_immutable: true
+        late_initialize:
+          skip_incomplete_check: {}
       ServiceNetworkARN:
         # ServiceNetworkARN is not supported in ModifyVpcEndpoint's input.
         is_immutable: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -884,9 +884,13 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       EgressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       Rules:
         from:
           operation: DescribeSecurityGroupRules
@@ -937,6 +941,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        template_path: hooks/security_group/delta_pre_compare.go.tpl
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:
@@ -1189,8 +1195,9 @@ resources:
   VpcEndpoint:
     fields:
       PolicyDocument:
-        late_initialize: {}
         is_iam_policy: true
+        late_initialize:
+          skip_incomplete_check: {}
       Tags:
         from:
           operation: CreateTags
@@ -1220,6 +1227,8 @@ resources:
       ServiceRegion:
         # ServiceRegion is not supported in ModifyVpcEndpoint's input.
         is_immutable: true
+        late_initialize:
+          skip_incomplete_check: {}
       ServiceNetworkARN:
         # ServiceNetworkARN is not supported in ModifyVpcEndpoint's input.
         is_immutable: true

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -41,26 +41,32 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	if len(a.ko.Spec.IngressRules) != len(b.ko.Spec.IngressRules) {
+		delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
+	} else {
+		for _, aRule := range a.ko.Spec.IngressRules {
+			if !containsRule(b.ko.Spec.IngressRules, aRule) {
+				delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
+				break
+			}
+		}
+	}
+	if len(a.ko.Spec.EgressRules) != len(b.ko.Spec.EgressRules) {
+		delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
+	} else {
+		for _, aRule := range a.ko.Spec.EgressRules {
+			if !containsRule(b.ko.Spec.EgressRules, aRule) {
+				delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
+				break
+			}
+		}
+	}
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 	} else if a.ko.Spec.Description != nil && b.ko.Spec.Description != nil {
 		if *a.ko.Spec.Description != *b.ko.Spec.Description {
 			delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
-		}
-	}
-	if len(a.ko.Spec.EgressRules) != len(b.ko.Spec.EgressRules) {
-		delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
-	} else if len(a.ko.Spec.EgressRules) > 0 {
-		if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.EgressRules, b.ko.Spec.EgressRules) {
-			delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
-		}
-	}
-	if len(a.ko.Spec.IngressRules) != len(b.ko.Spec.IngressRules) {
-		delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
-	} else if len(a.ko.Spec.IngressRules) > 0 {
-		if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.IngressRules, b.ko.Spec.IngressRules) {
-			delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {

--- a/pkg/resource/vpc_endpoint/manager.go
+++ b/pkg/resource/vpc_endpoint/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcendpoints,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=vpcendpoints/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"PolicyDocument"}
+var lateInitializeFieldNames = []string{"PolicyDocument", "ServiceRegion"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -251,10 +251,6 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
-	ko := rm.concreteResource(res).ko.DeepCopy()
-	if ko.Spec.PolicyDocument == nil {
-		return true
-	}
 	return false
 }
 
@@ -268,6 +264,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.PolicyDocument != nil && latestKo.Spec.PolicyDocument == nil {
 		latestKo.Spec.PolicyDocument = observedKo.Spec.PolicyDocument
+	}
+	if observedKo.Spec.ServiceRegion != nil && latestKo.Spec.ServiceRegion == nil {
+		latestKo.Spec.ServiceRegion = observedKo.Spec.ServiceRegion
 	}
 	return &resource{latestKo}
 }

--- a/templates/hooks/security_group/delta_pre_compare.go.tpl
+++ b/templates/hooks/security_group/delta_pre_compare.go.tpl
@@ -1,0 +1,20 @@
+	if len(a.ko.Spec.IngressRules) != len(b.ko.Spec.IngressRules) {
+		delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
+	} else {
+		for _, aRule := range a.ko.Spec.IngressRules {
+			if !containsRule(b.ko.Spec.IngressRules, aRule) {
+				delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
+				break
+			}
+		}
+	}
+	if len(a.ko.Spec.EgressRules) != len(b.ko.Spec.EgressRules) {
+		delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
+	} else {
+		for _, aRule := range a.ko.Spec.EgressRules {
+			if !containsRule(b.ko.Spec.EgressRules, aRule) {
+				delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
+				break
+			}
+		}
+	}


### PR DESCRIPTION
Description of changes:
VPCEndpoint: Add is_iam_policy for PolicyDocument (semantic JSON compare
instead of string compare), add late_initialize for ServiceRegion.

SecurityGroup: Replace order-sensitive DeepEqual for IngressRules/
EgressRules with set-based containsRule comparison via delta_pre_compare
hook, preventing false diffs from rule ordering differences.

Resolves aws-controllers-k8s/community#2695
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
