### PR TITLE
Mark VPCEndpoint.PolicyDocument as is_iam_policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-17T17:29:38Z"
+  build_date: "2026-06-19T02:46:40Z"
   build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
-  go_version: go1.26.2
+  go_version: go1.26.0
   version: v0.59.1-7-g2970ca9
 api_directory_checksum: dead0af9d288ce1313d7213fd1a7b2b2bbd293bc
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 700ce138d1425ec18cefe65887ec9d5ceb73698e
+  file_checksum: a50caae859bf5df3e86b4c706fc0bedbab997890
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -1190,6 +1190,7 @@ resources:
     fields:
       PolicyDocument:
         late_initialize: {}
+        is_iam_policy: true
       Tags:
         from:
           operation: CreateTags

--- a/generator.yaml
+++ b/generator.yaml
@@ -1190,6 +1190,7 @@ resources:
     fields:
       PolicyDocument:
         late_initialize: {}
+        is_iam_policy: true
       Tags:
         from:
           operation: CreateTags

--- a/pkg/resource/vpc_endpoint/delta.go
+++ b/pkg/resource/vpc_endpoint/delta.go
@@ -63,7 +63,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument) {
 		delta.Add("Spec.PolicyDocument", a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument)
 	} else if a.ko.Spec.PolicyDocument != nil && b.ko.Spec.PolicyDocument != nil {
-		if *a.ko.Spec.PolicyDocument != *b.ko.Spec.PolicyDocument {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.PolicyDocument, *b.ko.Spec.PolicyDocument); err != nil || !equal {
 			delta.Add("Spec.PolicyDocument", a.ko.Spec.PolicyDocument, b.ko.Spec.PolicyDocument)
 		}
 	}

--- a/test/e2e/resources/vpc_endpoint.yaml
+++ b/test/e2e/resources/vpc_endpoint.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   serviceName: $SERVICE_NAME
   vpcID: $VPC_ID
+  policyDocument: |
+    {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"*","Resource":"*"}]}
   tags:
     - key: $TAG_KEY
       value: $TAG_VALUE

--- a/test/e2e/tests/test_vpc_endpoint.py
+++ b/test/e2e/tests/test_vpc_endpoint.py
@@ -147,6 +147,17 @@ class TestVpcEndpoint:
         ec2_validator = EC2Validator(ec2_client)
         ec2_validator.assert_vpc_endpoint(resource_id)
 
+        # Update policyDocument with a different policy to verify
+        # updates still work with is_iam_policy comparison
+        updates = {
+            "spec": {
+                "policyDocument": '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":"*","Action":"s3:GetObject","Resource":"arn:aws:s3:::*"}]}'
+            }
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
         # Delete k8s resource
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True


### PR DESCRIPTION
## Summary

Adds is_iam_policy: true annotation to VpcEndpoint.PolicyDocument field in generator.yaml.

## Problem

The VPCEndpoint.PolicyDocument field accepts an IAM policy document (JSON). Without the is_iam_policy annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the AWS API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_iam_policy: true to VpcEndpoint.PolicyDocument in generator.yaml
- Regenerated controller code - delta.go now uses IAMPolicyDocumentEqual for semantic comparison
- Added policyDocument field to existing vpc_endpoint.yaml test fixture

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test now exercises the policy field via the updated fixture

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.