### PR TITLE
feat(launch_template): support data.tagSpecifications to tag instances at launch

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -3,11 +3,11 @@ ack_generate_info:
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
   go_version: go1.26.4
   version: v0.60.0
-api_directory_checksum: dead0af9d288ce1313d7213fd1a7b2b2bbd293bc
+api_directory_checksum: 0538f325c4ca2a28b05a8d6ae96be71423d97638
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: a50caae859bf5df3e86b4c706fc0bedbab997890
+  file_checksum: 1af8f1dd1311b61ced9097002dc8fede7fccfa53
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -145,7 +145,6 @@ ignore:
     - CreateLaunchTemplateInput.DryRun
     - CreateLaunchTemplateInput.ClientToken
     - CreateLaunchTemplateInput.TagSpecifications
-    - CreateLaunchTemplateVersionInput.LaunchTemplateData.TagSpecifications
     - LaunchTemplateEbsBlockDeviceRequest.VolumeInitializationRate
     - LaunchTemplateEbsBlockDevice.VolumeInitializationRate
     - InstanceRequirementsRequest.RequireEncryptionInTransit

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -5285,6 +5285,7 @@ type RequestLaunchTemplateData struct {
 	RAMDiskID             *string                                     `json:"ramDiskID,omitempty"`
 	SecurityGroupIDs      []*string                                   `json:"securityGroupIDs,omitempty"`
 	SecurityGroups        []*string                                   `json:"securityGroups,omitempty"`
+	TagSpecifications     []*LaunchTemplateTagSpecificationRequest    `json:"tagSpecifications,omitempty"`
 	UserData              *string                                     `json:"userData,omitempty"`
 }
 

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -21815,6 +21815,17 @@ func (in *RequestLaunchTemplateData) DeepCopyInto(out *RequestLaunchTemplateData
 			}
 		}
 	}
+	if in.TagSpecifications != nil {
+		in, out := &in.TagSpecifications, &out.TagSpecifications
+		*out = make([]*LaunchTemplateTagSpecificationRequest, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(LaunchTemplateTagSpecificationRequest)
+				(*in).DeepCopyInto(*out)
+			}
+		}
+	}
 	if in.UserData != nil {
 		in, out := &in.UserData, &out.UserData
 		*out = new(string)

--- a/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_launchtemplates.yaml
@@ -602,6 +602,26 @@ spec:
                     items:
                       type: string
                     type: array
+                  tagSpecifications:
+                    items:
+                      description: |-
+                        The tags specification for the resources that are created during instance
+                        launch.
+                      properties:
+                        resourceType:
+                          type: string
+                        tags:
+                          items:
+                            description: Describes a tag.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
                   userData:
                     type: string
                 type: object

--- a/generator.yaml
+++ b/generator.yaml
@@ -145,7 +145,6 @@ ignore:
     - CreateLaunchTemplateInput.DryRun
     - CreateLaunchTemplateInput.ClientToken
     - CreateLaunchTemplateInput.TagSpecifications
-    - CreateLaunchTemplateVersionInput.LaunchTemplateData.TagSpecifications
     - LaunchTemplateEbsBlockDeviceRequest.VolumeInitializationRate
     - LaunchTemplateEbsBlockDevice.VolumeInitializationRate
     - InstanceRequirementsRequest.RequireEncryptionInTransit

--- a/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
+++ b/helm/crds/ec2.services.k8s.aws_launchtemplates.yaml
@@ -602,6 +602,26 @@ spec:
                     items:
                       type: string
                     type: array
+                  tagSpecifications:
+                    items:
+                      description: |-
+                        The tags specification for the resources that are created during instance
+                        launch.
+                      properties:
+                        resourceType:
+                          type: string
+                        tags:
+                          items:
+                            description: Describes a tag.
+                            properties:
+                              key:
+                                type: string
+                              value:
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
                   userData:
                     type: string
                 type: object

--- a/pkg/resource/launch_template/delta.go
+++ b/pkg/resource/launch_template/delta.go
@@ -758,6 +758,13 @@ func newResourceDelta(
 				delta.Add("Spec.Data.SecurityGroups", a.ko.Spec.Data.SecurityGroups, b.ko.Spec.Data.SecurityGroups)
 			}
 		}
+		if len(a.ko.Spec.Data.TagSpecifications) != len(b.ko.Spec.Data.TagSpecifications) {
+			delta.Add("Spec.Data.TagSpecifications", a.ko.Spec.Data.TagSpecifications, b.ko.Spec.Data.TagSpecifications)
+		} else if len(a.ko.Spec.Data.TagSpecifications) > 0 {
+			if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.Data.TagSpecifications, b.ko.Spec.Data.TagSpecifications) {
+				delta.Add("Spec.Data.TagSpecifications", a.ko.Spec.Data.TagSpecifications, b.ko.Spec.Data.TagSpecifications)
+			}
+		}
 		if ackcompare.HasNilDifference(a.ko.Spec.Data.UserData, b.ko.Spec.Data.UserData) {
 			delta.Add("Spec.Data.UserData", a.ko.Spec.Data.UserData, b.ko.Spec.Data.UserData)
 		} else if a.ko.Spec.Data.UserData != nil && b.ko.Spec.Data.UserData != nil {

--- a/pkg/resource/launch_template/sdk.go
+++ b/pkg/resource/launch_template/sdk.go
@@ -1011,6 +1011,31 @@ func (rm *resourceManager) newCreateRequestPayload(
 		if r.ko.Spec.Data.SecurityGroups != nil {
 			f0.SecurityGroups = aws.ToStringSlice(r.ko.Spec.Data.SecurityGroups)
 		}
+		if r.ko.Spec.Data.TagSpecifications != nil {
+			f0f29 := []svcsdktypes.LaunchTemplateTagSpecificationRequest{}
+			for _, f0f29iter := range r.ko.Spec.Data.TagSpecifications {
+				f0f29elem := &svcsdktypes.LaunchTemplateTagSpecificationRequest{}
+				if f0f29iter.ResourceType != nil {
+					f0f29elem.ResourceType = svcsdktypes.ResourceType(*f0f29iter.ResourceType)
+				}
+				if f0f29iter.Tags != nil {
+					f0f29elemf1 := []svcsdktypes.Tag{}
+					for _, f0f29elemf1iter := range f0f29iter.Tags {
+						f0f29elemf1elem := &svcsdktypes.Tag{}
+						if f0f29elemf1iter.Key != nil {
+							f0f29elemf1elem.Key = f0f29elemf1iter.Key
+						}
+						if f0f29elemf1iter.Value != nil {
+							f0f29elemf1elem.Value = f0f29elemf1iter.Value
+						}
+						f0f29elemf1 = append(f0f29elemf1, *f0f29elemf1elem)
+					}
+					f0f29elem.Tags = f0f29elemf1
+				}
+				f0f29 = append(f0f29, *f0f29elem)
+			}
+			f0.TagSpecifications = f0f29
+		}
 		if r.ko.Spec.Data.UserData != nil {
 			f0.UserData = r.ko.Spec.Data.UserData
 		}
@@ -1695,6 +1720,31 @@ func (rm *resourceManager) sdkUpdate(
 		}
 		if resp.LaunchTemplateVersion.LaunchTemplateData.SecurityGroups != nil {
 			f2.SecurityGroups = aws.StringSlice(resp.LaunchTemplateVersion.LaunchTemplateData.SecurityGroups)
+		}
+		if resp.LaunchTemplateVersion.LaunchTemplateData.TagSpecifications != nil {
+			f2f30 := []*svcapitypes.LaunchTemplateTagSpecificationRequest{}
+			for _, f2f30iter := range resp.LaunchTemplateVersion.LaunchTemplateData.TagSpecifications {
+				f2f30elem := &svcapitypes.LaunchTemplateTagSpecificationRequest{}
+				if f2f30iter.ResourceType != "" {
+					f2f30elem.ResourceType = aws.String(string(f2f30iter.ResourceType))
+				}
+				if f2f30iter.Tags != nil {
+					f2f30elemf1 := []*svcapitypes.Tag{}
+					for _, f2f30elemf1iter := range f2f30iter.Tags {
+						f2f30elemf1elem := &svcapitypes.Tag{}
+						if f2f30elemf1iter.Key != nil {
+							f2f30elemf1elem.Key = f2f30elemf1iter.Key
+						}
+						if f2f30elemf1iter.Value != nil {
+							f2f30elemf1elem.Value = f2f30elemf1iter.Value
+						}
+						f2f30elemf1 = append(f2f30elemf1, f2f30elemf1elem)
+					}
+					f2f30elem.Tags = f2f30elemf1
+				}
+				f2f30 = append(f2f30, f2f30elem)
+			}
+			f2.TagSpecifications = f2f30
 		}
 		if resp.LaunchTemplateVersion.LaunchTemplateData.UserData != nil {
 			f2.UserData = resp.LaunchTemplateVersion.LaunchTemplateData.UserData
@@ -2474,6 +2524,31 @@ func (rm *resourceManager) newUpdateRequestPayload(
 		if r.ko.Spec.Data.SecurityGroups != nil {
 			f2.SecurityGroups = aws.ToStringSlice(r.ko.Spec.Data.SecurityGroups)
 		}
+		if r.ko.Spec.Data.TagSpecifications != nil {
+			f2f29 := []svcsdktypes.LaunchTemplateTagSpecificationRequest{}
+			for _, f2f29iter := range r.ko.Spec.Data.TagSpecifications {
+				f2f29elem := &svcsdktypes.LaunchTemplateTagSpecificationRequest{}
+				if f2f29iter.ResourceType != nil {
+					f2f29elem.ResourceType = svcsdktypes.ResourceType(*f2f29iter.ResourceType)
+				}
+				if f2f29iter.Tags != nil {
+					f2f29elemf1 := []svcsdktypes.Tag{}
+					for _, f2f29elemf1iter := range f2f29iter.Tags {
+						f2f29elemf1elem := &svcsdktypes.Tag{}
+						if f2f29elemf1iter.Key != nil {
+							f2f29elemf1elem.Key = f2f29elemf1iter.Key
+						}
+						if f2f29elemf1iter.Value != nil {
+							f2f29elemf1elem.Value = f2f29elemf1iter.Value
+						}
+						f2f29elemf1 = append(f2f29elemf1, *f2f29elemf1elem)
+					}
+					f2f29elem.Tags = f2f29elemf1
+				}
+				f2f29 = append(f2f29, *f2f29elem)
+			}
+			f2.TagSpecifications = f2f29
+		}
 		if r.ko.Spec.Data.UserData != nil {
 			f2.UserData = r.ko.Spec.Data.UserData
 		}
@@ -3244,6 +3319,31 @@ func (rm *resourceManager) setRequestLaunchTemplateData(
 	}
 	if resp.SecurityGroups != nil {
 		res.SecurityGroups = aws.StringSlice(resp.SecurityGroups)
+	}
+	if resp.TagSpecifications != nil {
+		resf30 := []*svcapitypes.LaunchTemplateTagSpecificationRequest{}
+		for _, resf30iter := range resp.TagSpecifications {
+			resf30elem := &svcapitypes.LaunchTemplateTagSpecificationRequest{}
+			if resf30iter.ResourceType != "" {
+				resf30elem.ResourceType = aws.String(string(resf30iter.ResourceType))
+			}
+			if resf30iter.Tags != nil {
+				resf30elemf1 := []*svcapitypes.Tag{}
+				for _, resf30elemf1iter := range resf30iter.Tags {
+					resf30elemf1elem := &svcapitypes.Tag{}
+					if resf30elemf1iter.Key != nil {
+						resf30elemf1elem.Key = resf30elemf1iter.Key
+					}
+					if resf30elemf1iter.Value != nil {
+						resf30elemf1elem.Value = resf30elemf1iter.Value
+					}
+					resf30elemf1 = append(resf30elemf1, resf30elemf1elem)
+				}
+				resf30elem.Tags = resf30elemf1
+			}
+			resf30 = append(resf30, resf30elem)
+		}
+		res.TagSpecifications = resf30
 	}
 	if resp.UserData != nil {
 		res.UserData = resp.UserData

--- a/test/e2e/resources/launch_template_tag_specifications.yaml
+++ b/test/e2e/resources/launch_template_tag_specifications.yaml
@@ -1,0 +1,13 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: LaunchTemplate
+metadata:
+  name: $LAUNCH_TEMPLATE_NAME
+spec:
+  name: $LAUNCH_TEMPLATE_NAME
+  data:
+    instanceType: t2.nano
+    tagSpecifications:
+      - resourceType: instance
+        tags:
+          - key: $INSTANCE_TAG_KEY
+            value: $INSTANCE_TAG_VALUE

--- a/test/e2e/tests/test_launch_template.py
+++ b/test/e2e/tests/test_launch_template.py
@@ -107,6 +107,45 @@ def launch_template_with_nested_virtualization(request):
         pass
 
 
+@pytest.fixture
+def launch_template_with_tag_specifications(request):
+    resource_name = random_suffix_name("lt-tag-spec", 24)
+    resource_file = "launch_template_tag_specifications"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["LAUNCH_TEMPLATE_NAME"] = resource_name
+    replacements["INSTANCE_TAG_KEY"] = "instance-tag-key"
+    replacements["INSTANCE_TAG_VALUE"] = "instance-tag-value"
+
+    # Load LaunchTemplate CR
+    resource_data = load_ec2_resource(
+        resource_file,
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    # Create k8s resource
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+        resource_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    # Try to delete, if doesn't already exist
+    try:
+        _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+        assert deleted
+    except:
+        pass
+
+
 @service_marker
 @pytest.mark.canary
 class TestLaunchTemplate:
@@ -317,3 +356,52 @@ class TestLaunchTemplate:
         # Verify CR spec reflects the updated value
         cr = k8s.get_resource(ref)
         assert cr["spec"]["data"]["cpuOptions"]["nestedVirtualization"] == "disabled"
+
+    def test_data_tag_specifications(self, ec2_client, launch_template_with_tag_specifications):
+        """Test that a LaunchTemplate can be created with data.tagSpecifications so
+        that tags are propagated onto the instances launched from the template.
+
+        Validates:
+        - LaunchTemplate is created with data.tagSpecifications
+        - The LaunchTemplateData stored in AWS contains the instance TagSpecifications
+        - The CR spec retains data.tagSpecifications after reconciliation
+
+        References: https://github.com/aws-controllers-k8s/community/issues/2836
+        """
+        (ref, cr) = launch_template_with_tag_specifications
+
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+        # Check resource synced successfully
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+        resource_id = cr["status"]["id"]
+
+        # Verify LaunchTemplate exists in AWS
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_launch_template(resource_id)
+
+        # Confirm the LaunchTemplateData persisted in AWS carries the instance
+        # tag specification we requested.
+        lt_version = ec2_validator.get_launch_template_version(
+            launch_template_id=resource_id, version="1"
+        )
+        assert lt_version is not None
+        lt_data = lt_version["LaunchTemplateData"]
+        assert "TagSpecifications" in lt_data
+
+        instance_tag_specs = [
+            ts for ts in lt_data["TagSpecifications"]
+            if ts["ResourceType"] == "instance"
+        ]
+        assert len(instance_tag_specs) == 1
+        assert {"Key": "instance-tag-key", "Value": "instance-tag-value"} in \
+            instance_tag_specs[0]["Tags"]
+
+        # Verify the CR spec retains the tag specification after reconciliation
+        cr = k8s.get_resource(ref)
+        spec_tag_specs = cr["spec"]["data"]["tagSpecifications"]
+        assert len(spec_tag_specs) == 1
+        assert spec_tag_specs[0]["resourceType"] == "instance"
+        assert {"key": "instance-tag-key", "value": "instance-tag-value"} in \
+            spec_tag_specs[0]["tags"]


### PR DESCRIPTION
Issue #2836, if available:

https://github.com/aws-controllers-k8s/community/issues/2836

**Description of changes:**

Surfaces `LaunchTemplateData.TagSpecifications` on the `LaunchTemplate` resource by removing it from generator.yaml's ignore list and regenerating. This lets users tag the instances/volumes/ENIs that EC2 creates when launching from the template.

**Updated**: removed one `ignore.field_paths` entry (CreateLaunchTemplateVersionInput.LaunchTemplateData.TagSpecifications). The companion root-level `CreateLaunchTemplateInput.TagSpecifications` ignore is kept (launch-template-object tags are already handled by the existing `updateTagSpecificationsInCreateRequest` hook, the two are independent).

**Generated**: apis/v1alpha1/types.go, deepcopy, config/crd + helm/crds, pkg/resource/launch_template/sdk.go (create + create-version marshalling, read-back), delta.go.

**Tests**: added `test_data_tag_specifications` e2e test + `launch_template_tag_specifications.yaml` sample.

Generated with code-generator v0.60.0

Test Steps:

 1. Live e2e against an EKS cluster (controller run out-of-cluster)

Install CRDs + run the controller:

```bash
kubectl apply -f config/crd/bases/ -f config/crd/common/bases/
./bin/controller --aws-region=us-west-2 --log-level=info --enable-leader-election=false
```

Create a LaunchTemplate with `data.tagSpecifications` (instance + volume):

```yaml
kubectl apply -f - <<'EOF'
apiVersion: ec2.services.k8s.aws/v1alpha1
kind: LaunchTemplate
metadata:
  name: ack-tagspec-test
spec:
  name: ack-tagspec-test
  data:
    instanceType: t3.micro
    tagSpecifications:
      - resourceType: instance
        tags:
          - {key: ManagedBy, value: ack-ec2-controller}
          - {key: CostCenter, value: data-platform}
      - resourceType: volume
        tags:
          - {key: ManagedBy, value: ack-ec2-controller}
  tags:
    - {key: Owner, value: vara}
EOF
```

ACK.ResourceSynced = True

Confirm the tag specs are stored in AWS:

```
LT_ID=$(kubectl get launchtemplate ack-tagspec-test -o jsonpath='{.status.id}')
aws ec2 describe-launch-template-versions --launch-template-id "$LT_ID" --versions 1 \
  --query 'LaunchTemplateVersions[0].LaunchTemplateData.TagSpecifications'
```

Returns both instance (`ManagedBy`, `CostCenter`) and volume (`ManagedBy`) blocks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
