### PR TITLE
feat: sync `IPv6CIDRBlockAssociationSet` while updating VPC state

### DIFF
--- a/pkg/resource/vpc/hooks.go
+++ b/pkg/resource/vpc/hooks.go
@@ -347,6 +347,7 @@ func (rm *resourceManager) customUpdateVPC(
 		}
 	}
 	updated.ko.Status.CIDRBlockAssociationSet = latest.ko.Status.CIDRBlockAssociationSet
+	updated.ko.Status.IPv6CIDRBlockAssociationSet = latest.ko.Status.IPv6CIDRBlockAssociationSet
 
 	if delta.DifferentAt("Spec.DisallowSecurityGroupDefaultRules") {
 		if desired.ko.Spec.DisallowSecurityGroupDefaultRules != nil && *desired.ko.Spec.DisallowSecurityGroupDefaultRules {

--- a/pkg/resource/vpc/hooks_test.go
+++ b/pkg/resource/vpc/hooks_test.go
@@ -1,0 +1,46 @@
+package vpc
+
+import (
+	"context"
+	"testing"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+)
+
+func TestCustomUpdateVPCPropagatesCIDRBlockStatusChanges(t *testing.T) {
+	desired := &resource{
+		ko: &svcapitypes.VPC{
+			Spec: svcapitypes.VPCSpec{
+				CIDRBlocks: []*string{aws.String("10.0.0.0/16")},
+			},
+		},
+	}
+	latest := &resource{
+		ko: &svcapitypes.VPC{
+			Spec: svcapitypes.VPCSpec{
+				CIDRBlocks: []*string{aws.String("10.0.0.0/16")},
+			},
+			Status: svcapitypes.VPCStatus{
+				CIDRBlockAssociationSet: []*svcapitypes.VPCCIDRBlockAssociation{
+					{CIDRBlock: aws.String("10.0.0.0/16")},
+				},
+				IPv6CIDRBlockAssociationSet: []*svcapitypes.VPCIPv6CIDRBlockAssociation{
+					{IPv6CIDRBlock: aws.String("2600:1f18::/56")},
+				},
+			},
+		},
+	}
+
+	rm := &resourceManager{}
+	delta := ackcompare.NewDelta()
+
+	updated, err := rm.customUpdateVPC(context.Background(), desired, latest, delta)
+	require.NoError(t, err)
+	assert.Equal(t, latest.ko.Status.CIDRBlockAssociationSet, updated.ko.Status.CIDRBlockAssociationSet)
+	assert.Equal(t, latest.ko.Status.IPv6CIDRBlockAssociationSet, updated.ko.Status.IPv6CIDRBlockAssociationSet)
+}


### PR DESCRIPTION
https://github.com/aws-controllers-k8s/ec2-controller/pull/330 introduced a change that causes a re-queue of the VPC to delete the default security group rules. This path isn't copying over the IPv6 CIDR block associations, which causes that block to stay empty despite the VPC having a CIDR association present on the console.

Surprisingly, we only see this issue when we're using Amazon provided CIDR blocks, and not when we use IPAM Managed CIDR blocks. Presumably there's a difference between associating a CIDR block with the VPC in both those cases, with the latter returning the CIDR block association immediately after the Create -> ReadOne flow in the runtime, so that the [status is appropriately saved](https://github.com/aws-controllers-k8s/runtime/blob/38bd4c967a0145f81d64505ad8cfe6fdc2d9093c/pkg/runtime/reconciler.go#L860).

