### PR TITLE
Add SourceDestCheckEnabled support to Instance resource

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-01T11:59:47Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
-  version: v0.60.0
-api_directory_checksum: 272258354311c09953120de733ae3d62743667cc
+  build_date: "2026-07-07T03:13:10Z"
+  build_hash: 84c9b9904125e2182619e048d7e35d0f8700d20c
+  go_version: go1.26.0
+  version: v0.60.0-3-g84c9b99
+api_directory_checksum: 301d8450d543bf325b291a3924650ec2b6127007
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 5219a5406bb8d56bfc6d051395e14e18a0c0c8c3
+  file_checksum: 9a7739648be56f078a7ed611542dadf232477c18
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -454,6 +454,12 @@ resources:
       SecurityGroups:
         set:
           - from: GroupName
+      SourceDestCheckEnabled:
+        type: bool
+        # Optional field, applied post-create; late-init the observed value to
+        # avoid a phantom delta when unset.
+        late_initialize:
+          skip_incomplete_check: {}
       LaunchTemplate.LaunchTemplateID:
         references:
           resource: LaunchTemplate

--- a/apis/v1alpha1/instance.go
+++ b/apis/v1alpha1/instance.go
@@ -203,7 +203,8 @@ type InstanceSpec struct {
 	// as part of the network interface instead of using this parameter.
 	//
 	// Default: Amazon EC2 uses the default security group.
-	SecurityGroups []*string `json:"securityGroups,omitempty"`
+	SecurityGroups         []*string `json:"securityGroups,omitempty"`
+	SourceDestCheckEnabled *bool     `json:"sourceDestCheckEnabled,omitempty"`
 	// The ID of the subnet to launch the instance into.
 	//
 	// If you specify a network interface, you must specify any subnets as part

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -13550,6 +13550,11 @@ func (in *InstanceSpec) DeepCopyInto(out *InstanceSpec) {
 			}
 		}
 	}
+	if in.SourceDestCheckEnabled != nil {
+		in, out := &in.SourceDestCheckEnabled, &out.SourceDestCheckEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	if in.SubnetID != nil {
 		in, out := &in.SubnetID, &out.SubnetID
 		*out = new(string)

--- a/config/crd/bases/ec2.services.k8s.aws_instances.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_instances.yaml
@@ -559,6 +559,8 @@ spec:
                 items:
                   type: string
                 type: array
+              sourceDestCheckEnabled:
+                type: boolean
               subnetID:
                 description: |-
                   The ID of the subnet to launch the instance into.

--- a/generator.yaml
+++ b/generator.yaml
@@ -454,6 +454,12 @@ resources:
       SecurityGroups:
         set:
           - from: GroupName
+      SourceDestCheckEnabled:
+        type: bool
+        # Optional field, applied post-create; late-init the observed value to
+        # avoid a phantom delta when unset.
+        late_initialize:
+          skip_incomplete_check: {}
       LaunchTemplate.LaunchTemplateID:
         references:
           resource: LaunchTemplate

--- a/helm/crds/ec2.services.k8s.aws_instances.yaml
+++ b/helm/crds/ec2.services.k8s.aws_instances.yaml
@@ -559,6 +559,8 @@ spec:
                 items:
                   type: string
                 type: array
+              sourceDestCheckEnabled:
+                type: boolean
               subnetID:
                 description: |-
                   The ID of the subnet to launch the instance into.

--- a/pkg/resource/instance/delta.go
+++ b/pkg/resource/instance/delta.go
@@ -515,6 +515,13 @@ func newResourceDelta(
 			delta.Add("Spec.SecurityGroups", a.ko.Spec.SecurityGroups, b.ko.Spec.SecurityGroups)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.SourceDestCheckEnabled, b.ko.Spec.SourceDestCheckEnabled) {
+		delta.Add("Spec.SourceDestCheckEnabled", a.ko.Spec.SourceDestCheckEnabled, b.ko.Spec.SourceDestCheckEnabled)
+	} else if a.ko.Spec.SourceDestCheckEnabled != nil && b.ko.Spec.SourceDestCheckEnabled != nil {
+		if *a.ko.Spec.SourceDestCheckEnabled != *b.ko.Spec.SourceDestCheckEnabled {
+			delta.Add("Spec.SourceDestCheckEnabled", a.ko.Spec.SourceDestCheckEnabled, b.ko.Spec.SourceDestCheckEnabled)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SubnetID, b.ko.Spec.SubnetID) {
 		delta.Add("Spec.SubnetID", a.ko.Spec.SubnetID, b.ko.Spec.SubnetID)
 	} else if a.ko.Spec.SubnetID != nil && b.ko.Spec.SubnetID != nil {

--- a/pkg/resource/instance/hooks.go
+++ b/pkg/resource/instance/hooks.go
@@ -118,6 +118,8 @@ func (rm *resourceManager) modifyInstanceAttributes(ctx context.Context, delta *
 		input.DisableApiStop = &svcsdktypes.AttributeBooleanValue{Value: desired.ko.Spec.DisableAPIStop}
 	} else if delta.DifferentAt("Spec.SecurityGroupIDs") {
 		input.Groups = aws.ToStringSlice(desired.ko.Spec.SecurityGroupIDs)
+	} else if delta.DifferentAt("Spec.SourceDestCheckEnabled") && desired.ko.Spec.SourceDestCheckEnabled != nil {
+		input.SourceDestCheck = &svcsdktypes.AttributeBooleanValue{Value: desired.ko.Spec.SourceDestCheckEnabled}
 	} else {
 		input = nil
 	}
@@ -157,6 +159,10 @@ func setAdditionalFields(instance svcsdktypes.Instance, ko *v1alpha1.Instance) {
 	ko.Spec.SecurityGroupIDs = []*string{}
 	for _, group := range instance.SecurityGroups {
 		ko.Spec.SecurityGroupIDs = append(ko.Spec.SecurityGroupIDs, group.GroupId)
+	}
+
+	if instance.SourceDestCheck != nil {
+		ko.Spec.SourceDestCheckEnabled = instance.SourceDestCheck
 	}
 
 	if monitoring := instance.Monitoring; monitoring != nil {

--- a/pkg/resource/instance/manager.go
+++ b/pkg/resource/instance/manager.go
@@ -50,7 +50,7 @@ var (
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=instances,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=ec2.services.k8s.aws,resources=instances/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{"HibernationOptions"}
+var lateInitializeFieldNames = []string{"HibernationOptions", "SourceDestCheckEnabled"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -268,6 +268,9 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	latestKo := rm.concreteResource(latest).ko.DeepCopy()
 	if observedKo.Spec.HibernationOptions != nil && latestKo.Spec.HibernationOptions == nil {
 		latestKo.Spec.HibernationOptions = observedKo.Spec.HibernationOptions
+	}
+	if observedKo.Spec.SourceDestCheckEnabled != nil && latestKo.Spec.SourceDestCheckEnabled == nil {
+		latestKo.Spec.SourceDestCheckEnabled = observedKo.Spec.SourceDestCheckEnabled
 	}
 	return &resource{latestKo}
 }

--- a/pkg/resource/instance/sdk.go
+++ b/pkg/resource/instance/sdk.go
@@ -1268,6 +1268,7 @@ func (rm *resourceManager) sdkCreate(
 	}
 
 	rm.setStatusDefaults(ko)
+
 	setAdditionalFields(resp.Instances[0], ko)
 
 	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
@@ -1275,6 +1276,13 @@ func (rm *resourceManager) sdkCreate(
 		// if desired tags and response tags are equal,
 		// then assign desired tags to maintain tag order
 		ko.Spec.Tags = desired.ko.Spec.Tags
+	}
+
+	// SourceDestCheck cannot be set at launch; apply it after create.
+	if desired.ko.Spec.SourceDestCheckEnabled != nil {
+		ko.Spec.SourceDestCheckEnabled = desired.ko.Spec.SourceDestCheckEnabled
+		msg := "Instance is pending update for SourceDestCheckEnabled"
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
 	}
 	return &resource{ko}, nil
 }

--- a/templates/hooks/instance/sdk_create_post_set_output.go.tpl
+++ b/templates/hooks/instance/sdk_create_post_set_output.go.tpl
@@ -1,3 +1,4 @@
+
 	setAdditionalFields(resp.Instances[0], ko)
 	
 	toAdd, toDelete := computeTagsDelta(desired.ko.Spec.Tags, ko.Spec.Tags)
@@ -5,4 +6,11 @@
 		// if desired tags and response tags are equal,
 		// then assign desired tags to maintain tag order
 		ko.Spec.Tags = desired.ko.Spec.Tags
+	}
+
+	// SourceDestCheck cannot be set at launch; apply it after create.
+	if desired.ko.Spec.SourceDestCheckEnabled != nil {
+		ko.Spec.SourceDestCheckEnabled = desired.ko.Spec.SourceDestCheckEnabled
+		msg := "Instance is pending update for SourceDestCheckEnabled"
+		ackcondition.SetSynced(&resource{ko}, corev1.ConditionFalse, &msg, nil)
 	}

--- a/test/e2e/resources/instance_source_dest_check.yaml
+++ b/test/e2e/resources/instance_source_dest_check.yaml
@@ -1,0 +1,12 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: Instance
+metadata:
+  name: $INSTANCE_NAME
+spec:
+  imageID: $INSTANCE_AMI_ID
+  instanceType: $INSTANCE_TYPE
+  subnetID: $INSTANCE_SUBNET_ID
+  sourceDestCheckEnabled: false
+  tags:
+    - key: $INSTANCE_TAG_KEY
+      value: $INSTANCE_TAG_VAL

--- a/test/e2e/tests/test_instance.py
+++ b/test/e2e/tests/test_instance.py
@@ -302,6 +302,102 @@ class TestInstance:
         # for successful test cleanup
         wait_for_instance_or_die(ec2_client, resource_id, 'terminated', TIMEOUT_SECONDS)
 
+    def test_source_dest_check(self, ec2_client):
+        """Test that SourceDestCheck can be disabled and re-enabled on an Instance.
+
+        Validates:
+        - Instance is created with sourceDestCheckEnabled: false
+        - AWS resource has SourceDestCheck disabled
+        - sourceDestCheckEnabled can be re-enabled via patch
+        - The resource syncs without error after each update
+
+        References: https://github.com/aws-controllers-k8s/community/issues/2883
+        """
+        test_resource_values = REPLACEMENT_VALUES.copy()
+        resource_name = random_suffix_name("inst-src-dst-chk", 24)
+        test_vpc = get_bootstrap_resources().SharedTestVPC
+        subnet_id = test_vpc.public_subnets.subnet_ids[0]
+
+        ami_id = get_ami_id(ec2_client)
+        test_resource_values["INSTANCE_NAME"] = resource_name
+        test_resource_values["INSTANCE_AMI_ID"] = ami_id
+        test_resource_values["INSTANCE_TYPE"] = INSTANCE_TYPE
+        test_resource_values["INSTANCE_SUBNET_ID"] = subnet_id
+        test_resource_values["INSTANCE_TAG_KEY"] = INSTANCE_TAG_KEY
+        test_resource_values["INSTANCE_TAG_VAL"] = INSTANCE_TAG_VAL
+
+        # Load Instance CR with sourceDestCheckEnabled: false
+        resource_data = load_ec2_resource(
+            "instance_source_dest_check",
+            additional_replacements=test_resource_values,
+        )
+        logging.debug(resource_data)
+
+        # Create k8s resource
+        ref = k8s.CustomResourceReference(
+            CRD_GROUP, CRD_VERSION, RESOURCE_PLURAL,
+            resource_name, namespace="default",
+        )
+        k8s.create_custom_resource(ref, resource_data)
+        cr = k8s.wait_resource_consumed_by_controller(ref)
+
+        assert cr is not None
+        assert k8s.get_resource_exists(ref)
+
+        try:
+            time.sleep(CREATE_WAIT_AFTER_SECONDS)
+
+            resource_id = cr["status"]["instanceID"]
+
+            # Check Instance exists
+            instance = get_instance(ec2_client, resource_id)
+            assert instance is not None
+
+            # Wait for instance to come up
+            wait_for_instance_or_die(ec2_client, resource_id, 'running', TIMEOUT_SECONDS)
+
+            # Check resource synced successfully
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+            # Verify SourceDestCheck is disabled in AWS
+            instance = get_instance(ec2_client, resource_id)
+            assert instance["SourceDestCheck"] is False
+
+            # Verify the CR spec shows sourceDestCheckEnabled: false
+            cr = k8s.get_resource(ref)
+            assert cr["spec"]["sourceDestCheckEnabled"] is False
+
+            # Re-enable SourceDestCheck
+            updates = {
+                "spec": {
+                    "sourceDestCheckEnabled": True
+                }
+            }
+            k8s.patch_custom_resource(ref, updates)
+            time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+            # Check resource synced successfully
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+            # Verify SourceDestCheck is now enabled in AWS
+            instance = get_instance(ec2_client, resource_id)
+            assert instance["SourceDestCheck"] is True
+
+            # Verify the CR spec shows sourceDestCheckEnabled: true
+            cr = k8s.get_resource(ref)
+            assert cr["spec"]["sourceDestCheckEnabled"] is True
+
+        finally:
+            # Delete k8s resource
+            try:
+                _, deleted = k8s.delete_custom_resource(ref, 3, 10)
+                assert deleted
+            except:
+                pass
+
+            # Wait for termination to release subnet dependency
+            if 'resource_id' in locals():
+                wait_for_instance_or_die(ec2_client, resource_id, 'terminated', TIMEOUT_SECONDS)
 
     def test_nested_virtualization(self, ec2_client):
         """Test that an Instance can be created with nestedVirtualization in cpuOptions.


### PR DESCRIPTION
Description of changes:
Adds support for managing the EC2 `Instance` `SourceDestCheck` attribute through a new `sourceDestCheckEnabled` spec field. Re-implements the previously closed PR #341.

**Behavior**
- `SourceDestCheck` cannot be set at launch (`RunInstances`), so it is applied post-create via `ModifyInstanceAttribute` once the instance is running. On create with the field set, the value is preserved and the resource is briefly marked `ResourceSynced=False` with the message `Instance is pending update for SourceDestCheckEnabled`.
- Updates (`false` <-> `true`) are handled in `modifyInstanceAttributes`; the current value is read back in `setAdditionalFields`.
- The field is optional. It is configured with `late_initialize` (`skip_incomplete_check`) so the observed value is back-filled into the spec when the user does not set it (or removes it). This keeps `desired` and `latest` in agreement and avoids a phantom delta.
- A guard in `modifyInstanceAttributes` only builds the `SourceDestCheck` input when the desired value is non-nil.

**Why both late_initialize and the nil guard are needed**
The reconciler runs `updateResource` before `lateInitializeResource`. If the field is nil in the desired spec, the standard delta fires and the update path runs first. Without the guard it would call `ModifyInstanceAttribute` with no attribute value and fail (`InvalidParameterCombination: No attributes specified`), returning an error before late-init could restore the value. The guard makes that a no-op so late-init back-fills the observed value on the same reconcile.

**Manual testing observations (live EKS cluster)**
- Create with `sourceDestCheckEnabled: false` -> EC2 `SourceDestCheck=false`, `ResourceSynced=True`.
- Re-enable via patch to `true` -> EC2 `SourceDestCheck=true`, `ResourceSynced=True`.
- Create *without* the field -> late-init populates the spec from the observed value; converges to `ResourceSynced=True` with no update calls.
- Remove the field after it was set (`spec.sourceDestCheckEnabled: null`) -> late-init restores the observed value into the spec; `ResourceSynced=True`, EC2 value preserved, no `ModifyInstanceAttribute` errors and no steady-state reconcile churn.
- Confirmed against the AWS API that a `ModifyInstanceAttribute` request built from a nil value omits the attribute entirely and is rejected with `InvalidParameterCombination: No attributes specified` (it does not silently disable `SourceDestCheck`), which motivated the guard.

**Testing**
- `make build-controller` and `go build ./...` pass.
- E2E test added covering create-with-disabled and re-enable-via-patch.

References: https://github.com/aws-controllers-k8s/community/issues/2883

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
