### PR TITLE
fix: key LaunchTemplate by Name so adopt-or-create works

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:06:17Z"
+  build_date: "2026-06-25T20:15:05Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
   go_version: go1.26.4
   version: v0.60.0
-api_directory_checksum: dead0af9d288ce1313d7213fd1a7b2b2bbd293bc
+api_directory_checksum: f3dc66047191e81e67448e9a31443f5fc464b31c
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: a50caae859bf5df3e86b4c706fc0bedbab997890
+  file_checksum: 3e55ae55dba695cf4bb245b827a6407e723a660c
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -145,6 +145,10 @@ ignore:
     - CreateLaunchTemplateInput.DryRun
     - CreateLaunchTemplateInput.ClientToken
     - CreateLaunchTemplateInput.TagSpecifications
+    # LaunchTemplate is keyed by Name. DescribeLaunchTemplates rejects requests
+    # that set both names and IDs, so drop the ID-based filter and always read
+    # by Name (Status.ID is populated from the response).
+    - DescribeLaunchTemplatesInput.LaunchTemplateIds
     - CreateLaunchTemplateVersionInput.LaunchTemplateData.TagSpecifications
     - LaunchTemplateEbsBlockDeviceRequest.VolumeInitializationRate
     - LaunchTemplateEbsBlockDevice.VolumeInitializationRate
@@ -665,13 +669,16 @@ resources:
             LaunchTemplateId: ID
         DescribeLaunchTemplates:
           input_fields:
-            LaunchTemplateIds: ID
+            LaunchTemplateNames: Name
           output_fields:
+            LaunchTemplateId: ID
             LatestVersionNumber: LatestVersion
             DefaultVersionNumber: DefaultVersion
     fields:
-      ID:
+      Name:
         is_primary_key: true
+        is_immutable: true
+      ID:
         print:
           name: ID
       Tags:
@@ -682,6 +689,12 @@ resources:
         from:
           operation: ModifyLaunchTemplate
           path: LaunchTemplate.DefaultVersionNumber
+        # DefaultVersion is server-populated (defaults to 1 on create). Late
+        # initialize it so an adopted template's observed version doesn't show
+        # as a spurious delta against an unset desired value, which would drive
+        # updateDefaultVersion into a "field DefaultVersion is required" error.
+        late_initialize:
+          skip_incomplete_check: {}
       Data.ElasticInferenceAccelerators.Type:
         go_tag: json:"type,omitempty"
       Data.ElasticGPUSpecifications.Type:

--- a/apis/v1alpha1/launch_template.go
+++ b/apis/v1alpha1/launch_template.go
@@ -33,6 +33,7 @@ type LaunchTemplateSpec struct {
 	// A name for the launch template.
 	//
 	// Regex Pattern: `^[a-zA-Z0-9\(\)\.\-/_]+$`
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	Name *string `json:"name"`
 	// The tags. The value parameter is required, but if you don't want the tag

--- a/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
@@ -616,6 +616,9 @@ spec:
 
                   Regex Pattern: `^[a-zA-Z0-9\(\)\.\-/_]+$`
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               tags:
                 description: |-
                   The tags. The value parameter is required, but if you don't want the tag

--- a/generator.yaml
+++ b/generator.yaml
@@ -145,6 +145,10 @@ ignore:
     - CreateLaunchTemplateInput.DryRun
     - CreateLaunchTemplateInput.ClientToken
     - CreateLaunchTemplateInput.TagSpecifications
+    # LaunchTemplate is keyed by Name. DescribeLaunchTemplates rejects requests
+    # that set both names and IDs, so drop the ID-based filter and always read
+    # by Name (Status.ID is populated from the response).
+    - DescribeLaunchTemplatesInput.LaunchTemplateIds
     - CreateLaunchTemplateVersionInput.LaunchTemplateData.TagSpecifications
     - LaunchTemplateEbsBlockDeviceRequest.VolumeInitializationRate
     - LaunchTemplateEbsBlockDevice.VolumeInitializationRate
@@ -665,13 +669,16 @@ resources:
             LaunchTemplateId: ID
         DescribeLaunchTemplates:
           input_fields:
-            LaunchTemplateIds: ID
+            LaunchTemplateNames: Name
           output_fields:
+            LaunchTemplateId: ID
             LatestVersionNumber: LatestVersion
             DefaultVersionNumber: DefaultVersion
     fields:
-      ID:
+      Name:
         is_primary_key: true
+        is_immutable: true
+      ID:
         print:
           name: ID
       Tags:
@@ -682,6 +689,12 @@ resources:
         from:
           operation: ModifyLaunchTemplate
           path: LaunchTemplate.DefaultVersionNumber
+        # DefaultVersion is server-populated (defaults to 1 on create). Late
+        # initialize it so an adopted template's observed version doesn't show
+        # as a spurious delta against an unset desired value, which would drive
+        # updateDefaultVersion into a "field DefaultVersion is required" error.
+        late_initialize:
+          skip_incomplete_check: {}
       Data.ElasticInferenceAccelerators.Type:
         go_tag: json:"type,omitempty"
       Data.ElasticGPUSpecifications.Type:

--- a/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
@@ -616,6 +616,9 @@ spec:
 
                   Regex Pattern: `^[a-zA-Z0-9\(\)\.\-/_]+$`
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               tags:
                 description: |-
                   The tags. The value parameter is required, but if you don't want the tag

--- a/pkg/resource/launch_template/hooks.go
+++ b/pkg/resource/launch_template/hooks.go
@@ -43,9 +43,16 @@ func (rm *resourceManager) setLatestLaunchTemplateAttributes(
 		exit(err)
 	}()
 
-	input, err := rm.newListLaunchTemplateVersionRequestPayload(r)
+	input, err := rm.newListLaunchTemplateVersionRequestPayload(&resource{ko})
 	if err != nil {
 		return err
+	}
+	// Without a template identifier, DescribeLaunchTemplateVersions returns
+	// versions across every template in the account, which would clobber this
+	// resource's LaunchTemplateData with unrelated data. Skip the lookup until
+	// the identifier is known (it is populated from sdkFind's response).
+	if input.LaunchTemplateId == nil && input.LaunchTemplateName == nil {
+		return nil
 	}
 
 	var resp *svcsdk.DescribeLaunchTemplateVersionsOutput
@@ -239,6 +246,12 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 	}
 }
 
+// checkForMissingRequiredFields gates sdkFind. LaunchTemplate is keyed by its
+// unique Name, so a DescribeLaunchTemplates lookup is possible as soon as
+// Spec.Name is set - even before Status.ID is populated. This lets
+// adopt-or-create discover a pre-existing template by name instead of looping
+// on CreateLaunchTemplate AlreadyExistsException. The generated default would
+// gate on Status.ID, which is nil until the first successful read.
 func (rm *resourceManager) checkForMissingRequiredFields(r *resource) bool {
-	return r.ko.Status.ID == nil
+	return r.ko.Spec.Name == nil
 }

--- a/pkg/resource/launch_template/manager.go
+++ b/pkg/resource/launch_template/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=launchtemplates,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=launchtemplates/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"DefaultVersion"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -260,7 +260,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.DefaultVersion != nil && latestKo.Spec.DefaultVersion == nil {
+		latestKo.Spec.DefaultVersion = observedKo.Spec.DefaultVersion
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.

--- a/pkg/resource/launch_template/resource.go
+++ b/pkg/resource/launch_template/resource.go
@@ -90,18 +90,18 @@ func (r *resource) SetIdentifiers(identifier *ackv1alpha1.AWSIdentifiers) error 
 	if identifier.NameOrID == "" {
 		return ackerrors.MissingNameIdentifier
 	}
-	r.ko.Status.ID = &identifier.NameOrID
+	r.ko.Spec.Name = &identifier.NameOrID
 
 	return nil
 }
 
 // PopulateResourceFromAnnotation populates the fields passed from adoption annotation
 func (r *resource) PopulateResourceFromAnnotation(fields map[string]string) error {
-	primaryKey, ok := fields["id"]
+	primaryKey, ok := fields["name"]
 	if !ok {
-		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: id"))
+		return ackerrors.NewTerminalError(fmt.Errorf("required field missing: name"))
 	}
-	r.ko.Status.ID = &primaryKey
+	r.ko.Spec.Name = &primaryKey
 
 	return nil
 }

--- a/pkg/resource/launch_template/sdk.go
+++ b/pkg/resource/launch_template/sdk.go
@@ -112,6 +112,11 @@ func (rm *resourceManager) sdkFind(
 		} else {
 			ko.Status.LatestVersion = nil
 		}
+		if elem.LaunchTemplateId != nil {
+			ko.Status.ID = elem.LaunchTemplateId
+		} else {
+			ko.Status.ID = nil
+		}
 		if elem.Operator != nil {
 			f6 := &svcapitypes.OperatorResponse{}
 			if elem.Operator.Managed != nil {
@@ -172,10 +177,10 @@ func (rm *resourceManager) newListRequestPayload(
 ) (*svcsdk.DescribeLaunchTemplatesInput, error) {
 	res := &svcsdk.DescribeLaunchTemplatesInput{}
 
-	if r.ko.Status.ID != nil {
+	if r.ko.Spec.Name != nil {
 		f2 := []string{}
-		f2 = append(f2, *r.ko.Status.ID)
-		res.LaunchTemplateIds = f2
+		f2 = append(f2, *r.ko.Spec.Name)
+		res.LaunchTemplateNames = f2
 	}
 
 	return res, nil
@@ -1050,7 +1055,14 @@ func (rm *resourceManager) sdkUpdate(
 	// We want to update the defaultVersion after we create the new
 	// version if needed.
 	// Wondering how this works? find out in https://go.dev/play/p/10QSDg2xbTB
-	if delta.DifferentAt("Spec.DefaultVersion") {
+	//
+	// Only call ModifyLaunchTemplate when the user actually set a desired
+	// DefaultVersion. An adopted template reports its server-side default
+	// (e.g. 1) while the desired spec leaves it unset, producing a spurious
+	// delta; without this guard updateDefaultVersion would fail with
+	// "field DefaultVersion is required" before late initialization can
+	// populate it.
+	if delta.DifferentAt("Spec.DefaultVersion") && desired.ko.Spec.DefaultVersion != nil {
 		defer func() {
 			err = rm.updateDefaultVersion(ctx, desired)
 		}()

--- a/templates/hooks/launch_template/sdk_update_pre_build_request.go.tpl
+++ b/templates/hooks/launch_template/sdk_update_pre_build_request.go.tpl
@@ -9,7 +9,14 @@
 	// We want to update the defaultVersion after we create the new
 	// version if needed.
 	// Wondering how this works? find out in https://go.dev/play/p/10QSDg2xbTB
-	if delta.DifferentAt("Spec.DefaultVersion") {
+	//
+	// Only call ModifyLaunchTemplate when the user actually set a desired
+	// DefaultVersion. An adopted template reports its server-side default
+	// (e.g. 1) while the desired spec leaves it unset, producing a spurious
+	// delta; without this guard updateDefaultVersion would fail with
+	// "field DefaultVersion is required" before late initialization can
+	// populate it.
+	if delta.DifferentAt("Spec.DefaultVersion") && desired.ko.Spec.DefaultVersion != nil {
 		defer func() {
 			err = rm.updateDefaultVersion(ctx, desired)
 		}()

--- a/test/e2e/resources/launch_template_adopt_or_create.yaml
+++ b/test/e2e/resources/launch_template_adopt_or_create.yaml
@@ -1,0 +1,13 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: LaunchTemplate
+metadata:
+  name: $LAUNCH_TEMPLATE_NAME
+  annotations:
+    services.k8s.aws/adoption-policy: adopt-or-create
+    services.k8s.aws/deletion-policy: delete
+spec:
+  name: $LAUNCH_TEMPLATE_NAME
+  data:
+    instanceType: t2.nano
+    monitoring:
+      enabled: false

--- a/test/e2e/tests/test_launch_template_adoption.py
+++ b/test/e2e/tests/test_launch_template_adoption.py
@@ -1,0 +1,88 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You may
+# not use this file except in compliance with the License. A copy of the
+# License is located at
+#
+# 	 http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is distributed
+# on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+# express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+"""Integration tests for the LaunchTemplate adopt-or-create flow.
+"""
+
+import pytest
+import time
+import logging
+
+from acktest.resources import random_suffix_name
+from acktest.k8s import resource as k8s
+from e2e import service_marker, CRD_GROUP, CRD_VERSION, load_ec2_resource
+from e2e.replacement_values import REPLACEMENT_VALUES
+from e2e.tests.helper import EC2Validator
+
+RESOURCE_PLURAL = "launchtemplates"
+
+CREATE_WAIT_AFTER_SECONDS = 10
+DELETE_WAIT_AFTER_SECONDS = 10
+
+
+@pytest.fixture
+def adopt_or_create_existing_launch_template(request, ec2_client):
+    resource_name = random_suffix_name("lt-adopt", 24)
+    existing = ec2_client.create_launch_template(
+        LaunchTemplateName=resource_name,
+        LaunchTemplateData={"InstanceType": "t2.nano"},
+    )
+    existing_id = existing["LaunchTemplate"]["LaunchTemplateId"]
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["LAUNCH_TEMPLATE_NAME"] = resource_name
+
+    resource_data = load_ec2_resource(
+        "launch_template_adopt_or_create",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr, existing_id)
+
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+    except:
+        pass
+    try:
+        ec2_client.delete_launch_template(LaunchTemplateId=existing_id)
+    except:
+        pass
+
+
+@service_marker
+@pytest.mark.canary
+class TestLaunchTemplateAdoption:
+    def test_adopt_or_create_by_name(self, ec2_client, adopt_or_create_existing_launch_template):
+        (ref, cr, existing_id) = adopt_or_create_existing_launch_template
+
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
+
+        cr = k8s.get_resource(ref)
+        assert cr["status"]["id"] == existing_id
+        assert cr["spec"]["data"]["instanceType"] == "t2.nano"
+
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_launch_template(existing_id)


### PR DESCRIPTION
Description of changes:
LaunchTemplate was keyed by Status.ID, so sdkFind short-circuited to
NotFound whenever the ID was unset and adopt-or-create looped on
CreateLaunchTemplate AlreadyExistsException. Make the unique Name the
primary key (immutable, since AWS cannot rename templates) so sdkFind
reads by name and adopts a pre-existing template. Also stop
DescribeLaunchTemplateVersions from running unfiltered when the template
identifier is unknown, which would clobber Spec.Data with unrelated data.

Resolves aws-controllers-k8s/community#2932

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
