### PR TITLE
fix(security_group): stop perpetual diff on server-normalized rules

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-07-22T05:47:11Z"
+  build_date: "2026-07-22T19:53:33Z"
   build_hash: ab6940f9c532e013d284f670e50b727102b4126d
   go_version: go1.26.0
   version: v0.61.0-2-gab6940f
@@ -7,7 +7,7 @@ api_directory_checksum: 301d8450d543bf325b291a3924650ec2b6127007
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 5f45d44f95a343588facbea73cf95b3121fef767
+  file_checksum: ad417315079b182e217c91f6de01776701e835a7
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-08T18:57:42Z"
+  build_date: "2026-07-21T03:32:23Z"
   build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.61.0
 api_directory_checksum: 301d8450d543bf325b291a3924650ec2b6127007
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 747ba445629cf7885a8a6174f56a38ee2dc4a7c8
+  file_checksum: 7671402a86f614f661db3a75f44e70809d518116
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-07-21T03:32:23Z"
-  build_hash: 0a6b791fa10a6140d862be334a6891868ee588eb
+  build_date: "2026-07-22T05:47:11Z"
+  build_hash: ab6940f9c532e013d284f670e50b727102b4126d
   go_version: go1.26.0
-  version: v0.61.0
+  version: v0.61.0-2-gab6940f
 api_directory_checksum: 301d8450d543bf325b291a3924650ec2b6127007
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 7671402a86f614f661db3a75f44e70809d518116
+  file_checksum: 5f45d44f95a343588facbea73cf95b3121fef767
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -887,9 +887,18 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
+        # Rule lists are compared in the delta_post_compare hook
+        # (customPostCompare), which canonicalises copies of both sides so
+        # server-side normalisation never produces a spurious diff. The
+        # generated field-by-field comparison is skipped to avoid a raw
+        # DeepEqual on the un-normalised lists.
+        compare:
+          is_ignored: true
       EgressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       Rules:
         from:
           operation: DescribeSecurityGroupRules
@@ -940,8 +949,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
-      delta_pre_compare:
-        code: customPreCompare(delta, a, b)
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -940,6 +940,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -887,11 +887,9 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
-        # Rule lists are compared in the delta_post_compare hook
-        # (customPostCompare), which canonicalises copies of both sides so
-        # server-side normalisation never produces a spurious diff. The
-        # generated field-by-field comparison is skipped to avoid a raw
-        # DeepEqual on the un-normalised lists.
+        # Compared in the delta_post_compare hook (customPostCompare) on
+        # canonicalised copies, so server-side normalisation never drives a
+        # spurious diff; the generated field comparison is skipped.
         compare:
           is_ignored: true
       EgressRules:

--- a/generator.yaml
+++ b/generator.yaml
@@ -887,9 +887,18 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
+        # Rule lists are compared in the delta_post_compare hook
+        # (customPostCompare), which canonicalises copies of both sides so
+        # server-side normalisation never produces a spurious diff. The
+        # generated field-by-field comparison is skipped to avoid a raw
+        # DeepEqual on the un-normalised lists.
+        compare:
+          is_ignored: true
       EgressRules:
         custom_field:
           list_of: IpPermission
+        compare:
+          is_ignored: true
       Rules:
         from:
           operation: DescribeSecurityGroupRules
@@ -940,8 +949,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
-      delta_pre_compare:
-        code: customPreCompare(delta, a, b)
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/generator.yaml
+++ b/generator.yaml
@@ -940,6 +940,8 @@ resources:
             GroupIds: Ids
             GroupNames: Names
     hooks:
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/security_group/sdk_create_post_build_request.go.tpl
       sdk_file_end:

--- a/generator.yaml
+++ b/generator.yaml
@@ -887,11 +887,9 @@ resources:
       IngressRules:
         custom_field:
           list_of: IpPermission
-        # Rule lists are compared in the delta_post_compare hook
-        # (customPostCompare), which canonicalises copies of both sides so
-        # server-side normalisation never produces a spurious diff. The
-        # generated field-by-field comparison is skipped to avoid a raw
-        # DeepEqual on the un-normalised lists.
+        # Compared in the delta_post_compare hook (customPostCompare) on
+        # canonicalised copies, so server-side normalisation never drives a
+        # spurious diff; the generated field comparison is skipped.
         compare:
           is_ignored: true
       EgressRules:

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -41,6 +41,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)

--- a/pkg/resource/security_group/delta.go
+++ b/pkg/resource/security_group/delta.go
@@ -41,27 +41,12 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
-	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.Description, b.ko.Spec.Description) {
 		delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
 	} else if a.ko.Spec.Description != nil && b.ko.Spec.Description != nil {
 		if *a.ko.Spec.Description != *b.ko.Spec.Description {
 			delta.Add("Spec.Description", a.ko.Spec.Description, b.ko.Spec.Description)
-		}
-	}
-	if len(a.ko.Spec.EgressRules) != len(b.ko.Spec.EgressRules) {
-		delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
-	} else if len(a.ko.Spec.EgressRules) > 0 {
-		if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.EgressRules, b.ko.Spec.EgressRules) {
-			delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
-		}
-	}
-	if len(a.ko.Spec.IngressRules) != len(b.ko.Spec.IngressRules) {
-		delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
-	} else if len(a.ko.Spec.IngressRules) > 0 {
-		if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.IngressRules, b.ko.Spec.IngressRules) {
-			delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
 		}
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
@@ -87,5 +72,6 @@ func newResourceDelta(
 		delta.Add("Spec.VPCRef", a.ko.Spec.VPCRef, b.ko.Spec.VPCRef)
 	}
 
+	customPostCompare(delta, a, b)
 	return delta
 }

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -15,6 +15,9 @@ package security_group
 
 import (
 	"context"
+	"net"
+	"sort"
+	"strconv"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -127,6 +130,314 @@ func (rm *resourceManager) referencesResolved(
 		}
 	}
 	return true
+}
+
+// allProtocols is the IpProtocol value EC2 uses to mean "all protocols".
+// For such rules AWS ignores the port range and DescribeSecurityGroups
+// returns the rule with FromPort/ToPort unset.
+const allProtocols = "-1"
+
+// wellKnownProtocols maps the IANA protocol numbers that EC2 canonicalises to
+// names on DescribeSecurityGroups read-back. A spec that uses the numeric form
+// (e.g. "6") would otherwise perpetually differ from the name AWS returns
+// ("tcp"). Protocols outside this set are returned by AWS as-is (their number),
+// so they need no mapping; "-1" (all protocols) is already canonical.
+var wellKnownProtocols = map[string]string{
+	"1":  "icmp",
+	"6":  "tcp",
+	"17": "udp",
+	"58": "icmpv6",
+}
+
+// canonicalizeProtocol maps a numeric IpProtocol to the name EC2 returns on
+// read-back so that numeric and name spellings of the same protocol compare
+// equal. Unknown protocols and names are returned unchanged.
+func canonicalizeProtocol(proto *string) *string {
+	if proto == nil {
+		return nil
+	}
+	if name, ok := wellKnownProtocols[*proto]; ok {
+		return &name
+	}
+	return proto
+}
+
+// canonicalizeCIDR rewrites a CIDR to the network form EC2 returns on
+// read-back: host bits are masked off and (for IPv6) the text is normalised
+// to lowercase, zero-compressed RFC 5952 form -- e.g. "100.68.0.18/18" ->
+// "100.68.0.0/18" and "2001:DB8:abcd:0012::1/64" -> "2001:db8:abcd:12::/64".
+// A value that does not parse as a CIDR is returned unchanged (AWS will
+// reject a truly malformed CIDR on the API call).
+func canonicalizeCIDR(cidr *string) *string {
+	if cidr == nil {
+		return nil
+	}
+	_, ipNet, err := net.ParseCIDR(*cidr)
+	if err != nil {
+		return cidr
+	}
+	canon := ipNet.String()
+	return &canon
+}
+
+// customPreCompare is injected at the top of the generated
+// newResourceDelta (see delta.go) via the `delta_pre_compare` hook in
+// generator.yaml. It rewrites Spec.IngressRules / Spec.EgressRules on both
+// sides into a single canonical form so the subsequent field-by-field
+// DeepEqual does not report spurious diffs that arise purely from how AWS
+// normalises rules on DescribeSecurityGroups read-back.
+//
+// It closes four independent perpetual-diff sources (see
+// aws-controllers-k8s/community#2822):
+//
+//  1. Self-references. A pair is a self-reference when GroupID equals the
+//     SG's own ID, or when GroupID/GroupRef/GroupName are all omitted (the
+//     spec form, since the ID is unknown until AWS assigns it). AWS fills
+//     GroupID, UserID and sometimes GroupName on read-back. We canonicalise
+//     to {GroupID: selfID} and clear GroupRef/UserID/GroupName.
+//  2. All-protocol ("-1") port ranges. AWS drops FromPort/ToPort for these;
+//     we drop them on both sides.
+//  3. Server-filled owner account. AWS populates UserID with the owning
+//     account for same-account grants; we clear it. Cross-account grants
+//     (UserID != owner) are preserved so the reference stays intact.
+//  4. Grant aggregation. AWS merges grants sharing (protocol, fromPort,
+//     toPort) into one IpPermission with array-valued grants; the spec may
+//     list them as separate rules. We aggregate both sides by that key and
+//     sort deterministically so ordering never drives a diff either.
+//  5. Protocol notation. AWS canonicalises well-known IANA protocol numbers
+//     to names on read-back ("6" -> "tcp"); we map numeric spec values to the
+//     same names so the two forms compare equal.
+//  6. CIDR canonicalisation. AWS masks host bits and normalises IPv6 text
+//     ("100.68.0.18/18" -> "100.68.0.0/18"); we rewrite CIDRs to the same
+//     network form so the spec and read-back compare equal.
+//
+// Mutating a and b in place matches the convention used by RouteTable,
+// NetworkAcl and VPC in this repo. It is safe against accidental spec
+// persistence because customUpdateSecurityGroup returns a deep copy of the
+// (already-normalised) desired, so the runtime's metadata+spec patch is
+// computed as diff(desired, updated) and is empty for these fields; nothing
+// escapes back to the Kubernetes object. Each reconcile also reads a fresh
+// desired from the API server, so the mutation never accumulates.
+//
+// GroupID is canonicalised to selfID (not cleared) on self-references so
+// that referencesResolved -- and the gate in customUpdateSecurityGroup --
+// still sees the pair as resolved and proceeds to syncSGRules. Because the
+// normalised objects flow into syncSGRules/containsRule as well, the same
+// canonical form suppresses churn at the compareIPPermission layer, and the
+// AWS Authorize/Revoke inputs it builds remain valid (GroupId defaults to
+// selfID, "-1" rules ignore ports, aggregated grants are accepted).
+func customPreCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	canonicalizeSGRules(a)
+	canonicalizeSGRules(b)
+}
+
+// canonicalizeSGRules rewrites the Ingress and Egress rule lists of r into a
+// canonical form used only for delta comparison and rule syncing. See
+// customPreCompare for the rationale and safety argument.
+func canonicalizeSGRules(r *resource) {
+	if r == nil || r.ko == nil {
+		return
+	}
+	var selfID string
+	if r.ko.Status.ID != nil {
+		selfID = *r.ko.Status.ID
+	}
+	var ownerAccountID string
+	if r.ko.Status.ACKResourceMetadata != nil &&
+		r.ko.Status.ACKResourceMetadata.OwnerAccountID != nil {
+		ownerAccountID = string(*r.ko.Status.ACKResourceMetadata.OwnerAccountID)
+	}
+	r.ko.Spec.IngressRules = canonicalizeRuleList(r.ko.Spec.IngressRules, selfID, ownerAccountID)
+	r.ko.Spec.EgressRules = canonicalizeRuleList(r.ko.Spec.EgressRules, selfID, ownerAccountID)
+}
+
+// canonicalizeRuleList normalises each rule (ports + grants), aggregates
+// rules sharing the same (protocol, fromPort, toPort) key, and returns the
+// result sorted deterministically. A nil input returns nil so an empty and
+// an absent rule list keep comparing equal.
+func canonicalizeRuleList(
+	rules []*svcapitypes.IPPermission,
+	selfID string,
+	ownerAccountID string,
+) []*svcapitypes.IPPermission {
+	if rules == nil {
+		return nil
+	}
+
+	// Per-rule field normalisation.
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		// Gap 5: AWS returns well-known protocols by name ("tcp"), so map a
+		// numeric spec value ("6") to the same name before comparing.
+		rule.IPProtocol = canonicalizeProtocol(rule.IPProtocol)
+		// Gap 1: AWS ignores and drops the port range for "-1" rules.
+		if rule.IPProtocol != nil && *rule.IPProtocol == allProtocols {
+			rule.FromPort = nil
+			rule.ToPort = nil
+		}
+		// Gap 6: AWS canonicalises CIDRs (masks host bits; lowercases and
+		// zero-compresses IPv6). Match that form on both sides.
+		for _, r := range rule.IPRanges {
+			if r != nil {
+				r.CIDRIP = canonicalizeCIDR(r.CIDRIP)
+			}
+		}
+		for _, r := range rule.IPv6Ranges {
+			if r != nil {
+				r.CIDRIPv6 = canonicalizeCIDR(r.CIDRIPv6)
+			}
+		}
+		for _, pair := range rule.UserIDGroupPairs {
+			canonicalizeGroupPair(pair, selfID, ownerAccountID)
+		}
+	}
+
+	// Gap 3: aggregate rules that share the same (protocol, fromPort,
+	// toPort) key, preserving first-seen order for stability before the
+	// final sort.
+	byKey := map[string]*svcapitypes.IPPermission{}
+	order := make([]string, 0, len(rules))
+	for _, rule := range rules {
+		if rule == nil {
+			continue
+		}
+		key := ruleAggregationKey(rule)
+		if existing, ok := byKey[key]; ok {
+			existing.IPRanges = append(existing.IPRanges, rule.IPRanges...)
+			existing.IPv6Ranges = append(existing.IPv6Ranges, rule.IPv6Ranges...)
+			existing.PrefixListIDs = append(existing.PrefixListIDs, rule.PrefixListIDs...)
+			existing.UserIDGroupPairs = append(existing.UserIDGroupPairs, rule.UserIDGroupPairs...)
+			continue
+		}
+		// Copy the rule and its grant slices so aggregation never aliases
+		// or mutates the caller's backing arrays.
+		merged := &svcapitypes.IPPermission{
+			FromPort:         rule.FromPort,
+			ToPort:           rule.ToPort,
+			IPProtocol:       rule.IPProtocol,
+			IPRanges:         append([]*svcapitypes.IPRange(nil), rule.IPRanges...),
+			IPv6Ranges:       append([]*svcapitypes.IPv6Range(nil), rule.IPv6Ranges...),
+			PrefixListIDs:    append([]*svcapitypes.PrefixListID(nil), rule.PrefixListIDs...),
+			UserIDGroupPairs: append([]*svcapitypes.UserIDGroupPair(nil), rule.UserIDGroupPairs...),
+		}
+		byKey[key] = merged
+		order = append(order, key)
+	}
+
+	out := make([]*svcapitypes.IPPermission, 0, len(order))
+	for _, key := range order {
+		rule := byKey[key]
+		sortGrants(rule)
+		out = append(out, rule)
+	}
+	// Sort rules by their aggregation key so read-back ordering never drives
+	// a diff. Keys are unique after aggregation, so the order is total.
+	sort.Slice(out, func(i, j int) bool {
+		return ruleAggregationKey(out[i]) < ruleAggregationKey(out[j])
+	})
+	return out
+}
+
+// canonicalizeGroupPair normalises a single UserIDGroupPair in place,
+// covering the self-reference (gap driving #2822) and server-filled owner
+// account (gap 2) cases.
+func canonicalizeGroupPair(
+	pair *svcapitypes.UserIDGroupPair,
+	selfID string,
+	ownerAccountID string,
+) {
+	if pair == nil {
+		return
+	}
+	// A self-reference is either an explicit reference to the SG's own ID
+	// (how AWS returns it, and how ResolveReferences fills a self groupRef)
+	// or a pair that omits all group identifiers (the spec shorthand for
+	// "this SG", since the ID is unknown until AWS assigns it).
+	isSelf := (pair.GroupID != nil && selfID != "" && *pair.GroupID == selfID) ||
+		(pair.GroupID == nil && pair.GroupRef == nil && pair.GroupName == nil)
+	if isSelf {
+		if selfID != "" {
+			id := selfID
+			pair.GroupID = &id
+		}
+		// GroupRef is a spec-only reference wrapper never present on AWS
+		// read-back; once GroupID is set it is redundant for comparison.
+		pair.GroupRef = nil
+		pair.GroupName = nil
+		pair.UserID = nil
+		return
+	}
+	// Non-self pairs: AWS auto-fills UserID with the owning account for
+	// same-account grants. Clear it so its absence in the spec is not a
+	// diff. Cross-account grants (UserID != owner) are preserved -- the
+	// account is required to identify the referenced group.
+	if pair.UserID != nil && ownerAccountID != "" && *pair.UserID == ownerAccountID {
+		pair.UserID = nil
+	}
+	// A resolved cross-SG reference carries both GroupRef (spec-only) and
+	// GroupID; drop GroupRef so it matches the AWS-returned form.
+	if pair.GroupRef != nil && pair.GroupID != nil {
+		pair.GroupRef = nil
+	}
+}
+
+// ruleAggregationKey returns the key AWS aggregates IpPermissions by:
+// protocol plus the (from, to) port range.
+func ruleAggregationKey(rule *svcapitypes.IPPermission) string {
+	proto := ""
+	if rule.IPProtocol != nil {
+		proto = *rule.IPProtocol
+	}
+	from := "nil"
+	if rule.FromPort != nil {
+		from = strconv.FormatInt(*rule.FromPort, 10)
+	}
+	to := "nil"
+	if rule.ToPort != nil {
+		to = strconv.FormatInt(*rule.ToPort, 10)
+	}
+	return proto + "/" + from + "/" + to
+}
+
+// sortGrants sorts every grant collection of a rule into a deterministic
+// order so that read-back ordering within a rule never drives a diff.
+func sortGrants(rule *svcapitypes.IPPermission) {
+	sort.Slice(rule.IPRanges, func(i, j int) bool {
+		return derefStr(rule.IPRanges[i].CIDRIP) < derefStr(rule.IPRanges[j].CIDRIP)
+	})
+	sort.Slice(rule.IPv6Ranges, func(i, j int) bool {
+		return derefStr(rule.IPv6Ranges[i].CIDRIPv6) < derefStr(rule.IPv6Ranges[j].CIDRIPv6)
+	})
+	sort.Slice(rule.PrefixListIDs, func(i, j int) bool {
+		return derefStr(rule.PrefixListIDs[i].PrefixListID) < derefStr(rule.PrefixListIDs[j].PrefixListID)
+	})
+	sort.Slice(rule.UserIDGroupPairs, func(i, j int) bool {
+		return userIDGroupPairSortKey(rule.UserIDGroupPairs[i]) <
+			userIDGroupPairSortKey(rule.UserIDGroupPairs[j])
+	})
+}
+
+// userIDGroupPairSortKey builds a stable sort key for a group pair from the
+// fields that identify it.
+func userIDGroupPairSortKey(pair *svcapitypes.UserIDGroupPair) string {
+	if pair == nil {
+		return ""
+	}
+	return derefStr(pair.GroupID) + "/" + derefStr(pair.UserID) + "/" +
+		derefStr(pair.GroupName)
+}
+
+func derefStr(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // syncSGRules analyzes desired and latest (if any)

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -251,6 +251,12 @@ func customPostCompare(
 	if a == nil || b == nil || a.ko == nil || b.ko == nil {
 		return
 	}
+	// Rule canonicalisation needs the SG's ID and owner account, which are nil
+	// pre-create. Skip rather than emit an unreliable diff; the next reconcile
+	// recomputes it once the identity is known.
+	if !securityGroupIdentityKnown(a) || !securityGroupIdentityKnown(b) {
+		return
+	}
 	aIngress, aEgress := canonicalizeCopiedRuleLists(a)
 	bIngress, bEgress := canonicalizeCopiedRuleLists(b)
 	if !equality.Semantic.DeepEqual(aIngress, bIngress) {
@@ -261,27 +267,29 @@ func customPostCompare(
 	}
 }
 
+// securityGroupIdentityKnown reports whether the SG's ID and owner account are
+// populated -- both required for a meaningful rule delta, and only set
+// post-create.
+func securityGroupIdentityKnown(r *resource) bool {
+	return r != nil && r.ko != nil &&
+		r.ko.Status.ID != nil &&
+		r.ko.Status.ACKResourceMetadata != nil &&
+		r.ko.Status.ACKResourceMetadata.OwnerAccountID != nil
+}
+
 // canonicalizeCopiedRuleLists returns canonical *copies* of r's rule lists; r is
-// never mutated. Used only for delta comparison (customPostCompare). The sync
-// path intentionally does NOT use this -- it authorises/revokes the raw spec
-// rules so a canonicalisation defect can never alter what is sent to AWS.
+// never mutated. Used only for delta comparison, never the sync path (which
+// authorises/revokes the raw spec rules). Precondition (guaranteed by
+// customPostCompare's identity guard + Name being required): Status.ID,
+// OwnerAccountID and Spec.Name are all non-nil.
 func canonicalizeCopiedRuleLists(
 	r *resource,
 ) (ingress []*svcapitypes.IPPermission, egress []*svcapitypes.IPPermission) {
-	if r == nil || r.ko == nil {
-		return nil, nil
-	}
-	var selfID string
-	if r.ko.Status.ID != nil {
-		selfID = *r.ko.Status.ID
-	}
-	var ownerAccountID string
-	if r.ko.Status.ACKResourceMetadata != nil &&
-		r.ko.Status.ACKResourceMetadata.OwnerAccountID != nil {
-		ownerAccountID = string(*r.ko.Status.ACKResourceMetadata.OwnerAccountID)
-	}
-	ingress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.IngressRules), selfID, ownerAccountID)
-	egress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.EgressRules), selfID, ownerAccountID)
+	selfID := *r.ko.Status.ID
+	ownerAccountID := string(*r.ko.Status.ACKResourceMetadata.OwnerAccountID)
+	selfName := *r.ko.Spec.Name
+	ingress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.IngressRules), selfID, selfName, ownerAccountID)
+	egress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.EgressRules), selfID, selfName, ownerAccountID)
 	return ingress, egress
 }
 
@@ -304,6 +312,7 @@ func deepCopyRuleList(rules []*svcapitypes.IPPermission) []*svcapitypes.IPPermis
 func canonicalizeRuleList(
 	rules []*svcapitypes.IPPermission,
 	selfID string,
+	selfName string,
 	ownerAccountID string,
 ) []*svcapitypes.IPPermission {
 	if rules == nil {
@@ -351,7 +360,7 @@ func canonicalizeRuleList(
 			}
 		}
 		for _, pair := range rule.UserIDGroupPairs {
-			canonicalizeGroupPair(pair, selfID, ownerAccountID)
+			canonicalizeGroupPair(pair, selfID, selfName, ownerAccountID)
 		}
 	}
 
@@ -403,6 +412,7 @@ func canonicalizeRuleList(
 func canonicalizeGroupPair(
 	pair *svcapitypes.UserIDGroupPair,
 	selfID string,
+	selfName string,
 	ownerAccountID string,
 ) {
 	if pair == nil {
@@ -415,39 +425,29 @@ func canonicalizeGroupPair(
 	pair.GroupRef = nil
 	pair.VPCRef = nil
 
-	// VPCID, PeeringStatus and VPCPeeringConnectionID are read-only reference
-	// metadata EC2 derives from the referenced group -- not customer inputs. The
-	// authorize path ignores them, and DescribeSecurityGroups fills them in from
-	// the peer group itself: VPCID is set to the peer group's network only when
-	// it differs from the containing group's VPC (i.e. a cross-VPC reference),
-	// PeeringStatus/VPCPeeringConnectionID likewise. Because the spec cannot set
-	// them meaningfully, an omitted VPCID would otherwise churn forever against
-	// the AWS-filled value on a cross-VPC peer reference. Clear them on the
-	// canonical copy (applied to both desired and latest) so they never drive a
-	// delta. The sync path authorises/revokes the raw spec rules, so this never
-	// affects what is sent to AWS.
+	// VPCID, PeeringStatus and VPCPeeringConnectionID are read-only: EC2 derives
+	// them from the referenced group and ignores any spec value (verified against
+	// the live API), so clear them on the copy to keep an AWS-filled cross-VPC
+	// read-back from churning against an omitted spec value.
 	pair.VPCID = nil
 	pair.PeeringStatus = nil
 	pair.VPCPeeringConnectionID = nil
 
-	// Self-reference: GroupID == selfID, or all group identifiers omitted (the
-	// spec shorthand, since the ID is unknown until AWS assigns it). AWS fills
-	// GroupID/UserID/GroupName on read-back, so canonicalise to {GroupID: selfID}.
-	isSelf := (pair.GroupID != nil && selfID != "" && *pair.GroupID == selfID) ||
-		(pair.GroupID == nil && pair.GroupName == nil)
-	if isSelf {
-		if selfID != "" {
-			id := selfID
-			pair.GroupID = &id
-		}
+	// Self-reference: AWS returns the SG's own GroupID/GroupName on read-back
+	// while the spec shorthand omits the group. Strip a self GroupID and a
+	// GroupName matching the SG's own name so both sides converge. A non-matching
+	// GroupName is a real value (by-name cross-ref, or user error) and is kept so
+	// a genuine diff still surfaces.
+	if pair.GroupID != nil && *pair.GroupID == selfID {
+		pair.GroupID = nil
+	}
+	if pair.GroupName != nil && *pair.GroupName == selfName {
 		pair.GroupName = nil
-		pair.UserID = nil
-		return
 	}
 	// AWS fills UserID with the owner account for same-account grants; clear it.
 	// Cross-account grants (UserID != owner) are kept -- the account identifies
 	// the referenced group.
-	if pair.UserID != nil && ownerAccountID != "" && *pair.UserID == ownerAccountID {
+	if pair.UserID != nil && *pair.UserID == ownerAccountID {
 		pair.UserID = nil
 	}
 }

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -415,6 +415,21 @@ func canonicalizeGroupPair(
 	pair.GroupRef = nil
 	pair.VPCRef = nil
 
+	// VPCID, PeeringStatus and VPCPeeringConnectionID are read-only reference
+	// metadata EC2 derives from the referenced group -- not customer inputs. The
+	// authorize path ignores them, and DescribeSecurityGroups fills them in from
+	// the peer group itself: VPCID is set to the peer group's network only when
+	// it differs from the containing group's VPC (i.e. a cross-VPC reference),
+	// PeeringStatus/VPCPeeringConnectionID likewise. Because the spec cannot set
+	// them meaningfully, an omitted VPCID would otherwise churn forever against
+	// the AWS-filled value on a cross-VPC peer reference. Clear them on the
+	// canonical copy (applied to both desired and latest) so they never drive a
+	// delta. The sync path authorises/revokes the raw spec rules, so this never
+	// affects what is sent to AWS.
+	pair.VPCID = nil
+	pair.PeeringStatus = nil
+	pair.VPCPeeringConnectionID = nil
+
 	// Self-reference: GroupID == selfID, or all group identifiers omitted (the
 	// spec shorthand, since the ID is unknown until AWS assigns it). AWS fills
 	// GroupID/UserID/GroupName on read-back, so canonicalise to {GroupID: selfID}.

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -268,8 +268,9 @@ func customPostCompare(
 }
 
 // canonicalizeCopiedRuleLists returns canonical *copies* of r's rule lists; r is
-// never mutated. Used for comparison (customPostCompare) and to build AWS
-// Authorize/Revoke inputs (syncSGRules).
+// never mutated. Used only for delta comparison (customPostCompare). The sync
+// path intentionally does NOT use this -- it authorises/revokes the raw spec
+// rules so a canonicalisation defect can never alter what is sent to AWS.
 func canonicalizeCopiedRuleLists(
 	r *resource,
 ) (ingress []*svcapitypes.IPPermission, egress []*svcapitypes.IPPermission) {
@@ -535,40 +536,38 @@ func (rm *resourceManager) syncSGRules(
 	exit := rlog.Trace("rm.syncSGRules")
 	defer func() { exit(err) }()
 
-	// Compare and authorise canonical copies so server-side normalisation never
-	// re-authorises an equivalent rule, without mutating desired/latest (and so
-	// the persisted Spec).
-	desiredIngressRules, desiredEgressRules := canonicalizeCopiedRuleLists(desired)
-	var latestIngressRules, latestEgressRules []*svcapitypes.IPPermission
-	if latest != nil {
-		latestIngressRules, latestEgressRules = canonicalizeCopiedRuleLists(latest)
-	}
-
+	// The sync path deliberately matches and authorises/revokes the RAW spec
+	// rules, never canonicalised copies. Canonicalisation lives only in the
+	// delta (customPostCompare): the canonical delta gates whether sync fires
+	// and converges once the state matches, so a canonicalisation defect can, at
+	// worst, mis-scope which rules churn -- it can never change the rule content
+	// sent to AWS. Keeping the raw spec here means the values submitted to
+	// Authorize/Revoke are always exactly what the user declared (or what AWS
+	// itself returned), which AWS then normalises server-side.
 	toAddIngress := []*svcapitypes.IPPermission{}
 	toAddEgress := []*svcapitypes.IPPermission{}
 	toDeleteIngress := []*svcapitypes.IPPermission{}
 	toDeleteEgress := []*svcapitypes.IPPermission{}
-
-	for _, desiredIngress := range desiredIngressRules {
-		if latest == nil || !containsRule(latestIngressRules, desiredIngress) {
+	for _, desiredIngress := range desired.ko.Spec.IngressRules {
+		if latest == nil || !containsRule(latest.ko.Spec.IngressRules, desiredIngress) {
 			// a desired rule is not in the latest resource; therefore, create
 			toAddIngress = append(toAddIngress, desiredIngress)
 		}
 	}
-	for _, desiredEgress := range desiredEgressRules {
-		if latest == nil || !containsRule(latestEgressRules, desiredEgress) {
+	for _, desiredEgress := range desired.ko.Spec.EgressRules {
+		if latest == nil || !containsRule(latest.ko.Spec.EgressRules, desiredEgress) {
 			toAddEgress = append(toAddEgress, desiredEgress)
 		}
 	}
 	if latest != nil {
-		for _, latestIngress := range latestIngressRules {
-			if !containsRule(desiredIngressRules, latestIngress) {
+		for _, latestIngress := range latest.ko.Spec.IngressRules {
+			if !containsRule(desired.ko.Spec.IngressRules, latestIngress) {
 				// a rule is in latest resource, but not in desired resource; therefore, delete
 				toDeleteIngress = append(toDeleteIngress, latestIngress)
 			}
 		}
-		for _, latestEgress := range latestEgressRules {
-			if !containsRule(desiredEgressRules, latestEgress) {
+		for _, latestEgress := range latest.ko.Spec.EgressRules {
+			if !containsRule(desired.ko.Spec.EgressRules, latestEgress) {
 				toDeleteEgress = append(toDeleteEgress, latestEgress)
 			}
 		}

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -138,6 +138,13 @@ func (rm *resourceManager) referencesResolved(
 // range for such rules on read-back.
 const allProtocols = "-1"
 
+// icmpv6Protocol is the canonical protocol name canonicalizeProtocol emits for
+// protocol 58. Unlike icmp, icmpv6 does not require an ICMP type/code (it is not
+// in the backend's PROTOCOLS_THAT_MUST_RECEIVE_ICMP_OPTION set), so the spec may
+// omit fromPort/toPort while AWS returns the "all types and codes" wildcard as
+// -1/-1 on read-back.
+const icmpv6Protocol = "icmpv6"
+
 // wellKnownProtocols are the IANA protocol numbers EC2 returns by name on
 // read-back, so a numeric spec value ("6") would otherwise differ forever from
 // the name ("tcp"). Other protocols (and "-1") are already canonical.
@@ -307,6 +314,19 @@ func canonicalizeRuleList(
 		if rule.IPProtocol != nil && *rule.IPProtocol == allProtocols {
 			rule.FromPort = nil // AWS drops the port range for "-1" rules.
 			rule.ToPort = nil
+		} else if rule.IPProtocol != nil && *rule.IPProtocol == icmpv6Protocol {
+			// icmpv6 overloads fromPort/toPort as ICMP type/code and, unlike
+			// icmp, allows omitting them: the spec may leave them nil while AWS
+			// returns the "all types and codes" wildcard as -1/-1 on read-back.
+			// Collapse that -1 wildcard to nil so the omitted and explicit
+			// spellings compare equal. A real type/code (0-255) is left
+			// untouched, and icmp (which requires a type/code) is unaffected.
+			if rule.FromPort != nil && *rule.FromPort == -1 {
+				rule.FromPort = nil
+			}
+			if rule.ToPort != nil && *rule.ToPort == -1 {
+				rule.ToPort = nil
+			}
 		}
 		for _, r := range rule.IPRanges {
 			if r != nil {

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -134,16 +134,26 @@ func (rm *resourceManager) referencesResolved(
 	return true
 }
 
-// allProtocols is the IpProtocol value for "all protocols"; AWS drops the port
-// range for such rules on read-back.
-const allProtocols = "-1"
-
 // icmpv6Protocol is the canonical protocol name canonicalizeProtocol emits for
 // protocol 58. Unlike icmp, icmpv6 does not require an ICMP type/code (it is not
 // in the backend's PROTOCOLS_THAT_MUST_RECEIVE_ICMP_OPTION set), so the spec may
 // omit fromPort/toPort while AWS returns the "all types and codes" wildcard as
 // -1/-1 on read-back.
 const icmpv6Protocol = "icmpv6"
+
+// portCarryingProtocols are the protocols EC2 keeps a port range for (or, for
+// ICMP, an overloaded type/code) on read-back. This mirrors the backend's
+// PROTOCOLS_THAT_CAN_RECEIVE_PORT_RANGE_OPTION_FROM_PAPERWORK set in EC2-NM-Frontend's
+// TypeSecurityGroupTrafficFilter. For every other protocol -- "-1" (all traffic)
+// and any other IP protocol number such as 50 (ESP) or 47 (GRE) -- AWS omits
+// fromPort/toPort on read-back. Keyed by the canonical name canonicalizeProtocol
+// emits (numeric 6/17/1/58 are mapped to tcp/udp/icmp/icmpv6 first).
+var portCarryingProtocols = map[string]struct{}{
+	"tcp":          {},
+	"udp":          {},
+	"icmp":         {},
+	icmpv6Protocol: {},
+}
 
 // wellKnownProtocols are the IANA protocol numbers EC2 returns by name on
 // read-back, so a numeric spec value ("6") would otherwise differ forever from
@@ -311,21 +321,28 @@ func canonicalizeRuleList(
 			continue
 		}
 		rule.IPProtocol = canonicalizeProtocol(rule.IPProtocol)
-		if rule.IPProtocol != nil && *rule.IPProtocol == allProtocols {
-			rule.FromPort = nil // AWS drops the port range for "-1" rules.
-			rule.ToPort = nil
-		} else if rule.IPProtocol != nil && *rule.IPProtocol == icmpv6Protocol {
-			// icmpv6 overloads fromPort/toPort as ICMP type/code and, unlike
-			// icmp, allows omitting them: the spec may leave them nil while AWS
-			// returns the "all types and codes" wildcard as -1/-1 on read-back.
-			// Collapse that -1 wildcard to nil so the omitted and explicit
-			// spellings compare equal. A real type/code (0-255) is left
-			// untouched, and icmp (which requires a type/code) is unaffected.
-			if rule.FromPort != nil && *rule.FromPort == -1 {
+		if rule.IPProtocol != nil {
+			proto := *rule.IPProtocol
+			if _, carriesPorts := portCarryingProtocols[proto]; !carriesPorts {
+				// AWS omits the port range for every protocol outside
+				// {tcp, udp, icmp, icmpv6}: "-1" (all traffic) and any other IP
+				// protocol number such as 50 (ESP) or 47 (GRE). Drop them so the
+				// spec form matches the read-back form.
 				rule.FromPort = nil
-			}
-			if rule.ToPort != nil && *rule.ToPort == -1 {
 				rule.ToPort = nil
+			} else if proto == icmpv6Protocol {
+				// icmpv6 overloads fromPort/toPort as ICMP type/code and, unlike
+				// icmp, allows omitting them: the spec may leave them nil while AWS
+				// returns the "all types and codes" wildcard as -1/-1 on read-back.
+				// Collapse that -1 wildcard to nil so the omitted and explicit
+				// spellings compare equal. A real type/code (0-255) is left
+				// untouched, and icmp (which requires a type/code) is unaffected.
+				if rule.FromPort != nil && *rule.FromPort == -1 {
+					rule.FromPort = nil
+				}
+				if rule.ToPort != nil && *rule.ToPort == -1 {
+					rule.ToPort = nil
+				}
 			}
 		}
 		for _, r := range rule.IPRanges {

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -190,11 +190,16 @@ func canonicalizeCIDR(cidr *string) *string {
 // It closes six independent perpetual-diff sources (see
 // aws-controllers-k8s/community#2822):
 //
-//  1. Self-references. A pair is a self-reference when GroupID equals the
-//     SG's own ID, or when GroupID/GroupRef/GroupName are all omitted (the
-//     spec form, since the ID is unknown until AWS assigns it). AWS fills
-//     GroupID, UserID and sometimes GroupName on read-back. We canonicalise
-//     to {GroupID: selfID} and clear GroupRef/UserID/GroupName.
+//  1. Reference wrappers and self-references. GroupRef/VPCRef are spec-only
+//     reference wrappers that ACK resolves into concrete IDs (GroupID/VPCID)
+//     before the delta runs and that AWS never returns on read-back; they are
+//     cleared first so they play no part in the delta at all. We assume the
+//     resolved ID is present (the referencesResolved guard defers rule sync
+//     until it is). A pair is additionally a self-reference when GroupID
+//     equals the SG's own ID, or when the group identifiers are all omitted
+//     (the spec shorthand, since the ID is unknown until AWS assigns it). AWS
+//     fills GroupID, UserID and sometimes GroupName on read-back. We
+//     canonicalise to {GroupID: selfID} and clear GroupName/UserID.
 //  2. All-protocol ("-1") port ranges. AWS drops FromPort/ToPort for these;
 //     we drop them on both sides.
 //  3. Server-filled owner account. AWS populates UserID with the owning
@@ -344,9 +349,11 @@ func canonicalizeRuleList(
 	return out
 }
 
-// canonicalizeGroupPair normalises a single UserIDGroupPair in place,
-// covering the self-reference (gap driving #2822) and server-filled owner
-// account (gap 2) cases.
+// canonicalizeGroupPair normalises a single UserIDGroupPair in place. Its
+// first act is to strip the spec-only reference wrappers (GroupRef/VPCRef) so
+// they play no part whatsoever in the delta; it then covers the
+// self-reference (gap driving #2822) and server-filled owner account (gap 2)
+// cases against the resolved concrete IDs.
 func canonicalizeGroupPair(
 	pair *svcapitypes.UserIDGroupPair,
 	selfID string,
@@ -355,20 +362,28 @@ func canonicalizeGroupPair(
 	if pair == nil {
 		return
 	}
-	// A self-reference is either an explicit reference to the SG's own ID
-	// (how AWS returns it, and how ResolveReferences fills a self groupRef)
-	// or a pair that omits all group identifiers (the spec shorthand for
-	// "this SG", since the ID is unknown until AWS assigns it).
+	// Step 1, before anything else: drop the spec-only reference wrappers.
+	// GroupRef/VPCRef are resolved into their concrete IDs (GroupID/VPCID) by
+	// ResolveReferences before the delta ever runs, and AWS never returns them
+	// on read-back. By the time we compare, the resolved ID is authoritative
+	// and the wrapper is dead weight, so it must not influence the delta in
+	// any way. A groupRef that has not resolved yet (GroupID still nil) is not
+	// this code's concern: the referencesResolved guard defers rule sync until
+	// the referenced ID is populated, so we assume GroupID is resolved here.
+	pair.GroupRef = nil
+	pair.VPCRef = nil
+
+	// A self-reference is an explicit reference to the SG's own (resolved) ID,
+	// or the spec shorthand that omits every group identifier ("this SG",
+	// since the ID is unknown until AWS assigns it). GroupRef is intentionally
+	// absent from this test: it has already been cleared above.
 	isSelf := (pair.GroupID != nil && selfID != "" && *pair.GroupID == selfID) ||
-		(pair.GroupID == nil && pair.GroupRef == nil && pair.GroupName == nil)
+		(pair.GroupID == nil && pair.GroupName == nil)
 	if isSelf {
 		if selfID != "" {
 			id := selfID
 			pair.GroupID = &id
 		}
-		// GroupRef is a spec-only reference wrapper never present on AWS
-		// read-back; once GroupID is set it is redundant for comparison.
-		pair.GroupRef = nil
 		pair.GroupName = nil
 		pair.UserID = nil
 		return
@@ -379,11 +394,6 @@ func canonicalizeGroupPair(
 	// account is required to identify the referenced group.
 	if pair.UserID != nil && ownerAccountID != "" && *pair.UserID == ownerAccountID {
 		pair.UserID = nil
-	}
-	// A resolved cross-SG reference carries both GroupRef (spec-only) and
-	// GroupID; drop GroupRef so it matches the AWS-returned form.
-	if pair.GroupRef != nil && pair.GroupID != nil {
-		pair.GroupRef = nil
 	}
 }
 

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -133,16 +133,13 @@ func (rm *resourceManager) referencesResolved(
 	return true
 }
 
-// allProtocols is the IpProtocol value EC2 uses to mean "all protocols".
-// For such rules AWS ignores the port range and DescribeSecurityGroups
-// returns the rule with FromPort/ToPort unset.
+// allProtocols is the IpProtocol value for "all protocols"; AWS drops the port
+// range for such rules on read-back.
 const allProtocols = "-1"
 
-// wellKnownProtocols maps the IANA protocol numbers that EC2 canonicalises to
-// names on DescribeSecurityGroups read-back. A spec that uses the numeric form
-// (e.g. "6") would otherwise perpetually differ from the name AWS returns
-// ("tcp"). Protocols outside this set are returned by AWS as-is (their number),
-// so they need no mapping; "-1" (all protocols) is already canonical.
+// wellKnownProtocols are the IANA protocol numbers EC2 returns by name on
+// read-back, so a numeric spec value ("6") would otherwise differ forever from
+// the name ("tcp"). Other protocols (and "-1") are already canonical.
 var wellKnownProtocols = map[string]string{
 	"1":  "icmp",
 	"6":  "tcp",
@@ -150,9 +147,8 @@ var wellKnownProtocols = map[string]string{
 	"58": "icmpv6",
 }
 
-// canonicalizeProtocol maps a numeric IpProtocol to the name EC2 returns on
-// read-back so that numeric and name spellings of the same protocol compare
-// equal. Unknown protocols and names are returned unchanged.
+// canonicalizeProtocol maps a numeric IpProtocol to the name EC2 returns;
+// unknown protocols and names pass through unchanged.
 func canonicalizeProtocol(proto *string) *string {
 	if proto == nil {
 		return nil
@@ -163,12 +159,9 @@ func canonicalizeProtocol(proto *string) *string {
 	return proto
 }
 
-// canonicalizeCIDR rewrites a CIDR to the network form EC2 returns on
-// read-back: host bits are masked off and (for IPv6) the text is normalised
-// to lowercase, zero-compressed RFC 5952 form -- e.g. "100.68.0.18/18" ->
-// "100.68.0.0/18" and "2001:DB8:abcd:0012::1/64" -> "2001:db8:abcd:12::/64".
-// A value that does not parse as a CIDR is returned unchanged (AWS will
-// reject a truly malformed CIDR on the API call).
+// canonicalizeCIDR rewrites a CIDR to the network form EC2 returns: host bits
+// masked off, IPv6 lowercased and zero-compressed (e.g. "100.68.0.18/18" ->
+// "100.68.0.0/18"). An unparseable value passes through unchanged.
 func canonicalizeCIDR(cidr *string) *string {
 	if cidr == nil {
 		return nil
@@ -181,38 +174,13 @@ func canonicalizeCIDR(cidr *string) *string {
 	return &canon
 }
 
-// customPostCompare is injected at the end of the generated newResourceDelta
-// (see delta.go) via the `delta_post_compare` hook in generator.yaml. The
-// generated field-by-field comparison skips Spec.IngressRules and
-// Spec.EgressRules entirely (they are marked `compare.is_ignored: true`);
-// this hook compares them instead.
-//
-// Unlike a `delta_pre_compare` hook, it MUST NOT mutate a or b: the same
-// objects are used downstream as the merge-patch base in
-// patchResourceMetadataAndSpec, so any mutation here would leak into the
-// persisted Spec. Instead it compares canonical *copies* and records a delta
-// against the original (un-normalised) values, so genuine changes are
-// reported while server-side normalisation never produces a spurious diff.
-//
-// canonicalizeCopiedRuleLists closes the perpetual-diff sources from
-// aws-controllers-k8s/community#2822:
-//
-//  1. Reference wrappers and self-references. GroupRef/VPCRef are spec-only
-//     wrappers AWS never returns; they are cleared in the copy. A pair is a
-//     self-reference when GroupID equals the SG's own ID, or when the group
-//     identifiers are all omitted (the spec shorthand). We canonicalise to
-//     {GroupID: selfID} and clear GroupName/UserID.
-//  2. All-protocol ("-1") port ranges. AWS drops FromPort/ToPort for these.
-//  3. Server-filled owner account. AWS populates UserID with the owning
-//     account for same-account grants; we clear it. Cross-account grants
-//     (UserID != owner) are preserved so the reference stays intact.
-//  4. Grant aggregation. AWS merges grants sharing (protocol, fromPort,
-//     toPort) into one IpPermission; we aggregate both sides by that key and
-//     sort deterministically so ordering never drives a diff.
-//  5. Protocol notation. AWS canonicalises well-known IANA protocol numbers
-//     to names on read-back ("6" -> "tcp").
-//  6. CIDR canonicalisation. AWS masks host bits and normalises IPv6 text
-//     ("100.68.0.18/18" -> "100.68.0.0/18").
+// customPostCompare compares Spec.IngressRules/EgressRules, which the generated
+// delta skips (they are marked compare.is_ignored). It normalises canonical
+// *copies* of both sides -- never a or b, which become the merge-patch base in
+// patchResourceMetadataAndSpec -- so the server-side rule normalisation behind
+// aws-controllers-k8s/community#2822 never drives a spurious diff, while genuine
+// changes still register. See canonicalizeRuleList and canonicalizeGroupPair for
+// the specific normalisations.
 func customPostCompare(
 	delta *ackcompare.Delta,
 	a *resource,
@@ -231,10 +199,9 @@ func customPostCompare(
 	}
 }
 
-// canonicalizeCopiedRuleLists returns canonical *copies* of r's Ingress and
-// Egress rule lists. r is never mutated, so callers can use the result purely
-// for comparison (customPostCompare) or to build AWS Authorize/Revoke inputs
-// (syncSGRules) without affecting the persisted Spec.
+// canonicalizeCopiedRuleLists returns canonical *copies* of r's rule lists; r is
+// never mutated. Used for comparison (customPostCompare) and to build AWS
+// Authorize/Revoke inputs (syncSGRules).
 func canonicalizeCopiedRuleLists(
 	r *resource,
 ) (ingress []*svcapitypes.IPPermission, egress []*svcapitypes.IPPermission) {
@@ -255,9 +222,8 @@ func canonicalizeCopiedRuleLists(
 	return ingress, egress
 }
 
-// deepCopyRuleList returns a deep copy of a rule list so that in-place
-// canonicalisation never touches the caller's backing data. A nil input
-// returns nil so an empty and an absent rule list keep comparing equal.
+// deepCopyRuleList deep-copies a rule list so canonicalisation never touches the
+// caller's data. nil in -> nil out (absent and empty stay equal).
 func deepCopyRuleList(rules []*svcapitypes.IPPermission) []*svcapitypes.IPPermission {
 	if rules == nil {
 		return nil
@@ -269,10 +235,9 @@ func deepCopyRuleList(rules []*svcapitypes.IPPermission) []*svcapitypes.IPPermis
 	return out
 }
 
-// canonicalizeRuleList normalises each rule (ports + grants), aggregates
-// rules sharing the same (protocol, fromPort, toPort) key, and returns the
-// result sorted deterministically. A nil input returns nil so an empty and
-// an absent rule list keep comparing equal.
+// canonicalizeRuleList normalises each rule and its grants, aggregates rules
+// sharing the same (protocol, fromPort, toPort) key, and returns them
+// deterministically sorted. nil in -> nil out.
 func canonicalizeRuleList(
 	rules []*svcapitypes.IPPermission,
 	selfID string,
@@ -282,21 +247,16 @@ func canonicalizeRuleList(
 		return nil
 	}
 
-	// Per-rule field normalisation.
+	// Per-rule field normalisation to match the AWS read-back form.
 	for _, rule := range rules {
 		if rule == nil {
 			continue
 		}
-		// Gap 5: AWS returns well-known protocols by name ("tcp"), so map a
-		// numeric spec value ("6") to the same name before comparing.
 		rule.IPProtocol = canonicalizeProtocol(rule.IPProtocol)
-		// Gap 1: AWS ignores and drops the port range for "-1" rules.
 		if rule.IPProtocol != nil && *rule.IPProtocol == allProtocols {
-			rule.FromPort = nil
+			rule.FromPort = nil // AWS drops the port range for "-1" rules.
 			rule.ToPort = nil
 		}
-		// Gap 6: AWS canonicalises CIDRs (masks host bits; lowercases and
-		// zero-compresses IPv6). Match that form on both sides.
 		for _, r := range rule.IPRanges {
 			if r != nil {
 				r.CIDRIP = canonicalizeCIDR(r.CIDRIP)
@@ -312,9 +272,8 @@ func canonicalizeRuleList(
 		}
 	}
 
-	// Gap 3: aggregate rules that share the same (protocol, fromPort,
-	// toPort) key, preserving first-seen order for stability before the
-	// final sort.
+	// AWS merges grants sharing a (protocol, fromPort, toPort) key into one
+	// IpPermission; aggregate the same way, keeping first-seen order.
 	byKey := map[string]*svcapitypes.IPPermission{}
 	order := make([]string, 0, len(rules))
 	for _, rule := range rules {
@@ -329,8 +288,7 @@ func canonicalizeRuleList(
 			existing.UserIDGroupPairs = append(existing.UserIDGroupPairs, rule.UserIDGroupPairs...)
 			continue
 		}
-		// Copy the rule and its grant slices so aggregation never aliases
-		// or mutates the caller's backing arrays.
+		// Copy so aggregation never aliases the caller's backing arrays.
 		merged := &svcapitypes.IPPermission{
 			FromPort:         rule.FromPort,
 			ToPort:           rule.ToPort,
@@ -350,19 +308,15 @@ func canonicalizeRuleList(
 		sortGrants(rule)
 		out = append(out, rule)
 	}
-	// Sort rules by their aggregation key so read-back ordering never drives
-	// a diff. Keys are unique after aggregation, so the order is total.
+	// Sort by aggregation key (unique after aggregation) so read-back ordering
+	// never drives a diff.
 	sort.Slice(out, func(i, j int) bool {
 		return ruleAggregationKey(out[i]) < ruleAggregationKey(out[j])
 	})
 	return out
 }
 
-// canonicalizeGroupPair normalises a single UserIDGroupPair in place. Its
-// first act is to strip the spec-only reference wrappers (GroupRef/VPCRef) so
-// they play no part whatsoever in the delta; it then covers the
-// self-reference (gap driving #2822) and server-filled owner account (gap 2)
-// cases against the resolved concrete IDs.
+// canonicalizeGroupPair normalises a single UserIDGroupPair (on a copy).
 func canonicalizeGroupPair(
 	pair *svcapitypes.UserIDGroupPair,
 	selfID string,
@@ -371,21 +325,16 @@ func canonicalizeGroupPair(
 	if pair == nil {
 		return
 	}
-	// Step 1, before anything else: drop the spec-only reference wrappers.
-	// GroupRef/VPCRef are resolved into their concrete IDs (GroupID/VPCID) by
-	// ResolveReferences before the delta ever runs, and AWS never returns them
-	// on read-back. By the time we compare, the resolved ID is authoritative
-	// and the wrapper is dead weight, so it must not influence the delta in
-	// any way. A groupRef that has not resolved yet (GroupID still nil) is not
-	// this code's concern: the referencesResolved guard defers rule sync until
-	// the referenced ID is populated, so we assume GroupID is resolved here.
+	// GroupRef/VPCRef are spec-only wrappers ResolveReferences turns into
+	// concrete IDs before the delta and AWS never returns; drop them so they
+	// never drive a diff. GroupID is assumed resolved (referencesResolved
+	// defers sync until it is).
 	pair.GroupRef = nil
 	pair.VPCRef = nil
 
-	// A self-reference is an explicit reference to the SG's own (resolved) ID,
-	// or the spec shorthand that omits every group identifier ("this SG",
-	// since the ID is unknown until AWS assigns it). GroupRef is intentionally
-	// absent from this test: it has already been cleared above.
+	// Self-reference: GroupID == selfID, or all group identifiers omitted (the
+	// spec shorthand, since the ID is unknown until AWS assigns it). AWS fills
+	// GroupID/UserID/GroupName on read-back, so canonicalise to {GroupID: selfID}.
 	isSelf := (pair.GroupID != nil && selfID != "" && *pair.GroupID == selfID) ||
 		(pair.GroupID == nil && pair.GroupName == nil)
 	if isSelf {
@@ -397,10 +346,9 @@ func canonicalizeGroupPair(
 		pair.UserID = nil
 		return
 	}
-	// Non-self pairs: AWS auto-fills UserID with the owning account for
-	// same-account grants. Clear it so its absence in the spec is not a
-	// diff. Cross-account grants (UserID != owner) are preserved -- the
-	// account is required to identify the referenced group.
+	// AWS fills UserID with the owner account for same-account grants; clear it.
+	// Cross-account grants (UserID != owner) are kept -- the account identifies
+	// the referenced group.
 	if pair.UserID != nil && ownerAccountID != "" && *pair.UserID == ownerAccountID {
 		pair.UserID = nil
 	}
@@ -424,14 +372,9 @@ func ruleAggregationKey(rule *svcapitypes.IPPermission) string {
 	return proto + "/" + from + "/" + to
 }
 
-// sortGrants sorts every grant collection of a rule into a deterministic
-// order so that read-back ordering within a rule never drives a diff.
-//
-// The per-element sort keys are nil-safe (a nil element sorts as ""), matching
-// the nil check in canonicalizeRuleList. Neither the CRD schema (which rejects
-// null list entries) nor the read-back setter (which always allocates each
-// element) can produce a nil element, so this is defensive only -- but it keeps
-// the comparators panic-free and consistent with the rest of the file.
+// sortGrants deterministically orders a rule's grant collections so read-back
+// ordering never drives a diff. Sort keys are nil-safe (defensive; the schema
+// and setters never emit nil elements).
 func sortGrants(rule *svcapitypes.IPPermission) {
 	if rule == nil {
 		return
@@ -504,11 +447,9 @@ func (rm *resourceManager) syncSGRules(
 	exit := rlog.Trace("rm.syncSGRules")
 	defer func() { exit(err) }()
 
-	// Compare and authorise the canonical form of both sides so that
-	// server-side normalisation (see customPostCompare) never revokes and
-	// re-authorises an equivalent rule. Copies are used so neither desired
-	// nor latest -- and therefore neither the persisted Spec nor the AWS
-	// read-back reflected into it -- is mutated.
+	// Compare and authorise canonical copies so server-side normalisation never
+	// re-authorises an equivalent rule, without mutating desired/latest (and so
+	// the persisted Spec).
 	desiredIngressRules, desiredEgressRules := canonicalizeCopiedRuleLists(desired)
 	var latestIngressRules, latestEgressRules []*svcapitypes.IPPermission
 	if latest != nil {

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -187,7 +187,7 @@ func canonicalizeCIDR(cidr *string) *string {
 // DeepEqual does not report spurious diffs that arise purely from how AWS
 // normalises rules on DescribeSecurityGroups read-back.
 //
-// It closes four independent perpetual-diff sources (see
+// It closes six independent perpetual-diff sources (see
 // aws-controllers-k8s/community#2822):
 //
 //  1. Self-references. A pair is a self-reference when GroupID equals the
@@ -407,20 +407,53 @@ func ruleAggregationKey(rule *svcapitypes.IPPermission) string {
 
 // sortGrants sorts every grant collection of a rule into a deterministic
 // order so that read-back ordering within a rule never drives a diff.
+//
+// The per-element sort keys are nil-safe (a nil element sorts as ""), matching
+// the nil check in canonicalizeRuleList. Neither the CRD schema (which rejects
+// null list entries) nor the read-back setter (which always allocates each
+// element) can produce a nil element, so this is defensive only -- but it keeps
+// the comparators panic-free and consistent with the rest of the file.
 func sortGrants(rule *svcapitypes.IPPermission) {
+	if rule == nil {
+		return
+	}
 	sort.Slice(rule.IPRanges, func(i, j int) bool {
-		return derefStr(rule.IPRanges[i].CIDRIP) < derefStr(rule.IPRanges[j].CIDRIP)
+		return ipRangeSortKey(rule.IPRanges[i]) < ipRangeSortKey(rule.IPRanges[j])
 	})
 	sort.Slice(rule.IPv6Ranges, func(i, j int) bool {
-		return derefStr(rule.IPv6Ranges[i].CIDRIPv6) < derefStr(rule.IPv6Ranges[j].CIDRIPv6)
+		return ipv6RangeSortKey(rule.IPv6Ranges[i]) < ipv6RangeSortKey(rule.IPv6Ranges[j])
 	})
 	sort.Slice(rule.PrefixListIDs, func(i, j int) bool {
-		return derefStr(rule.PrefixListIDs[i].PrefixListID) < derefStr(rule.PrefixListIDs[j].PrefixListID)
+		return prefixListIDSortKey(rule.PrefixListIDs[i]) < prefixListIDSortKey(rule.PrefixListIDs[j])
 	})
 	sort.Slice(rule.UserIDGroupPairs, func(i, j int) bool {
 		return userIDGroupPairSortKey(rule.UserIDGroupPairs[i]) <
 			userIDGroupPairSortKey(rule.UserIDGroupPairs[j])
 	})
+}
+
+// ipRangeSortKey builds a nil-safe stable sort key for an IPv4 CIDR grant.
+func ipRangeSortKey(r *svcapitypes.IPRange) string {
+	if r == nil {
+		return ""
+	}
+	return derefStr(r.CIDRIP)
+}
+
+// ipv6RangeSortKey builds a nil-safe stable sort key for an IPv6 CIDR grant.
+func ipv6RangeSortKey(r *svcapitypes.IPv6Range) string {
+	if r == nil {
+		return ""
+	}
+	return derefStr(r.CIDRIPv6)
+}
+
+// prefixListIDSortKey builds a nil-safe stable sort key for a prefix-list grant.
+func prefixListIDSortKey(p *svcapitypes.PrefixListID) string {
+	if p == nil {
+		return ""
+	}
+	return derefStr(p.PrefixListID)
 }
 
 // userIDGroupPairSortKey builds a stable sort key for a group pair from the

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"sort"
 	"strconv"
+	"strings"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
@@ -159,18 +160,70 @@ func canonicalizeProtocol(proto *string) *string {
 	return proto
 }
 
-// canonicalizeCIDR rewrites a CIDR to the network form EC2 returns: host bits
-// masked off, IPv6 lowercased and zero-compressed (e.g. "100.68.0.18/18" ->
-// "100.68.0.0/18"). An unparseable value passes through unchanged.
+// canonicalizeCIDR rewrites a CIDR to the exact network form the EC2 backend
+// stores. It is a direct port of com.amazon.ec2.nm.CidrBlock.canonicalizeAddress
+// (package EC2-NM-Common, the class the EC2 control plane uses): a network mask
+// is built one byte at a time from the prefix length and ANDed with the address,
+// masking off every host bit. The masked address is rendered in the same text
+// form AWS returns on read-back -- dotted-quad for IPv4, RFC 5952 lowercase
+// zero-compressed for IPv6 (matching the backend's Guava
+// InetAddresses.toAddrString) -- so "100.68.0.18/18" -> "100.68.0.0/18" and
+// "2001:DB8:abcd:0012::1/64" -> "2001:db8:abcd:12::/64".
+//
+// Applying the backend's own conversion here, before both the delta comparison
+// and the Authorize/Revoke request, is what stops the spurious diff: the desired
+// spec form and the AWS read-back form collapse to the identical network. It
+// also avoids the InvalidPermission.Duplicate error AWS throws when a
+// non-canonical CIDR is submitted for a rule already stored in canonical form.
+//
+// A value that is not a well-formed CIDR -- or whose prefix is longer than the
+// address, which the backend rejects -- passes through unchanged.
 func canonicalizeCIDR(cidr *string) *string {
 	if cidr == nil {
 		return nil
 	}
-	_, ipNet, err := net.ParseCIDR(*cidr)
-	if err != nil {
+	slash := strings.LastIndex(*cidr, "/")
+	if slash < 0 {
 		return cidr
 	}
-	canon := ipNet.String()
+	ip := net.ParseIP((*cidr)[:slash])
+	prefixLength, err := strconv.Atoi((*cidr)[slash+1:])
+	if ip == nil || err != nil || prefixLength < 0 {
+		return cidr
+	}
+
+	// Match the backend's byte layout: 4 bytes for IPv4, 16 for IPv6.
+	addr := ip.To4()
+	if addr == nil {
+		addr = ip.To16()
+	}
+	if addr == nil {
+		return cidr
+	}
+
+	// Build the network mask exactly as CidrBlock.canonicalizeAddress does --
+	// one byte at a time -- and AND it into the address. Bytes past the prefix
+	// stay zero, which is the host-bit masking.
+	remaining := prefixLength
+	network := make(net.IP, len(addr))
+	for i := 0; i < len(addr) && remaining > 0; i++ {
+		var maskByte byte
+		if remaining > 8 {
+			maskByte = 0xff
+			remaining -= 8
+		} else {
+			maskByte = byte(((1 << remaining) - 1) << (8 - remaining))
+			remaining = 0
+		}
+		network[i] = addr[i] & maskByte
+	}
+	// remaining != 0 means the prefix is longer than the address (e.g. /40 on an
+	// IPv4 address); the backend treats this as malformed, so leave it untouched.
+	if remaining != 0 {
+		return cidr
+	}
+
+	canon := network.String() + "/" + strconv.Itoa(prefixLength)
 	return &canon
 }
 

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -135,19 +135,17 @@ func (rm *resourceManager) referencesResolved(
 }
 
 // icmpv6Protocol is the canonical protocol name canonicalizeProtocol emits for
-// protocol 58. Unlike icmp, icmpv6 does not require an ICMP type/code (it is not
-// in the backend's PROTOCOLS_THAT_MUST_RECEIVE_ICMP_OPTION set), so the spec may
-// omit fromPort/toPort while AWS returns the "all types and codes" wildcard as
-// -1/-1 on read-back.
+// protocol 58. Unlike icmp, icmpv6 does not require an ICMP type/code, so the
+// spec may omit fromPort/toPort while AWS returns the "all types and codes"
+// wildcard as -1/-1 on read-back.
 const icmpv6Protocol = "icmpv6"
 
 // portCarryingProtocols are the protocols EC2 keeps a port range for (or, for
-// ICMP, an overloaded type/code) on read-back. This mirrors the backend's
-// PROTOCOLS_THAT_CAN_RECEIVE_PORT_RANGE_OPTION_FROM_PAPERWORK set in EC2-NM-Frontend's
-// TypeSecurityGroupTrafficFilter. For every other protocol -- "-1" (all traffic)
-// and any other IP protocol number such as 50 (ESP) or 47 (GRE) -- AWS omits
-// fromPort/toPort on read-back. Keyed by the canonical name canonicalizeProtocol
-// emits (numeric 6/17/1/58 are mapped to tcp/udp/icmp/icmpv6 first).
+// ICMP, an overloaded type/code) on read-back. For every other protocol -- "-1"
+// (all traffic) and any other IP protocol number such as 50 (ESP) or 47 (GRE)
+// -- AWS omits fromPort/toPort on read-back. Keyed by the canonical name
+// canonicalizeProtocol emits (numeric 6/17/1/58 are mapped to tcp/udp/icmp/icmpv6
+// first).
 var portCarryingProtocols = map[string]struct{}{
 	"tcp":          {},
 	"udp":          {},
@@ -177,22 +175,19 @@ func canonicalizeProtocol(proto *string) *string {
 	return proto
 }
 
-// canonicalizeCIDR rewrites a CIDR to the exact network form the EC2 backend
-// stores. It is a direct port of com.amazon.ec2.nm.CidrBlock.canonicalizeAddress
-// (package EC2-NM-Common, the class the EC2 control plane uses): a network mask
-// is built one byte at a time from the prefix length and ANDed with the address,
-// masking off every host bit. The masked address is rendered in the same text
-// form AWS returns on read-back -- dotted-quad for IPv4, RFC 5952 lowercase
-// zero-compressed for IPv6 (matching the backend's Guava
-// InetAddresses.toAddrString) -- so "100.68.0.18/18" -> "100.68.0.0/18" and
-// "2001:DB8:abcd:0012::1/64" -> "2001:db8:abcd:12::/64".
+// canonicalizeCIDR rewrites a CIDR to the exact network form AWS stores and
+// returns on read-back: a network mask is built one byte at a time from the
+// prefix length and ANDed with the address, masking off every host bit. The
+// masked address is rendered in the same text form AWS returns -- dotted-quad
+// for IPv4, RFC 5952 lowercase zero-compressed for IPv6 -- so "100.68.0.18/18"
+// -> "100.68.0.0/18" and "2001:DB8:abcd:0012::1/64" -> "2001:db8:abcd:12::/64".
 //
-// Applying the backend's own conversion here, before both the delta comparison
-// and the Authorize/Revoke request, is what stops the spurious diff: the desired
-// spec form and the AWS read-back form collapse to the identical network.
+// Applying this conversion before the delta comparison is what stops the
+// spurious diff: the desired spec form and the AWS read-back form collapse to
+// the identical network.
 //
 // A value that is not a well-formed CIDR -- or whose prefix is longer than the
-// address, which the backend rejects -- passes through unchanged.
+// address, which AWS rejects -- passes through unchanged.
 func canonicalizeCIDR(cidr *string) *string {
 	if cidr == nil {
 		return nil
@@ -207,7 +202,7 @@ func canonicalizeCIDR(cidr *string) *string {
 		return cidr
 	}
 
-	// Match the backend's byte layout: 4 bytes for IPv4, 16 for IPv6.
+	// Use the canonical byte layout: 4 bytes for IPv4, 16 for IPv6.
 	addr := ip.To4()
 	if addr == nil {
 		addr = ip.To16()
@@ -216,9 +211,8 @@ func canonicalizeCIDR(cidr *string) *string {
 		return cidr
 	}
 
-	// Build the network mask exactly as CidrBlock.canonicalizeAddress does --
-	// one byte at a time -- and AND it into the address. Bytes past the prefix
-	// stay zero, which is the host-bit masking.
+	// Build the network mask one byte at a time and AND it into the address.
+	// Bytes past the prefix stay zero, which is the host-bit masking.
 	remaining := prefixLength
 	network := make(net.IP, len(addr))
 	for i := 0; i < len(addr) && remaining > 0; i++ {
@@ -233,7 +227,7 @@ func canonicalizeCIDR(cidr *string) *string {
 		network[i] = addr[i] & maskByte
 	}
 	// remaining != 0 means the prefix is longer than the address (e.g. /40 on an
-	// IPv4 address); the backend treats this as malformed, so leave it untouched.
+	// IPv4 address); AWS treats this as malformed, so leave it untouched.
 	if remaining != 0 {
 		return cidr
 	}

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	awserr "github.com/aws/aws-sdk-go/aws/awserr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 	"github.com/aws-controllers-k8s/ec2-controller/pkg/tags"
@@ -180,72 +181,65 @@ func canonicalizeCIDR(cidr *string) *string {
 	return &canon
 }
 
-// customPreCompare is injected at the top of the generated
-// newResourceDelta (see delta.go) via the `delta_pre_compare` hook in
-// generator.yaml. It rewrites Spec.IngressRules / Spec.EgressRules on both
-// sides into a single canonical form so the subsequent field-by-field
-// DeepEqual does not report spurious diffs that arise purely from how AWS
-// normalises rules on DescribeSecurityGroups read-back.
+// customPostCompare is injected at the end of the generated newResourceDelta
+// (see delta.go) via the `delta_post_compare` hook in generator.yaml. The
+// generated field-by-field comparison skips Spec.IngressRules and
+// Spec.EgressRules entirely (they are marked `compare.is_ignored: true`);
+// this hook compares them instead.
 //
-// It closes six independent perpetual-diff sources (see
-// aws-controllers-k8s/community#2822):
+// Unlike a `delta_pre_compare` hook, it MUST NOT mutate a or b: the same
+// objects are used downstream as the merge-patch base in
+// patchResourceMetadataAndSpec, so any mutation here would leak into the
+// persisted Spec. Instead it compares canonical *copies* and records a delta
+// against the original (un-normalised) values, so genuine changes are
+// reported while server-side normalisation never produces a spurious diff.
+//
+// canonicalizeCopiedRuleLists closes the perpetual-diff sources from
+// aws-controllers-k8s/community#2822:
 //
 //  1. Reference wrappers and self-references. GroupRef/VPCRef are spec-only
-//     reference wrappers that ACK resolves into concrete IDs (GroupID/VPCID)
-//     before the delta runs and that AWS never returns on read-back; they are
-//     cleared first so they play no part in the delta at all. We assume the
-//     resolved ID is present (the referencesResolved guard defers rule sync
-//     until it is). A pair is additionally a self-reference when GroupID
-//     equals the SG's own ID, or when the group identifiers are all omitted
-//     (the spec shorthand, since the ID is unknown until AWS assigns it). AWS
-//     fills GroupID, UserID and sometimes GroupName on read-back. We
-//     canonicalise to {GroupID: selfID} and clear GroupName/UserID.
-//  2. All-protocol ("-1") port ranges. AWS drops FromPort/ToPort for these;
-//     we drop them on both sides.
+//     wrappers AWS never returns; they are cleared in the copy. A pair is a
+//     self-reference when GroupID equals the SG's own ID, or when the group
+//     identifiers are all omitted (the spec shorthand). We canonicalise to
+//     {GroupID: selfID} and clear GroupName/UserID.
+//  2. All-protocol ("-1") port ranges. AWS drops FromPort/ToPort for these.
 //  3. Server-filled owner account. AWS populates UserID with the owning
 //     account for same-account grants; we clear it. Cross-account grants
 //     (UserID != owner) are preserved so the reference stays intact.
 //  4. Grant aggregation. AWS merges grants sharing (protocol, fromPort,
-//     toPort) into one IpPermission with array-valued grants; the spec may
-//     list them as separate rules. We aggregate both sides by that key and
-//     sort deterministically so ordering never drives a diff either.
+//     toPort) into one IpPermission; we aggregate both sides by that key and
+//     sort deterministically so ordering never drives a diff.
 //  5. Protocol notation. AWS canonicalises well-known IANA protocol numbers
-//     to names on read-back ("6" -> "tcp"); we map numeric spec values to the
-//     same names so the two forms compare equal.
+//     to names on read-back ("6" -> "tcp").
 //  6. CIDR canonicalisation. AWS masks host bits and normalises IPv6 text
-//     ("100.68.0.18/18" -> "100.68.0.0/18"); we rewrite CIDRs to the same
-//     network form so the spec and read-back compare equal.
-//
-// Mutating a and b in place matches the convention used by RouteTable,
-// NetworkAcl and VPC in this repo. It is safe against accidental spec
-// persistence because customUpdateSecurityGroup returns a deep copy of the
-// (already-normalised) desired, so the runtime's metadata+spec patch is
-// computed as diff(desired, updated) and is empty for these fields; nothing
-// escapes back to the Kubernetes object. Each reconcile also reads a fresh
-// desired from the API server, so the mutation never accumulates.
-//
-// GroupID is canonicalised to selfID (not cleared) on self-references so
-// that referencesResolved -- and the gate in customUpdateSecurityGroup --
-// still sees the pair as resolved and proceeds to syncSGRules. Because the
-// normalised objects flow into syncSGRules/containsRule as well, the same
-// canonical form suppresses churn at the compareIPPermission layer, and the
-// AWS Authorize/Revoke inputs it builds remain valid (GroupId defaults to
-// selfID, "-1" rules ignore ports, aggregated grants are accepted).
-func customPreCompare(
+//     ("100.68.0.18/18" -> "100.68.0.0/18").
+func customPostCompare(
 	delta *ackcompare.Delta,
 	a *resource,
 	b *resource,
 ) {
-	canonicalizeSGRules(a)
-	canonicalizeSGRules(b)
+	if a == nil || b == nil || a.ko == nil || b.ko == nil {
+		return
+	}
+	aIngress, aEgress := canonicalizeCopiedRuleLists(a)
+	bIngress, bEgress := canonicalizeCopiedRuleLists(b)
+	if !equality.Semantic.DeepEqual(aIngress, bIngress) {
+		delta.Add("Spec.IngressRules", a.ko.Spec.IngressRules, b.ko.Spec.IngressRules)
+	}
+	if !equality.Semantic.DeepEqual(aEgress, bEgress) {
+		delta.Add("Spec.EgressRules", a.ko.Spec.EgressRules, b.ko.Spec.EgressRules)
+	}
 }
 
-// canonicalizeSGRules rewrites the Ingress and Egress rule lists of r into a
-// canonical form used only for delta comparison and rule syncing. See
-// customPreCompare for the rationale and safety argument.
-func canonicalizeSGRules(r *resource) {
+// canonicalizeCopiedRuleLists returns canonical *copies* of r's Ingress and
+// Egress rule lists. r is never mutated, so callers can use the result purely
+// for comparison (customPostCompare) or to build AWS Authorize/Revoke inputs
+// (syncSGRules) without affecting the persisted Spec.
+func canonicalizeCopiedRuleLists(
+	r *resource,
+) (ingress []*svcapitypes.IPPermission, egress []*svcapitypes.IPPermission) {
 	if r == nil || r.ko == nil {
-		return
+		return nil, nil
 	}
 	var selfID string
 	if r.ko.Status.ID != nil {
@@ -256,8 +250,23 @@ func canonicalizeSGRules(r *resource) {
 		r.ko.Status.ACKResourceMetadata.OwnerAccountID != nil {
 		ownerAccountID = string(*r.ko.Status.ACKResourceMetadata.OwnerAccountID)
 	}
-	r.ko.Spec.IngressRules = canonicalizeRuleList(r.ko.Spec.IngressRules, selfID, ownerAccountID)
-	r.ko.Spec.EgressRules = canonicalizeRuleList(r.ko.Spec.EgressRules, selfID, ownerAccountID)
+	ingress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.IngressRules), selfID, ownerAccountID)
+	egress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.EgressRules), selfID, ownerAccountID)
+	return ingress, egress
+}
+
+// deepCopyRuleList returns a deep copy of a rule list so that in-place
+// canonicalisation never touches the caller's backing data. A nil input
+// returns nil so an empty and an absent rule list keep comparing equal.
+func deepCopyRuleList(rules []*svcapitypes.IPPermission) []*svcapitypes.IPPermission {
+	if rules == nil {
+		return nil
+	}
+	out := make([]*svcapitypes.IPPermission, len(rules))
+	for i, r := range rules {
+		out[i] = r.DeepCopy()
+	}
+	return out
 }
 
 // canonicalizeRuleList normalises each rule (ports + grants), aggregates
@@ -495,31 +504,42 @@ func (rm *resourceManager) syncSGRules(
 	exit := rlog.Trace("rm.syncSGRules")
 	defer func() { exit(err) }()
 
+	// Compare and authorise the canonical form of both sides so that
+	// server-side normalisation (see customPostCompare) never revokes and
+	// re-authorises an equivalent rule. Copies are used so neither desired
+	// nor latest -- and therefore neither the persisted Spec nor the AWS
+	// read-back reflected into it -- is mutated.
+	desiredIngressRules, desiredEgressRules := canonicalizeCopiedRuleLists(desired)
+	var latestIngressRules, latestEgressRules []*svcapitypes.IPPermission
+	if latest != nil {
+		latestIngressRules, latestEgressRules = canonicalizeCopiedRuleLists(latest)
+	}
+
 	toAddIngress := []*svcapitypes.IPPermission{}
 	toAddEgress := []*svcapitypes.IPPermission{}
 	toDeleteIngress := []*svcapitypes.IPPermission{}
 	toDeleteEgress := []*svcapitypes.IPPermission{}
 
-	for _, desiredIngress := range desired.ko.Spec.IngressRules {
-		if latest == nil || !containsRule(latest.ko.Spec.IngressRules, desiredIngress) {
+	for _, desiredIngress := range desiredIngressRules {
+		if latest == nil || !containsRule(latestIngressRules, desiredIngress) {
 			// a desired rule is not in the latest resource; therefore, create
 			toAddIngress = append(toAddIngress, desiredIngress)
 		}
 	}
-	for _, desiredEgress := range desired.ko.Spec.EgressRules {
-		if latest == nil || !containsRule(latest.ko.Spec.EgressRules, desiredEgress) {
+	for _, desiredEgress := range desiredEgressRules {
+		if latest == nil || !containsRule(latestEgressRules, desiredEgress) {
 			toAddEgress = append(toAddEgress, desiredEgress)
 		}
 	}
 	if latest != nil {
-		for _, latestIngress := range latest.ko.Spec.IngressRules {
-			if !containsRule(desired.ko.Spec.IngressRules, latestIngress) {
+		for _, latestIngress := range latestIngressRules {
+			if !containsRule(desiredIngressRules, latestIngress) {
 				// a rule is in latest resource, but not in desired resource; therefore, delete
 				toDeleteIngress = append(toDeleteIngress, latestIngress)
 			}
 		}
-		for _, latestEgress := range latest.ko.Spec.EgressRules {
-			if !containsRule(desired.ko.Spec.EgressRules, latestEgress) {
+		for _, latestEgress := range latestEgressRules {
+			if !containsRule(desiredEgressRules, latestEgress) {
 				toDeleteEgress = append(toDeleteEgress, latestEgress)
 			}
 		}

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -172,9 +172,7 @@ func canonicalizeProtocol(proto *string) *string {
 //
 // Applying the backend's own conversion here, before both the delta comparison
 // and the Authorize/Revoke request, is what stops the spurious diff: the desired
-// spec form and the AWS read-back form collapse to the identical network. It
-// also avoids the InvalidPermission.Duplicate error AWS throws when a
-// non-canonical CIDR is submitted for a rule already stored in canonical form.
+// spec form and the AWS read-back form collapse to the identical network.
 //
 // A value that is not a well-formed CIDR -- or whose prefix is longer than the
 // address, which the backend rejects -- passes through unchanged.

--- a/pkg/resource/security_group/hooks.go
+++ b/pkg/resource/security_group/hooks.go
@@ -280,16 +280,14 @@ func securityGroupIdentityKnown(r *resource) bool {
 // canonicalizeCopiedRuleLists returns canonical *copies* of r's rule lists; r is
 // never mutated. Used only for delta comparison, never the sync path (which
 // authorises/revokes the raw spec rules). Precondition (guaranteed by
-// customPostCompare's identity guard + Name being required): Status.ID,
-// OwnerAccountID and Spec.Name are all non-nil.
+// customPostCompare's identity guard): Status.ID and OwnerAccountID are non-nil.
 func canonicalizeCopiedRuleLists(
 	r *resource,
 ) (ingress []*svcapitypes.IPPermission, egress []*svcapitypes.IPPermission) {
 	selfID := *r.ko.Status.ID
 	ownerAccountID := string(*r.ko.Status.ACKResourceMetadata.OwnerAccountID)
-	selfName := *r.ko.Spec.Name
-	ingress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.IngressRules), selfID, selfName, ownerAccountID)
-	egress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.EgressRules), selfID, selfName, ownerAccountID)
+	ingress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.IngressRules), selfID, ownerAccountID)
+	egress = canonicalizeRuleList(deepCopyRuleList(r.ko.Spec.EgressRules), selfID, ownerAccountID)
 	return ingress, egress
 }
 
@@ -312,7 +310,6 @@ func deepCopyRuleList(rules []*svcapitypes.IPPermission) []*svcapitypes.IPPermis
 func canonicalizeRuleList(
 	rules []*svcapitypes.IPPermission,
 	selfID string,
-	selfName string,
 	ownerAccountID string,
 ) []*svcapitypes.IPPermission {
 	if rules == nil {
@@ -360,7 +357,7 @@ func canonicalizeRuleList(
 			}
 		}
 		for _, pair := range rule.UserIDGroupPairs {
-			canonicalizeGroupPair(pair, selfID, selfName, ownerAccountID)
+			canonicalizeGroupPair(pair, selfID, ownerAccountID)
 		}
 	}
 
@@ -412,7 +409,6 @@ func canonicalizeRuleList(
 func canonicalizeGroupPair(
 	pair *svcapitypes.UserIDGroupPair,
 	selfID string,
-	selfName string,
 	ownerAccountID string,
 ) {
 	if pair == nil {
@@ -433,17 +429,18 @@ func canonicalizeGroupPair(
 	pair.PeeringStatus = nil
 	pair.VPCPeeringConnectionID = nil
 
-	// Self-reference: AWS returns the SG's own GroupID/GroupName on read-back
-	// while the spec shorthand omits the group. Strip a self GroupID and a
-	// GroupName matching the SG's own name so both sides converge. A non-matching
-	// GroupName is a real value (by-name cross-ref, or user error) and is kept so
-	// a genuine diff still surfaces.
+	// Self-reference: AWS returns the SG's own GroupID on read-back while the
+	// spec shorthand omits the group, so strip a self GroupID to converge both
+	// sides.
 	if pair.GroupID != nil && *pair.GroupID == selfID {
 		pair.GroupID = nil
 	}
-	if pair.GroupName != nil && *pair.GroupName == selfName {
-		pair.GroupName = nil
-	}
+
+	// GroupName is left untouched: AWS never returns it on read-back (it resolves
+	// names to a GroupID), and by-name references only work in a default VPC. A
+	// bare-GroupName reference therefore can't converge and will diff every
+	// reconcile -- an accepted trade-off for a rare, default-VPC-only pattern.
+
 	// AWS fills UserID with the owner account for same-account grants; clear it.
 	// Cross-account grants (UserID != owner) are kept -- the account identifies
 	// the referenced group.

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -234,7 +234,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 // lossless, and the only case a foreign UserId is dropped is when
 // GroupId==selfID -- an impossible input AWS rejects anyway. A legitimate
 // cross-account reference always uses GroupId=peer (!= selfID) and is
-// preserved (see TestCustomPreCompare_CrossAccount_NotSuppressed).
+// preserved (see TestCustomPostCompare_CrossAccount_NotSuppressed).
 func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 	t.Run("self GroupID + foreign UserID: classified self, foreign UserID dropped", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
@@ -515,16 +515,16 @@ func TestCanonicalizeRuleList(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// canonicalizeSGRules (resource-level guards)
+// canonicalizeCopiedRuleLists (resource-level guards, non-mutating)
 // -----------------------------------------------------------------------------
 
-func TestCanonicalizeSGRules_Guards(t *testing.T) {
+func TestCanonicalizeCopiedRuleLists_Guards(t *testing.T) {
 	t.Run("nil resource does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeSGRules(nil) })
+		assert.NotPanics(t, func() { canonicalizeCopiedRuleLists(nil) })
 	})
 
 	t.Run("nil ko does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeSGRules(&resource{}) })
+		assert.NotPanics(t, func() { canonicalizeCopiedRuleLists(&resource{}) })
 	})
 
 	t.Run("nil Status.ID: omitted self-ref pair is left group-id-less", func(t *testing.T) {
@@ -533,17 +533,36 @@ func TestCanonicalizeSGRules_Guards(t *testing.T) {
 			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("coredns")}},
 		}}, nil)
 		r.ko.Status.ID = nil
-		assert.NotPanics(t, func() { canonicalizeSGRules(r) })
+		var ingress []*svcapitypes.IPPermission
+		assert.NotPanics(t, func() { ingress, _ = canonicalizeCopiedRuleLists(r) })
+		assert.Nil(t, ingress[0].UserIDGroupPairs[0].GroupID)
+	})
+
+	t.Run("does not mutate the source resource", func(t *testing.T) {
+		// The whole point of the copy-based approach: canonicalisation must
+		// never touch the caller's rule lists (they become the merge-patch
+		// base in patchResourceMetadataAndSpec).
+		r := mkResource([]*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("6"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{GroupRef: groupRef("myself")}},
+		}}, nil)
+		ingress, _ := canonicalizeCopiedRuleLists(r)
+		// Source untouched: numeric protocol and groupRef preserved, no groupID injected.
+		assert.Equal(t, "6", *r.ko.Spec.IngressRules[0].IPProtocol)
+		assert.NotNil(t, r.ko.Spec.IngressRules[0].UserIDGroupPairs[0].GroupRef)
 		assert.Nil(t, r.ko.Spec.IngressRules[0].UserIDGroupPairs[0].GroupID)
+		// Copy canonicalised: protocol mapped to name, self-ref resolved to selfID.
+		assert.Equal(t, "tcp", *ingress[0].IPProtocol)
+		assert.Equal(t, testSelfID, *ingress[0].UserIDGroupPairs[0].GroupID)
 	})
 }
 
 // -----------------------------------------------------------------------------
-// customPreCompare via newResourceDelta (end-to-end delta suppression)
+// customPostCompare via newResourceDelta (end-to-end delta suppression)
 // -----------------------------------------------------------------------------
 
 // desiredLatestDelta normalises both sides through newResourceDelta (which
-// invokes customPreCompare) and returns the resulting delta.
+// invokes customPostCompare) and returns the resulting delta.
 func desiredLatestDelta(desired, latest *resource) *struct{ ing, egr bool } {
 	d := newResourceDelta(desired, latest)
 	return &struct{ ing, egr bool }{
@@ -552,7 +571,7 @@ func desiredLatestDelta(desired, latest *resource) *struct{ ing, egr bool } {
 	}
 }
 
-func TestCustomPreCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
+func TestCustomPostCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
 	// desired mirrors the post-ResolveReferences state: GroupRef set AND
 	// GroupID filled with selfID. latest is the AWS read-back: GroupID set,
 	// UserID/GroupName filled, no GroupRef.
@@ -574,7 +593,7 @@ func TestCustomPreCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "self-ref via groupRef must not produce a diff")
 }
 
-func TestCustomPreCompare_SelfRef_Omitted_NoDiff(t *testing.T) {
+func TestCustomPostCompare_SelfRef_Omitted_NoDiff(t *testing.T) {
 	// The exact #2822 reproducer: userIDGroupPair with only description +
 	// userID, no groupID and no groupRef. latest has GroupID filled by AWS.
 	desired := mkResource([]*svcapitypes.IPPermission{{
@@ -595,7 +614,7 @@ func TestCustomPreCompare_SelfRef_Omitted_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "omitted-groupID self-ref (#2822) must not produce a diff")
 }
 
-func TestCustomPreCompare_GroupRefOnly_NoDiff(t *testing.T) {
+func TestCustomPostCompare_GroupRefOnly_NoDiff(t *testing.T) {
 	// desired mirrors the post-ResolveReferences state for a cross-SG rule
 	// written with a groupRef: the wrapper is still set AND GroupID is
 	// resolved. latest is the AWS read-back: GroupID only, no wrapper. The
@@ -618,7 +637,7 @@ func TestCustomPreCompare_GroupRefOnly_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "a spec-only groupRef must never produce a diff")
 }
 
-func TestCustomPreCompare_AllProtocolPorts_NoDiff(t *testing.T) {
+func TestCustomPostCompare_AllProtocolPorts_NoDiff(t *testing.T) {
 	desired := mkResource(nil, []*svcapitypes.IPPermission{{
 		IPProtocol: aws.String("-1"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
 		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
@@ -632,7 +651,7 @@ func TestCustomPreCompare_AllProtocolPorts_NoDiff(t *testing.T) {
 	assert.False(t, got.egr, "-1 rule with spec ports vs AWS-dropped ports must not diff")
 }
 
-func TestCustomPreCompare_GrantAggregation_NoDiff(t *testing.T) {
+func TestCustomPostCompare_GrantAggregation_NoDiff(t *testing.T) {
 	// desired: two separate rules; latest: AWS-aggregated single rule, and
 	// grants in reversed order to also exercise sorting.
 	desired := mkResource([]*svcapitypes.IPPermission{
@@ -653,7 +672,7 @@ func TestCustomPreCompare_GrantAggregation_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "split desired rules vs AWS-aggregated latest must not diff")
 }
 
-func TestCustomPreCompare_SelfRef_Egress_NoDiff(t *testing.T) {
+func TestCustomPostCompare_SelfRef_Egress_NoDiff(t *testing.T) {
 	// Same self-ref suppression must hold on the egress side (symmetric code
 	// path through canonicalizeRuleList).
 	desired := mkResource(nil, []*svcapitypes.IPPermission{{
@@ -672,7 +691,7 @@ func TestCustomPreCompare_SelfRef_Egress_NoDiff(t *testing.T) {
 	assert.False(t, got.egr, "self-ref egress must not produce a diff")
 }
 
-func TestCustomPreCompare_DescriptionChange_StillFires(t *testing.T) {
+func TestCustomPostCompare_DescriptionChange_StillFires(t *testing.T) {
 	// Description participates in comparison and must NOT be normalised away:
 	// a description-only change on an otherwise-identical rule must diff.
 	desired := mkResource([]*svcapitypes.IPPermission{{
@@ -688,7 +707,7 @@ func TestCustomPreCompare_DescriptionChange_StillFires(t *testing.T) {
 	assert.True(t, got.ing, "a description-only change must still produce a diff")
 }
 
-func TestCustomPreCompare_NumericProtocol_NoDiff(t *testing.T) {
+func TestCustomPostCompare_NumericProtocol_NoDiff(t *testing.T) {
 	// Verified against AWS: submitting IpProtocol "6" is stored and returned
 	// as "tcp". The spec numeric form must not perpetually diff from the
 	// name AWS returns.
@@ -705,7 +724,7 @@ func TestCustomPreCompare_NumericProtocol_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "numeric protocol (6) vs name (tcp) must not diff")
 }
 
-func TestCustomPreCompare_DifferentProtocol_StillFires(t *testing.T) {
+func TestCustomPostCompare_DifferentProtocol_StillFires(t *testing.T) {
 	// A genuine protocol change (tcp -> udp) must still be detected.
 	desired := mkResource([]*svcapitypes.IPPermission{{
 		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("6"),
@@ -720,7 +739,7 @@ func TestCustomPreCompare_DifferentProtocol_StillFires(t *testing.T) {
 	assert.True(t, got.ing, "tcp vs udp must still produce a diff")
 }
 
-func TestCustomPreCompare_NonCanonicalCIDR_NoDiff(t *testing.T) {
+func TestCustomPostCompare_NonCanonicalCIDR_NoDiff(t *testing.T) {
 	// Verified against AWS: submitting "100.68.0.18/18" is stored/returned as
 	// "100.68.0.0/18"; IPv6 is also masked and text-normalised. The spec's
 	// non-canonical form must not perpetually diff from the read-back form.
@@ -739,7 +758,7 @@ func TestCustomPreCompare_NonCanonicalCIDR_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "non-canonical CIDR vs AWS-canonicalized form must not diff")
 }
 
-func TestCustomPreCompare_DifferentCIDR_StillFires(t *testing.T) {
+func TestCustomPostCompare_DifferentCIDR_StillFires(t *testing.T) {
 	// A genuinely different network must still diff.
 	desired := mkResource([]*svcapitypes.IPPermission{{
 		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
@@ -754,7 +773,7 @@ func TestCustomPreCompare_DifferentCIDR_StillFires(t *testing.T) {
 	assert.True(t, got.ing, "a different CIDR network must still produce a diff")
 }
 
-func TestCustomPreCompare_RealDiff_StillFires(t *testing.T) {
+func TestCustomPostCompare_RealDiff_StillFires(t *testing.T) {
 	desired := mkResource([]*svcapitypes.IPPermission{{
 		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
 		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{GroupID: aws.String(testSelfID)}},
@@ -770,7 +789,7 @@ func TestCustomPreCompare_RealDiff_StillFires(t *testing.T) {
 	assert.True(t, got.ing, "a genuine port change must still produce a diff")
 }
 
-func TestCustomPreCompare_CrossAccount_NotSuppressed(t *testing.T) {
+func TestCustomPostCompare_CrossAccount_NotSuppressed(t *testing.T) {
 	// desired omits the cross-account UserID; latest carries the peer
 	// account. Because the peer account differs from the owner account it is
 	// NOT stripped, so the missing UserID on desired remains a real diff.
@@ -785,7 +804,7 @@ func TestCustomPreCompare_CrossAccount_NotSuppressed(t *testing.T) {
 	assert.True(t, got.ing, "cross-account UserID divergence must remain a diff (not silently dropped)")
 }
 
-func TestCustomPreCompare_SelfRef_StaysResolved(t *testing.T) {
+func TestCustomPostCompare_SelfRef_StaysResolved(t *testing.T) {
 	// customUpdateSecurityGroup relies on GroupID being non-nil after
 	// normalisation so that referencesResolved keeps syncSGRules open for a
 	// self-reference expressed via groupRef.

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -160,17 +160,24 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 		assert.Nil(t, p.GroupRef)
 	})
 
-	t.Run("VPCRef cleared, VPCID preserved on a cross-SG pair", func(t *testing.T) {
-		// VPCRef is a spec-only reference wrapper AWS never returns; VPCID is
-		// the concrete value AWS does return on read-back and must survive.
+	t.Run("read-only reference metadata cleared on a cross-SG pair", func(t *testing.T) {
+		// VPCID, PeeringStatus and VPCPeeringConnectionID are read-only values
+		// EC2 derives from the referenced group (VPCID is filled only for a
+		// cross-VPC peer). The customer cannot set them meaningfully, so they
+		// must never drive a delta -- clear them alongside the VPCRef wrapper.
 		p := &svcapitypes.UserIDGroupPair{
-			GroupID: aws.String(testOtherID),
-			VPCID:   aws.String("vpc-123"),
-			VPCRef:  groupRef("my-vpc"),
+			GroupID:                aws.String(testOtherID),
+			VPCID:                  aws.String("vpc-123"),
+			VPCRef:                 groupRef("my-vpc"),
+			PeeringStatus:          aws.String("active"),
+			VPCPeeringConnectionID: aws.String("pcx-123"),
 		}
 		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
 		assert.Nil(t, p.VPCRef, "VPCRef must be cleared to match AWS read-back form")
-		assert.Equal(t, "vpc-123", *p.VPCID, "concrete VPCID must be preserved")
+		assert.Nil(t, p.VPCID, "server-derived VPCID must be cleared")
+		assert.Nil(t, p.PeeringStatus, "read-only PeeringStatus must be cleared")
+		assert.Nil(t, p.VPCPeeringConnectionID, "read-only VPCPeeringConnectionID must be cleared")
 	})
 
 	t.Run("VPCRef cleared on a self-ref pair", func(t *testing.T) {

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -49,6 +49,7 @@ func mkResource(ingress, egress []*svcapitypes.IPPermission) *resource {
 	return &resource{
 		ko: &svcapitypes.SecurityGroup{
 			Spec: svcapitypes.SecurityGroupSpec{
+				Name:         aws.String(testSelfName),
 				IngressRules: ingress,
 				EgressRules:  egress,
 			},
@@ -68,43 +69,42 @@ func mkResource(ingress, egress []*svcapitypes.IPPermission) *resource {
 
 func TestCanonicalizeGroupPair(t *testing.T) {
 	t.Run("nil pair does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeGroupPair(nil, testSelfID, testOwnerAcctID) })
+		assert.NotPanics(t, func() { canonicalizeGroupPair(nil, testSelfID, testSelfName, testOwnerAcctID) })
 	})
 
-	t.Run("self-ref by explicit self GroupID: keep selfID, clear the rest", func(t *testing.T) {
+	t.Run("self-ref by explicit self GroupID: stripped group-id-less", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
 			GroupID:   aws.String(testSelfID),
 			UserID:    aws.String(testOwnerAcctID),
 			GroupName: aws.String(testSelfName),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "self GroupID is stripped so it matches the omitted spec form")
 		assert.Nil(t, p.UserID)
 		assert.Nil(t, p.GroupName)
 		assert.Nil(t, p.GroupRef)
 	})
 
-	t.Run("self-ref by omission: GroupID canonicalised up to selfID", func(t *testing.T) {
+	t.Run("self-ref by omission: left group-id-less", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
 			Description: aws.String("coredns"),
 			UserID:      aws.String(testOwnerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		// This is the #2822 fix: the omitted GroupID must become selfID so
-		// it matches the AWS-filled latest side.
-		assert.NotNil(t, p.GroupID)
-		assert.Equal(t, testSelfID, *p.GroupID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		// The #2822 fix: the omitted-groupID spec form must match the AWS
+		// read-back, whose self GroupID is stripped to nil on the latest side.
+		assert.Nil(t, p.GroupID)
 		assert.Nil(t, p.UserID)
 		assert.NotNil(t, p.Description, "description is preserved")
 	})
 
-	t.Run("self-ref by groupRef: clear GroupRef, keep selfID", func(t *testing.T) {
+	t.Run("self-ref by groupRef: clear GroupRef, strip self GroupID", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
 			GroupID:  aws.String(testSelfID),
 			GroupRef: groupRef("myself"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "self GroupID stripped")
 		assert.Nil(t, p.GroupRef, "GroupRef must be cleared to match AWS read-back form")
 	})
 
@@ -115,19 +115,19 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:  aws.String(testOtherID),
 			GroupRef: groupRef("other"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Nil(t, p.GroupRef, "GroupRef must never survive into the delta")
 		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
 	})
 
-	t.Run("groupRef with an unresolved (nil) GroupID canonicalises to self", func(t *testing.T) {
+	t.Run("groupRef with an unresolved (nil) GroupID: wrapper cleared, stays group-id-less", func(t *testing.T) {
 		// The delta assumes GroupID is resolved: a wrapper-only pair is
-		// stripped and, being identifier-less, treated as self. Guarding an
-		// unresolved reference is referencesResolved's job, not this function's.
+		// stripped. Guarding an unresolved reference is referencesResolved's
+		// job, not this function's.
 		p := &svcapitypes.UserIDGroupPair{GroupRef: groupRef("not-yet-created")}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Nil(t, p.GroupRef)
-		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.GroupID)
 	})
 
 	t.Run("cross-SG same-account: clear owner UserID, keep GroupID", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testOwnerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Nil(t, p.UserID, "server-filled owner account cleared")
 	})
@@ -145,7 +145,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID, "cross-account UserID must be preserved")
 	})
@@ -155,7 +155,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:  aws.String(testOtherID),
 			GroupRef: groupRef("other"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Nil(t, p.GroupRef)
 	})
@@ -172,7 +172,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			PeeringStatus:          aws.String("active"),
 			VPCPeeringConnectionID: aws.String("pcx-123"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
 		assert.Nil(t, p.VPCRef, "VPCRef must be cleared to match AWS read-back form")
 		assert.Nil(t, p.VPCID, "server-derived VPCID must be cleared")
@@ -185,71 +185,65 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testSelfID),
 			VPCRef:  groupRef("my-vpc"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "self GroupID stripped")
 		assert.Nil(t, p.VPCRef, "VPCRef must be cleared on a self-reference too")
 	})
 
-	t.Run("by-name reference is not treated as self-ref", func(t *testing.T) {
+	t.Run("by-name reference to another SG (non-matching name) is preserved", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{GroupName: aws.String("some-named-sg")}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "a by-name pair must not be canonicalised to selfID")
-		assert.Equal(t, "some-named-sg", *p.GroupName)
+		assert.Equal(t, "some-named-sg", *p.GroupName, "a non-self GroupName must survive")
 	})
 
-	t.Run("empty selfID (nil Status.ID): omitted pair is not stamped with a group id", func(t *testing.T) {
-		// Pre-create / adoption: Status.ID is not yet known. An omitted
-		// self-ref pair must not gain a bogus (empty) GroupID and must not
-		// panic; the server-fillable fields are still cleared.
-		p := &svcapitypes.UserIDGroupPair{
-			Description: aws.String("coredns"),
-			UserID:      aws.String(testOwnerAcctID),
-		}
-		canonicalizeGroupPair(p, "", testOwnerAcctID)
-		assert.Nil(t, p.GroupID, "must not set a GroupID when selfID is unknown")
-		assert.Nil(t, p.UserID)
+	t.Run("self-ref by GroupName matching own name is stripped", func(t *testing.T) {
+		// A self-reference expressed purely by the SG's own name (no GroupID).
+		p := &svcapitypes.UserIDGroupPair{GroupName: aws.String(testSelfName)}
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupName, "a GroupName matching the SG's own name is stripped")
+		assert.Nil(t, p.GroupID)
 	})
 
-	t.Run("empty selfID: explicit GroupID pair is left intact (self unknown)", func(t *testing.T) {
-		// With no known selfID we cannot classify an explicit-id pair as a
-		// self-reference, so it is treated as a cross-SG pair: GroupID kept,
-		// only an owner-account UserID stripped.
+	t.Run("self GroupID + non-matching GroupName: name preserved (no swallowed diff)", func(t *testing.T) {
+		// The self GroupID is stripped, but a GroupName that is NOT the SG's own
+		// name is a real value and must survive so a genuine diff still fires.
 		p := &svcapitypes.UserIDGroupPair{
-			GroupID: aws.String(testSelfID),
-			UserID:  aws.String(testOwnerAcctID),
+			GroupID:   aws.String(testSelfID),
+			GroupName: aws.String("some-other-name"),
 		}
-		canonicalizeGroupPair(p, "", testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
-		assert.Nil(t, p.UserID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "self GroupID stripped")
+		assert.Equal(t, "some-other-name", *p.GroupName, "a non-self GroupName must not be swallowed")
 	})
+
 }
 
-// TestCanonicalizeGroupPair_InconsistentInputs documents, against real EC2
-// behavior, that dropping the owner UserID on a self-ref is lossless:
-// {GroupId=self} and {GroupId=self, UserId=owner} produce the identical rule
-// (AWS auto-fills the owner). A foreign UserID is only ever dropped when paired
-// with the SG's own GroupID -- an input AWS rejects anyway; a legitimate
-// cross-account ref uses GroupId=peer and is preserved (see
+// TestCanonicalizeGroupPair_InconsistentInputs documents how nonsensical inputs
+// (which AWS rejects) canonicalise. A self GroupID is always stripped to nil; a
+// UserID is dropped only when it equals the owner account, so a foreign UserID
+// paired with a self/absent group is left intact. A legitimate cross-account
+// ref (GroupId=peer, UserId=peer) is preserved (see
 // TestCustomPostCompare_CrossAccount_NotSuppressed).
 func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
-	t.Run("self GroupID + foreign UserID: classified self, foreign UserID dropped", func(t *testing.T) {
+	t.Run("self GroupID + foreign UserID: self GroupID stripped, foreign UserID kept", func(t *testing.T) {
+		// Nonsensical input AWS rejects (InvalidGroup.NotFound). The self GroupID
+		// is stripped; the non-owner UserID is not touched.
 		p := &svcapitypes.UserIDGroupPair{
 			GroupID: aws.String(testSelfID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
-		assert.Nil(t, p.UserID,
-			"a foreign UserID paired with the SG's own GroupID is nonsensical "+
-				"(AWS rejects it as InvalidGroup.NotFound); dropping it is safe")
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID)
+		assert.Equal(t, testPeerAcctID, *p.UserID)
 	})
 
-	t.Run("omitted group + foreign UserID: classified self, UserID dropped", func(t *testing.T) {
+	t.Run("omitted group + foreign UserID: stays group-id-less, UserID kept", func(t *testing.T) {
 		// {UserID: foreign} with no group is invalid to AWS (MissingParameter).
 		p := &svcapitypes.UserIDGroupPair{UserID: aws.String(testPeerAcctID)}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
-		assert.Equal(t, testSelfID, *p.GroupID)
-		assert.Nil(t, p.UserID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		assert.Nil(t, p.GroupID)
+		assert.Equal(t, testPeerAcctID, *p.UserID)
 	})
 
 	t.Run("peer GroupID + foreign UserID: NOT self, cross-account preserved", func(t *testing.T) {
@@ -257,7 +251,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID,
 			"a legitimate cross-account reference (GroupId=peer) must be preserved")
@@ -270,7 +264,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 
 func TestCanonicalizeRuleList(t *testing.T) {
 	t.Run("nil stays nil (absent == empty)", func(t *testing.T) {
-		assert.Nil(t, canonicalizeRuleList(nil, testSelfID, testOwnerAcctID))
+		assert.Nil(t, canonicalizeRuleList(nil, testSelfID, testSelfName, testOwnerAcctID))
 	})
 
 	t.Run("drops port range for all-protocol -1 rules", func(t *testing.T) {
@@ -279,7 +273,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			FromPort:   aws.Int64(0),
 			ToPort:     aws.Int64(0),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Nil(t, out[0].FromPort)
 		assert.Nil(t, out[0].ToPort)
@@ -294,7 +288,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}}},
 			{IPProtocol: aws.String("47"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 2)
 		for _, r := range out {
 			assert.Nil(t, r.FromPort, "protocol %s must drop fromPort", *r.IPProtocol)
@@ -309,11 +303,11 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		spec := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("50"), FromPort: aws.Int64(-1), ToPort: aws.Int64(-1),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		readBack := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("50"),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, readBack, spec, "ported spec and portless read-back must canonicalise equal")
 	})
 
@@ -325,7 +319,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("58")},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("47")}, // GRE: not well-known, kept as number
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		got := map[string]bool{}
 		for _, r := range out {
 			got[*r.IPProtocol] = true
@@ -345,7 +339,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1, "6 and tcp on the same port are the same protocol")
 	})
 
@@ -354,7 +348,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:DB8:abcd:0012::1/64")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, "100.68.0.0/18", *out[0].IPRanges[0].CIDRIP)
 		assert.Equal(t, "2001:db8:abcd:12::/64", *out[0].IPv6Ranges[0].CIDRIPv6)
 	})
@@ -365,11 +359,11 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		a := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		b := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.0/18")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, *a[0].IPRanges[0].CIDRIP, *b[0].IPRanges[0].CIDRIP)
 	})
 
@@ -377,7 +371,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("not-a-cidr")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, "not-a-cidr", *out[0].IPRanges[0].CIDRIP)
 	})
 
@@ -386,7 +380,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.NotNil(t, out[0].FromPort)
 		assert.NotNil(t, out[0].ToPort)
@@ -401,7 +395,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Nil(t, out[0].FromPort)
 		assert.Nil(t, out[0].ToPort)
@@ -414,7 +408,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("58"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Equal(t, "icmpv6", *out[0].IPProtocol)
 		assert.Nil(t, out[0].FromPort)
@@ -428,13 +422,13 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		omitted := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("icmpv6"),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		wildcard := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("icmpv6"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.True(t, equality.Semantic.DeepEqual(omitted, wildcard),
 			"omitted and -1/-1 icmpv6 must be indistinguishable after canonicalisation")
 	})
@@ -446,7 +440,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("icmpv6"),
 			FromPort:   aws.Int64(128),
 			ToPort:     aws.Int64(0),
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.NotNil(t, out[0].FromPort)
 		assert.EqualValues(t, 128, *out[0].FromPort)
@@ -460,7 +454,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1, "the two rules must merge into one")
 		assert.Len(t, out[0].IPRanges, 2)
 	})
@@ -469,7 +463,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 2)
 	})
 
@@ -482,8 +476,8 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
 		}
-		out1 := canonicalizeRuleList(in1, testSelfID, testOwnerAcctID)
-		out2 := canonicalizeRuleList(in2, testSelfID, testOwnerAcctID)
+		out1 := canonicalizeRuleList(in1, testSelfID, testSelfName, testOwnerAcctID)
+		out2 := canonicalizeRuleList(in2, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t, ruleAggregationKey(out1[0]), ruleAggregationKey(out2[0]))
 		assert.Equal(t, ruleAggregationKey(out1[1]), ruleAggregationKey(out2[1]))
 	})
@@ -497,7 +491,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			orig,
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, orig.IPRanges, 1, "the caller's original rule must not be mutated by aggregation")
 	})
 
@@ -509,7 +503,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPv6Ranges:    []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:db8:1::/48")}},
 				PrefixListIDs: []*svcapitypes.PrefixListID{{PrefixListID: aws.String("pl-11")}}},
-		}, testSelfID, testOwnerAcctID)
+		}, testSelfID, testSelfName, testOwnerAcctID)
 		assert.Len(t, out, 1, "same (proto,from,to) rules merge")
 		// merged and sorted ascending (lexicographic: '1' < ':')
 		assert.Equal(t, []string{"2001:db8:1::/48", "2001:db8::/48"},
@@ -529,8 +523,8 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				UserIDGroupPairs: pairs,
 			}}
 		}
-		a := canonicalizeRuleList(mk("sg-aaa", "sg-bbb"), testSelfID, testOwnerAcctID)
-		b := canonicalizeRuleList(mk("sg-bbb", "sg-aaa"), testSelfID, testOwnerAcctID)
+		a := canonicalizeRuleList(mk("sg-aaa", "sg-bbb"), testSelfID, testSelfName, testOwnerAcctID)
+		b := canonicalizeRuleList(mk("sg-bbb", "sg-aaa"), testSelfID, testSelfName, testOwnerAcctID)
 		assert.Equal(t,
 			[]string{*a[0].UserIDGroupPairs[0].GroupID, *a[0].UserIDGroupPairs[1].GroupID},
 			[]string{*b[0].UserIDGroupPairs[0].GroupID, *b[0].UserIDGroupPairs[1].GroupID},
@@ -547,7 +541,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 						nil,
 						{GroupID: aws.String(testSelfID)},
 					}},
-			}, testSelfID, testOwnerAcctID)
+			}, testSelfID, testSelfName, testOwnerAcctID)
 		})
 		assert.Len(t, out, 1, "the nil rule is skipped, the real one is kept")
 	})
@@ -571,7 +565,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 					nil,
 					{PrefixListID: aws.String("pl-11")},
 				},
-			}}, testSelfID, testOwnerAcctID)
+			}}, testSelfID, testSelfName, testOwnerAcctID)
 		})
 		assert.Len(t, out, 1)
 	})
@@ -583,19 +577,18 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				{GroupName: nil, UserID: aws.String(testOwnerAcctID)},                  // omitted self-ref
 				{GroupID: aws.String(testOtherID), UserID: aws.String(testPeerAcctID)}, // cross-account
 			},
-		}}, testSelfID, testOwnerAcctID)
+		}}, testSelfID, testSelfName, testOwnerAcctID)
 		pairs := out[0].UserIDGroupPairs
-		// find each by GroupID
+		// the self-ref pair is stripped group-id-less; the cross-SG pair keeps its id
 		var self, cross *svcapitypes.UserIDGroupPair
 		for _, p := range pairs {
-			if p.GroupID != nil && *p.GroupID == testSelfID {
+			if p.GroupID == nil {
 				self = p
-			}
-			if p.GroupID != nil && *p.GroupID == testOtherID {
+			} else if *p.GroupID == testOtherID {
 				cross = p
 			}
 		}
-		assert.NotNil(t, self, "omitted pair canonicalised to selfID")
+		assert.NotNil(t, self, "omitted self-ref left group-id-less")
 		assert.Nil(t, self.UserID, "self-ref owner UserID cleared")
 		assert.NotNil(t, cross, "cross-SG pair kept")
 		assert.Equal(t, testPeerAcctID, *cross.UserID, "cross-account UserID preserved")
@@ -695,29 +688,10 @@ func TestCanonicalizeCIDR_BoundaryVectors(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// canonicalizeCopiedRuleLists (resource-level guards, non-mutating)
+// canonicalizeCopiedRuleLists (non-mutating)
 // -----------------------------------------------------------------------------
 
-func TestCanonicalizeCopiedRuleLists_Guards(t *testing.T) {
-	t.Run("nil resource does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeCopiedRuleLists(nil) })
-	})
-
-	t.Run("nil ko does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeCopiedRuleLists(&resource{}) })
-	})
-
-	t.Run("nil Status.ID: omitted self-ref pair is left group-id-less", func(t *testing.T) {
-		r := mkResource([]*svcapitypes.IPPermission{{
-			FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
-			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("coredns")}},
-		}}, nil)
-		r.ko.Status.ID = nil
-		var ingress []*svcapitypes.IPPermission
-		assert.NotPanics(t, func() { ingress, _ = canonicalizeCopiedRuleLists(r) })
-		assert.Nil(t, ingress[0].UserIDGroupPairs[0].GroupID)
-	})
-
+func TestCanonicalizeCopiedRuleLists_NonMutating(t *testing.T) {
 	t.Run("does not mutate the source resource", func(t *testing.T) {
 		// The whole point of the copy-based approach: canonicalisation must
 		// never touch the caller's rule lists (they become the merge-patch
@@ -731,9 +705,9 @@ func TestCanonicalizeCopiedRuleLists_Guards(t *testing.T) {
 		assert.Equal(t, "6", *r.ko.Spec.IngressRules[0].IPProtocol)
 		assert.NotNil(t, r.ko.Spec.IngressRules[0].UserIDGroupPairs[0].GroupRef)
 		assert.Nil(t, r.ko.Spec.IngressRules[0].UserIDGroupPairs[0].GroupID)
-		// Copy canonicalised: protocol mapped to name, self-ref resolved to selfID.
+		// Copy canonicalised: protocol mapped to name, self-ref stripped group-id-less.
 		assert.Equal(t, "tcp", *ingress[0].IPProtocol)
-		assert.Equal(t, testSelfID, *ingress[0].UserIDGroupPairs[0].GroupID)
+		assert.Nil(t, ingress[0].UserIDGroupPairs[0].GroupID)
 	})
 }
 
@@ -817,12 +791,8 @@ func TestCustomPostCompare_GroupRefOnly_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "a spec-only groupRef must never produce a diff")
 }
 
-// TestCustomPostCompare_ReadOnlyPeerMetadata_NoDiff proves that VPCID,
-// PeeringStatus and VPCPeeringConnectionID never drive a delta. These are
-// read-only values EC2 derives from the referenced group (populated on a
-// cross-VPC peer read-back, absent on a same-VPC one) -- the authorize path
-// accepts and discards any client-supplied value. Neither an omitted spec
-// value nor a stale/mismatched one may churn against the AWS-filled read-back.
+// VPCID, PeeringStatus and VPCPeeringConnectionID are read-only (EC2-derived);
+// neither an omitted nor a stale spec value may churn against the read-back.
 func TestCustomPostCompare_ReadOnlyPeerMetadata_NoDiff(t *testing.T) {
 	// latest mirrors a cross-VPC peer reference as AWS returns it: GroupID +
 	// owner UserID plus the three derived read-only fields.
@@ -869,6 +839,28 @@ func TestCustomPostCompare_ReadOnlyPeerMetadata_NoDiff(t *testing.T) {
 		got := desiredLatestDelta(desired, latest)
 		assert.False(t, got.ing, "stale spec peer metadata must not diff against AWS-derived values")
 	})
+}
+
+func TestCustomPostCompare_BadGroupName_StillFires(t *testing.T) {
+	// A self GroupID paired with a GroupName that is NOT the SG's own name: the
+	// self GroupID is stripped, but the bogus name must survive so the diff
+	// against the AWS read-back (which has no such name) still fires. The old
+	// "clear GroupName whenever GroupID==self" logic would have swallowed it.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), GroupName: aws.String("bogus-name"),
+		}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), UserID: aws.String(testOwnerAcctID),
+		}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "a non-self GroupName must not be swallowed -- the diff must fire")
 }
 
 func TestCustomPostCompare_AllProtocolPorts_NoDiff(t *testing.T) {
@@ -1057,20 +1049,10 @@ func TestCustomPostCompare_SelfRef_StaysResolved(t *testing.T) {
 		"delta must not nil the resolved GroupID of a self-ref")
 }
 
-// -----------------------------------------------------------------------------
-// Full delta path: composite ingress + egress
-//
-// The tests above each isolate a single normalisation on one rule list. These
-// exercise the whole delta path (newResourceDelta -> customPostCompare) with a
-// realistic resource that stacks many normalisations across BOTH ingress and
-// egress in one pass: self-reference by omission, grant aggregation, CIDR
-// canonicalisation, read-only peer metadata, all-protocol port dropping and
-// numeric-protocol naming -- desired in raw spec form, latest in AWS read-back
-// form.
-// -----------------------------------------------------------------------------
+// Full delta path: a realistic resource stacking many normalisations across
+// both rule lists in one pass (desired = raw spec, latest = AWS read-back).
 
-// compositeSpec builds a desired (raw spec) resource that combines several
-// normalisations on both rule lists.
+// compositeSpec is the raw-spec desired side.
 func compositeSpec() *resource {
 	ingress := []*svcapitypes.IPPermission{
 		// self-reference by omission (#2822): no groupID, no groupRef
@@ -1096,10 +1078,8 @@ func compositeSpec() *resource {
 	return mkResource(ingress, egress)
 }
 
-// compositeReadBack builds the latest resource as AWS returns it: rules
-// aggregated, CIDRs canonicalised, grants reordered, self/owner and peer
-// metadata filled, ports dropped, protocols named. Callers may tweak the
-// returned lists to introduce a genuine change.
+// compositeReadBack is the AWS read-back latest side (aggregated, canonicalised,
+// reordered, metadata filled). Callers may tweak it to introduce a real change.
 func compositeReadBack() *resource {
 	ingress := []*svcapitypes.IPPermission{
 		// self-reference: AWS filled groupID (self) + owner userID
@@ -1163,4 +1143,69 @@ func TestCustomPostCompare_Composite_RealIngressChange_FiresIngressOnly(t *testi
 	got := desiredLatestDelta(desired, latest)
 	assert.True(t, got.ing, "a genuine ingress group reference change must produce a diff")
 	assert.False(t, got.egr, "unchanged egress must stay suppressed")
+}
+
+// Without the parent SG identity (ID + owner account) the rule delta is skipped
+// -- the pre-create patchResourceMetadataAndSpec state -- and must not panic.
+func TestCustomPostCompare_NilParentID_SkipsRuleDelta(t *testing.T) {
+	// A resource with no Status.ID and no ACKResourceMetadata (pre-create form).
+	mkNilID := func(ingress []*svcapitypes.IPPermission) *resource {
+		return &resource{ko: &svcapitypes.SecurityGroup{
+			Spec:   svcapitypes.SecurityGroupSpec{IngressRules: ingress},
+			Status: svcapitypes.SecurityGroupStatus{},
+		}}
+	}
+	// A self-ref-by-omission rule that WOULD canonicalize differently against an
+	// ID-bearing read-back (desired -> no groupID, latest -> groupID=self), so a
+	// naive comparison would report a diff. The skip must suppress it.
+	specRule := func() []*svcapitypes.IPPermission {
+		return []*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("coredns")}},
+		}}
+	}
+	readBackRule := func() []*svcapitypes.IPPermission {
+		return []*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				Description: aws.String("coredns"), GroupID: aws.String(testSelfID),
+				UserID: aws.String(testOwnerAcctID),
+			}},
+		}}
+	}
+
+	t.Run("desired (pre-create) has no parent ID", func(t *testing.T) {
+		desired := mkNilID(specRule())
+		latest := mkResource(readBackRule(), nil)
+		var got *struct{ ing, egr bool }
+		assert.NotPanics(t, func() { got = desiredLatestDelta(desired, latest) })
+		assert.False(t, got.ing, "rule delta must be skipped when desired lacks the parent ID")
+		assert.False(t, got.egr, "rule delta must be skipped when desired lacks the parent ID")
+	})
+
+	t.Run("latest has no parent ID", func(t *testing.T) {
+		desired := mkResource(readBackRule(), nil)
+		latest := mkNilID(specRule())
+		var got *struct{ ing, egr bool }
+		assert.NotPanics(t, func() { got = desiredLatestDelta(desired, latest) })
+		assert.False(t, got.ing, "rule delta must be skipped when latest lacks the parent ID")
+		assert.False(t, got.egr, "rule delta must be skipped when latest lacks the parent ID")
+	})
+
+	t.Run("parent ID present but owner account unknown", func(t *testing.T) {
+		// ID is set but ACKResourceMetadata/OwnerAccountID is not: same-account
+		// UserID clearing can't be applied, so the delta is still untrustworthy
+		// and must be skipped.
+		desired := &resource{ko: &svcapitypes.SecurityGroup{
+			Spec: svcapitypes.SecurityGroupSpec{IngressRules: specRule()},
+			Status: svcapitypes.SecurityGroupStatus{
+				ID: aws.String(testSelfID), // no ACKResourceMetadata
+			},
+		}}
+		latest := mkResource(readBackRule(), nil)
+		var got *struct{ ing, egr bool }
+		assert.NotPanics(t, func() { got = desiredLatestDelta(desired, latest) })
+		assert.False(t, got.ing, "rule delta must be skipped when the owner account is unknown")
+		assert.False(t, got.egr, "rule delta must be skipped when the owner account is unknown")
+	})
 }

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -120,12 +120,9 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 	})
 
 	t.Run("groupRef with an unresolved (nil) GroupID canonicalises to self", func(t *testing.T) {
-		// Accepted tradeoff: the delta assumes GroupID is resolved. A pair
-		// that still carries a groupRef with no resolved GroupID is stripped
-		// of the wrapper and, being otherwise identifier-less, treated as a
-		// self-reference. The referencesResolved guard is what actually keeps
-		// an unresolved reference from being authorised prematurely; this
-		// function only shapes the delta.
+		// The delta assumes GroupID is resolved: a wrapper-only pair is
+		// stripped and, being identifier-less, treated as self. Guarding an
+		// unresolved reference is referencesResolved's job, not this function's.
 		p := &svcapitypes.UserIDGroupPair{GroupRef: groupRef("not-yet-created")}
 		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupRef)
@@ -219,22 +216,13 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 	})
 }
 
-// TestCanonicalizeGroupPair_InconsistentInputs documents what happens to the
-// UserID/GroupName fields that the self-ref branch drops when the input is
-// inconsistent. Ground truth, verified directly against the EC2 API:
-//
-//   - {GroupId=self}              -> accepted; AWS auto-fills UserId=owner
-//   - {GroupId=self, UserId=owner} -> accepted; identical rule to the above
-//   - {GroupId=self, UserId=foreign} -> REJECTED (InvalidGroup.NotFound): a
-//     foreign UserId scopes the group lookup to that account, where the SG's
-//     own id does not exist
-//   - {UserId=foreign} (no group) -> REJECTED (MissingParameter)
-//
-// So dropping the owner UserId/GroupName on a genuine self-reference is
-// lossless, and the only case a foreign UserId is dropped is when
-// GroupId==selfID -- an impossible input AWS rejects anyway. A legitimate
-// cross-account reference always uses GroupId=peer (!= selfID) and is
-// preserved (see TestCustomPostCompare_CrossAccount_NotSuppressed).
+// TestCanonicalizeGroupPair_InconsistentInputs documents, against real EC2
+// behavior, that dropping the owner UserID on a self-ref is lossless:
+// {GroupId=self} and {GroupId=self, UserId=owner} produce the identical rule
+// (AWS auto-fills the owner). A foreign UserID is only ever dropped when paired
+// with the SG's own GroupID -- an input AWS rejects anyway; a legitimate
+// cross-account ref uses GroupId=peer and is preserved (see
+// TestCustomPostCompare_CrossAccount_NotSuppressed).
 func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 	t.Run("self GroupID + foreign UserID: classified self, foreign UserID dropped", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
@@ -463,10 +451,8 @@ func TestCanonicalizeRuleList(t *testing.T) {
 	})
 
 	t.Run("handles nil CIDR/prefix grant elements without panic", func(t *testing.T) {
-		// Defensive: sortGrants and the per-element loops must tolerate a nil
-		// element in IPRanges/IPv6Ranges/PrefixListIDs. This cannot occur via
-		// a CR (schema rejects null list entries) or on read-back (the setter
-		// always allocates), but the guards keep the comparators panic-free.
+		// Defensive only: a nil grant element can't occur via a CR or read-back,
+		// but sortGrants and the per-element loops must tolerate it.
 		var out []*svcapitypes.IPPermission
 		assert.NotPanics(t, func() {
 			out = canonicalizeRuleList([]*svcapitypes.IPPermission{{
@@ -805,9 +791,9 @@ func TestCustomPostCompare_CrossAccount_NotSuppressed(t *testing.T) {
 }
 
 func TestCustomPostCompare_SelfRef_StaysResolved(t *testing.T) {
-	// customUpdateSecurityGroup relies on GroupID being non-nil after
-	// normalisation so that referencesResolved keeps syncSGRules open for a
-	// self-reference expressed via groupRef.
+	// customPostCompare works on copies and must not mutate desired, so
+	// referencesResolved still sees the resolved GroupID and keeps syncSGRules
+	// open for a groupRef self-reference.
 	desired := mkResource([]*svcapitypes.IPPermission{{
 		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
 		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
@@ -820,5 +806,5 @@ func TestCustomPostCompare_SelfRef_StaysResolved(t *testing.T) {
 
 	rm := &resourceManager{}
 	assert.True(t, rm.referencesResolved(desired),
-		"after normalisation a self-ref must still be seen as resolved")
+		"delta must not nil the resolved GroupID of a self-ref")
 }

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -107,6 +107,31 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 		assert.Nil(t, p.GroupRef, "GroupRef must be cleared to match AWS read-back form")
 	})
 
+	t.Run("GroupRef is cleared even on a resolved cross-SG pair", func(t *testing.T) {
+		// A groupRef pointing at another SG resolves to that SG's GroupID.
+		// The wrapper is stripped; the resolved GroupID is authoritative.
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID:  aws.String(testOtherID),
+			GroupRef: groupRef("other"),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Nil(t, p.GroupRef, "GroupRef must never survive into the delta")
+		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
+	})
+
+	t.Run("groupRef with an unresolved (nil) GroupID canonicalises to self", func(t *testing.T) {
+		// Accepted tradeoff: the delta assumes GroupID is resolved. A pair
+		// that still carries a groupRef with no resolved GroupID is stripped
+		// of the wrapper and, being otherwise identifier-less, treated as a
+		// self-reference. The referencesResolved guard is what actually keeps
+		// an unresolved reference from being authorised prematurely; this
+		// function only shapes the delta.
+		p := &svcapitypes.UserIDGroupPair{GroupRef: groupRef("not-yet-created")}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Nil(t, p.GroupRef)
+		assert.Equal(t, testSelfID, *p.GroupID)
+	})
+
 	t.Run("cross-SG same-account: clear owner UserID, keep GroupID", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
 			GroupID: aws.String(testOtherID),
@@ -135,6 +160,29 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Nil(t, p.GroupRef)
+	})
+
+	t.Run("VPCRef cleared, VPCID preserved on a cross-SG pair", func(t *testing.T) {
+		// VPCRef is a spec-only reference wrapper AWS never returns; VPCID is
+		// the concrete value AWS does return on read-back and must survive.
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testOtherID),
+			VPCID:   aws.String("vpc-123"),
+			VPCRef:  groupRef("my-vpc"),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Nil(t, p.VPCRef, "VPCRef must be cleared to match AWS read-back form")
+		assert.Equal(t, "vpc-123", *p.VPCID, "concrete VPCID must be preserved")
+	})
+
+	t.Run("VPCRef cleared on a self-ref pair", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testSelfID),
+			VPCRef:  groupRef("my-vpc"),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.VPCRef, "VPCRef must be cleared on a self-reference too")
 	})
 
 	t.Run("by-name reference is not treated as self-ref", func(t *testing.T) {
@@ -545,6 +593,29 @@ func TestCustomPreCompare_SelfRef_Omitted_NoDiff(t *testing.T) {
 
 	got := desiredLatestDelta(desired, latest)
 	assert.False(t, got.ing, "omitted-groupID self-ref (#2822) must not produce a diff")
+}
+
+func TestCustomPreCompare_GroupRefOnly_NoDiff(t *testing.T) {
+	// desired mirrors the post-ResolveReferences state for a cross-SG rule
+	// written with a groupRef: the wrapper is still set AND GroupID is
+	// resolved. latest is the AWS read-back: GroupID only, no wrapper. The
+	// spec-only groupRef must not drive a diff.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID:  aws.String(testOtherID),
+			GroupRef: groupRef("other-sg"),
+		}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testOtherID),
+		}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "a spec-only groupRef must never produce a diff")
 }
 
 func TestCustomPreCompare_AllProtocolPorts_NoDiff(t *testing.T) {

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -1056,3 +1056,111 @@ func TestCustomPostCompare_SelfRef_StaysResolved(t *testing.T) {
 	assert.True(t, rm.referencesResolved(desired),
 		"delta must not nil the resolved GroupID of a self-ref")
 }
+
+// -----------------------------------------------------------------------------
+// Full delta path: composite ingress + egress
+//
+// The tests above each isolate a single normalisation on one rule list. These
+// exercise the whole delta path (newResourceDelta -> customPostCompare) with a
+// realistic resource that stacks many normalisations across BOTH ingress and
+// egress in one pass: self-reference by omission, grant aggregation, CIDR
+// canonicalisation, read-only peer metadata, all-protocol port dropping and
+// numeric-protocol naming -- desired in raw spec form, latest in AWS read-back
+// form.
+// -----------------------------------------------------------------------------
+
+// compositeSpec builds a desired (raw spec) resource that combines several
+// normalisations on both rule lists.
+func compositeSpec() *resource {
+	ingress := []*svcapitypes.IPPermission{
+		// self-reference by omission (#2822): no groupID, no groupRef
+		{FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("coredns")}}},
+		// two grants AWS aggregates under 443/tcp, one CIDR non-canonical
+		{FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
+		{FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}}},
+		// cross-SG reference; read-only peer metadata omitted in spec
+		{FromPort: aws.Int64(8443), ToPort: aws.Int64(8443), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{GroupID: aws.String(testOtherID)}}},
+	}
+	egress := []*svcapitypes.IPPermission{
+		// all-protocol rule with explicit ports AWS drops
+		{IPProtocol: aws.String("-1"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}}},
+		// numeric protocol AWS returns by name
+		{FromPort: aws.Int64(22), ToPort: aws.Int64(22), IPProtocol: aws.String("6"),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}}},
+	}
+	return mkResource(ingress, egress)
+}
+
+// compositeReadBack builds the latest resource as AWS returns it: rules
+// aggregated, CIDRs canonicalised, grants reordered, self/owner and peer
+// metadata filled, ports dropped, protocols named. Callers may tweak the
+// returned lists to introduce a genuine change.
+func compositeReadBack() *resource {
+	ingress := []*svcapitypes.IPPermission{
+		// self-reference: AWS filled groupID (self) + owner userID
+		{FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				Description: aws.String("coredns"), GroupID: aws.String(testSelfID),
+				UserID: aws.String(testOwnerAcctID)}}},
+		// aggregated 443/tcp, CIDRs canonical and in reversed order
+		{FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			IPRanges: []*svcapitypes.IPRange{
+				{CIDRIP: aws.String("100.68.0.0/18")},
+				{CIDRIP: aws.String("10.0.0.0/20")}}},
+		// cross-SG reference: owner userID + derived read-only peer metadata
+		{FromPort: aws.Int64(8443), ToPort: aws.Int64(8443), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				GroupID: aws.String(testOtherID), UserID: aws.String(testOwnerAcctID),
+				VPCID: aws.String("vpc-peer-b"), PeeringStatus: aws.String("active"),
+				VPCPeeringConnectionID: aws.String("pcx-realvalue")}}},
+	}
+	egress := []*svcapitypes.IPPermission{
+		// all-protocol rule: ports dropped
+		{IPProtocol: aws.String("-1"),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}}},
+		// protocol returned as name
+		{FromPort: aws.Int64(22), ToPort: aws.Int64(22), IPProtocol: aws.String("tcp"),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}}},
+	}
+	return mkResource(ingress, egress)
+}
+
+func TestCustomPostCompare_Composite_IngressAndEgress_NoDiff(t *testing.T) {
+	// A realistic resource stacking many normalisations on both lists must
+	// converge with zero delta on ingress AND egress in a single pass.
+	got := desiredLatestDelta(compositeSpec(), compositeReadBack())
+	assert.False(t, got.ing, "composite ingress normalisations must not diff")
+	assert.False(t, got.egr, "composite egress normalisations must not diff")
+}
+
+func TestCustomPostCompare_Composite_RealEgressChange_FiresEgressOnly(t *testing.T) {
+	// Same fully-normalised resource, but with one genuine change buried in
+	// the egress list (the 22/tcp rule's CIDR). The full path must still
+	// suppress the (unchanged) ingress and surface the real egress diff --
+	// the two lists are evaluated independently.
+	desired := compositeSpec()
+	latest := compositeReadBack()
+	latest.ko.Spec.EgressRules[1].IPRanges[0].CIDRIP = aws.String("10.1.0.0/16") // was 10.0.0.0/16
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "unchanged ingress must stay suppressed")
+	assert.True(t, got.egr, "a genuine egress CIDR change must produce a diff")
+}
+
+func TestCustomPostCompare_Composite_RealIngressChange_FiresIngressOnly(t *testing.T) {
+	// Symmetric to the above: a genuine change buried in the ingress list
+	// (the cross-SG reference now points at a different group) must surface on
+	// ingress while the fully-normalised egress stays suppressed.
+	desired := compositeSpec()
+	latest := compositeReadBack()
+	latest.ko.Spec.IngressRules[2].UserIDGroupPairs[0].GroupID = aws.String("sg-different0000")
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "a genuine ingress group reference change must produce a diff")
+	assert.False(t, got.egr, "unchanged egress must stay suppressed")
+}

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -501,6 +501,100 @@ func TestCanonicalizeRuleList(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
+// canonicalizeCIDR (direct port of EC2-NM-Common CidrBlock.canonicalizeAddress)
+// -----------------------------------------------------------------------------
+
+func TestCanonicalizeCIDR(t *testing.T) {
+	cases := []struct {
+		name string
+		in   *string
+		want *string
+	}{
+		{"nil passes through", nil, nil},
+		{"IPv4 host bits masked", aws.String("100.68.0.18/18"), aws.String("100.68.0.0/18")},
+		{"IPv4 already canonical", aws.String("10.0.0.0/24"), aws.String("10.0.0.0/24")},
+		{"IPv4 /32 host preserved", aws.String("10.0.0.5/32"), aws.String("10.0.0.5/32")},
+		{"IPv4 /0 collapses to zero network", aws.String("10.10.0.0/0"), aws.String("0.0.0.0/0")},
+		// IPv6 is lowercased, zero-compressed, and leading zeros in a hextet
+		// dropped -- the RFC 5952 form AWS returns on read-back.
+		{"IPv6 host bits masked and normalized", aws.String("2001:DB8:abcd:0012::1/64"), aws.String("2001:db8:abcd:12::/64")},
+		{"IPv6 already canonical", aws.String("2600:1f16::/48"), aws.String("2600:1f16::/48")},
+		// The backend rejects a prefix longer than the address; we leave it
+		// untouched rather than emit a bogus network.
+		{"IPv4 prefix too long passes through", aws.String("10.0.0.0/40"), aws.String("10.0.0.0/40")},
+		{"IPv6 prefix too long passes through", aws.String("2001:db8::/129"), aws.String("2001:db8::/129")},
+		{"negative prefix passes through", aws.String("10.0.0.0/-1"), aws.String("10.0.0.0/-1")},
+		{"missing prefix passes through", aws.String("10.0.0.0"), aws.String("10.0.0.0")},
+		{"malformed address passes through", aws.String("not-a-cidr"), aws.String("not-a-cidr")},
+		{"non-numeric prefix passes through", aws.String("10.0.0.0/abc"), aws.String("10.0.0.0/abc")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := canonicalizeCIDR(tc.in)
+			if tc.want == nil {
+				assert.Nil(t, got)
+				return
+			}
+			if assert.NotNil(t, got) {
+				assert.Equal(t, *tc.want, *got)
+			}
+		})
+	}
+
+	t.Run("does not mutate the caller's string", func(t *testing.T) {
+		orig := "100.68.0.18/18"
+		in := orig
+		_ = canonicalizeCIDR(&in)
+		assert.Equal(t, orig, in, "input pointer target must be unchanged")
+	})
+}
+
+// TestCanonicalizeCIDR_BackendParityVectors reuses the boundary vectors from the
+// EC2 backend's own unit test, com.amazon.ec2.nm.TestCidrBlock#testCanonicalizing
+// (and its isValidAndCanonical* cases), in package EC2-NM-Common. The backend
+// tests parseAsCanonical, which *rejects* a non-canonical CIDR; canonicalizeCIDR
+// instead *rewrites* it to the canonical form, so each backend "not canonical"
+// case becomes an input->expected-network assertion here. These vectors exercise
+// the partial-byte mask at the /7, /8, /9, /31 and /127 boundaries -- the part of
+// the ported CidrBlock.canonicalizeAddress loop most prone to off-by-one bugs.
+func TestCanonicalizeCIDR_BackendParityVectors(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// testCanonicalizing: IPv6 /8 boundary (first byte only).
+		{"ff10::/8", "ff00::/8"}, // backend rejects as non-canonical
+		{"ff00::/8", "ff00::/8"}, // backend accepts as canonical
+		// testCanonicalizing: IPv6 /7 boundary (first byte mask 0xfe).
+		{"ff00::/7", "fe00::/7"}, // backend rejects
+		{"fe00::/7", "fe00::/7"}, // backend accepts
+		// testCanonicalizing: IPv4 /9 boundary (second byte mask 0x80).
+		{"10.64.0.0/9", "10.0.0.0/9"},    // backend rejects
+		{"10.128.0.0/9", "10.128.0.0/9"}, // backend accepts
+		// testCanonicalizing: IPv6 /8 with a host bit in the last hextet.
+		{"::1/8", "::/8"}, // backend rejects
+		{"::/8", "::/8"},  // backend accepts
+		// isValidAndCanonicalIpv4: /31 boundary (last byte mask 0xfe).
+		{"255.255.255.255/31", "255.255.255.254/31"}, // backend rejects
+		{"0.0.0.0/0", "0.0.0.0/0"},                   // backend accepts
+		{"255.255.255.255/32", "255.255.255.255/32"}, // backend accepts
+		// isValidAndCanonicalIpv6: /127 boundary and a canonical /64.
+		{"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/127", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/127"}, // backend rejects
+		{"ffff:ffff:ffff:ffff::/64", "ffff:ffff:ffff:ffff::/64"},                                       // backend accepts
+		{"6be8:7177:fd47:df14:f49b:a890:3a67:8000/113", "6be8:7177:fd47:df14:f49b:a890:3a67:8000/113"}, // backend accepts (/113 boundary)
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			in := tc.in
+			got := canonicalizeCIDR(&in)
+			if assert.NotNil(t, got) {
+				assert.Equal(t, tc.want, *got)
+			}
+		})
+	}
+}
+
+// -----------------------------------------------------------------------------
 // canonicalizeCopiedRuleLists (resource-level guards, non-mutating)
 // -----------------------------------------------------------------------------
 

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -1,0 +1,659 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package security_group
+
+import (
+	"testing"
+
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+)
+
+const (
+	testSelfID      = "sg-self"
+	testOtherID     = "sg-other"
+	testOwnerAcctID = "111122223333"
+	testPeerAcctID  = "999988887777"
+	testSelfName    = "self-sg-name"
+)
+
+func groupRef(name string) *ackv1alpha1.AWSResourceReferenceWrapper {
+	return &ackv1alpha1.AWSResourceReferenceWrapper{
+		From: &ackv1alpha1.AWSResourceReference{Name: aws.String(name)},
+	}
+}
+
+func ruleWithPairs(pairs ...*svcapitypes.UserIDGroupPair) *svcapitypes.IPPermission {
+	return &svcapitypes.IPPermission{UserIDGroupPairs: pairs}
+}
+
+// mkResource builds a resource with Status.ID = testSelfID and
+// Status.ACKResourceMetadata.OwnerAccountID = testOwnerAcctID, mirroring the
+// values the runtime populates on both desired and latest.
+func mkResource(ingress, egress []*svcapitypes.IPPermission) *resource {
+	return &resource{
+		ko: &svcapitypes.SecurityGroup{
+			Spec: svcapitypes.SecurityGroupSpec{
+				IngressRules: ingress,
+				EgressRules:  egress,
+			},
+			Status: svcapitypes.SecurityGroupStatus{
+				ID: aws.String(testSelfID),
+				ACKResourceMetadata: &ackv1alpha1.ResourceMetadata{
+					OwnerAccountID: (*ackv1alpha1.AWSAccountID)(aws.String(testOwnerAcctID)),
+				},
+			},
+		},
+	}
+}
+
+// -----------------------------------------------------------------------------
+// canonicalizeGroupPair
+// -----------------------------------------------------------------------------
+
+func TestCanonicalizeGroupPair(t *testing.T) {
+	t.Run("nil pair does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() { canonicalizeGroupPair(nil, testSelfID, testOwnerAcctID) })
+	})
+
+	t.Run("self-ref by explicit self GroupID: keep selfID, clear the rest", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID:   aws.String(testSelfID),
+			UserID:    aws.String(testOwnerAcctID),
+			GroupName: aws.String(testSelfName),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.UserID)
+		assert.Nil(t, p.GroupName)
+		assert.Nil(t, p.GroupRef)
+	})
+
+	t.Run("self-ref by omission: GroupID canonicalised up to selfID", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			Description: aws.String("coredns"),
+			UserID:      aws.String(testOwnerAcctID),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		// This is the #2822 fix: the omitted GroupID must become selfID so
+		// it matches the AWS-filled latest side.
+		assert.NotNil(t, p.GroupID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.UserID)
+		assert.NotNil(t, p.Description, "description is preserved")
+	})
+
+	t.Run("self-ref by groupRef: clear GroupRef, keep selfID", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID:  aws.String(testSelfID),
+			GroupRef: groupRef("myself"),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.GroupRef, "GroupRef must be cleared to match AWS read-back form")
+	})
+
+	t.Run("cross-SG same-account: clear owner UserID, keep GroupID", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testOtherID),
+			UserID:  aws.String(testOwnerAcctID),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testOtherID, *p.GroupID)
+		assert.Nil(t, p.UserID, "server-filled owner account cleared")
+	})
+
+	t.Run("cross-account: preserve UserID and GroupID", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testOtherID),
+			UserID:  aws.String(testPeerAcctID),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testOtherID, *p.GroupID)
+		assert.Equal(t, testPeerAcctID, *p.UserID, "cross-account UserID must be preserved")
+	})
+
+	t.Run("cross-SG by ref: drop GroupRef once GroupID resolved", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID:  aws.String(testOtherID),
+			GroupRef: groupRef("other"),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testOtherID, *p.GroupID)
+		assert.Nil(t, p.GroupRef)
+	})
+
+	t.Run("by-name reference is not treated as self-ref", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{GroupName: aws.String("some-named-sg")}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "a by-name pair must not be canonicalised to selfID")
+		assert.Equal(t, "some-named-sg", *p.GroupName)
+	})
+
+	t.Run("empty selfID (nil Status.ID): omitted pair is not stamped with a group id", func(t *testing.T) {
+		// Pre-create / adoption: Status.ID is not yet known. An omitted
+		// self-ref pair must not gain a bogus (empty) GroupID and must not
+		// panic; the server-fillable fields are still cleared.
+		p := &svcapitypes.UserIDGroupPair{
+			Description: aws.String("coredns"),
+			UserID:      aws.String(testOwnerAcctID),
+		}
+		canonicalizeGroupPair(p, "", testOwnerAcctID)
+		assert.Nil(t, p.GroupID, "must not set a GroupID when selfID is unknown")
+		assert.Nil(t, p.UserID)
+	})
+
+	t.Run("empty selfID: explicit GroupID pair is left intact (self unknown)", func(t *testing.T) {
+		// With no known selfID we cannot classify an explicit-id pair as a
+		// self-reference, so it is treated as a cross-SG pair: GroupID kept,
+		// only an owner-account UserID stripped.
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testSelfID),
+			UserID:  aws.String(testOwnerAcctID),
+		}
+		canonicalizeGroupPair(p, "", testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.UserID)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// canonicalizeRuleList
+// -----------------------------------------------------------------------------
+
+func TestCanonicalizeRuleList(t *testing.T) {
+	t.Run("nil stays nil (absent == empty)", func(t *testing.T) {
+		assert.Nil(t, canonicalizeRuleList(nil, testSelfID, testOwnerAcctID))
+	})
+
+	t.Run("drops port range for all-protocol -1 rules", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("-1"),
+			FromPort:   aws.Int64(0),
+			ToPort:     aws.Int64(0),
+			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1)
+		assert.Nil(t, out[0].FromPort)
+		assert.Nil(t, out[0].ToPort)
+	})
+
+	t.Run("maps well-known numeric protocols to names, leaves others as-is", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("6"), FromPort: aws.Int64(22), ToPort: aws.Int64(22)},
+			{IPProtocol: aws.String("17"), FromPort: aws.Int64(53), ToPort: aws.Int64(53)},
+			{IPProtocol: aws.String("1"), FromPort: aws.Int64(-1), ToPort: aws.Int64(-1)},
+			{IPProtocol: aws.String("58")},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
+			{IPProtocol: aws.String("47")}, // GRE: not well-known, kept as number
+		}, testSelfID, testOwnerAcctID)
+		got := map[string]bool{}
+		for _, r := range out {
+			got[*r.IPProtocol] = true
+		}
+		assert.True(t, got["tcp"], "6 -> tcp")
+		assert.True(t, got["udp"], "17 -> udp")
+		assert.True(t, got["icmp"], "1 -> icmp")
+		assert.True(t, got["icmpv6"], "58 -> icmpv6")
+		assert.True(t, got["47"], "unknown protocol number kept as-is")
+		assert.False(t, got["6"], "numeric 6 must not survive")
+	})
+
+	t.Run("numeric and name forms aggregate together", func(t *testing.T) {
+		// "6" and "tcp" on the same port must collapse to one rule.
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("6"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1, "6 and tcp on the same port are the same protocol")
+	})
+
+	t.Run("canonicalizes IPv4 and IPv6 CIDRs to network form", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
+			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:DB8:abcd:0012::1/64")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Equal(t, "100.68.0.0/18", *out[0].IPRanges[0].CIDRIP)
+		assert.Equal(t, "2001:db8:abcd:12::/64", *out[0].IPv6Ranges[0].CIDRIPv6)
+	})
+
+	t.Run("non-canonical and canonical CIDR aggregate to one grant shape", func(t *testing.T) {
+		// A spec written as "100.68.0.18/18" must match the AWS read-back
+		// "100.68.0.0/18" (same rule, same port).
+		a := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
+		}}, testSelfID, testOwnerAcctID)
+		b := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.0/18")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Equal(t, *a[0].IPRanges[0].CIDRIP, *b[0].IPRanges[0].CIDRIP)
+	})
+
+	t.Run("leaves a malformed CIDR untouched", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("not-a-cidr")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Equal(t, "not-a-cidr", *out[0].IPRanges[0].CIDRIP)
+	})
+
+	t.Run("does not drop ports for icmp (-1 type is meaningful)", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("icmp"),
+			FromPort:   aws.Int64(-1),
+			ToPort:     aws.Int64(-1),
+		}}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1)
+		assert.NotNil(t, out[0].FromPort)
+		assert.NotNil(t, out[0].ToPort)
+	})
+
+	t.Run("aggregates rules sharing (proto, fromPort, toPort)", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1, "the two rules must merge into one")
+		assert.Len(t, out[0].IPRanges, 2)
+	})
+
+	t.Run("does not aggregate rules with different ports", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 2)
+	})
+
+	t.Run("produces a deterministic order regardless of input order", func(t *testing.T) {
+		in1 := []*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
+		}
+		in2 := []*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
+		}
+		out1 := canonicalizeRuleList(in1, testSelfID, testOwnerAcctID)
+		out2 := canonicalizeRuleList(in2, testSelfID, testOwnerAcctID)
+		assert.Equal(t, ruleAggregationKey(out1[0]), ruleAggregationKey(out2[0]))
+		assert.Equal(t, ruleAggregationKey(out1[1]), ruleAggregationKey(out2[1]))
+	})
+
+	t.Run("does not alias caller grant slices when aggregating", func(t *testing.T) {
+		orig := &svcapitypes.IPPermission{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}},
+		}
+		_ = canonicalizeRuleList([]*svcapitypes.IPPermission{
+			orig,
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, orig.IPRanges, 1, "the caller's original rule must not be mutated by aggregation")
+	})
+
+	t.Run("aggregates and sorts IPv6Ranges and PrefixListIDs", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPv6Ranges:    []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:db8::/48")}},
+				PrefixListIDs: []*svcapitypes.PrefixListID{{PrefixListID: aws.String("pl-22")}}},
+			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				IPv6Ranges:    []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:db8:1::/48")}},
+				PrefixListIDs: []*svcapitypes.PrefixListID{{PrefixListID: aws.String("pl-11")}}},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1, "same (proto,from,to) rules merge")
+		// merged and sorted ascending (lexicographic: '1' < ':')
+		assert.Equal(t, []string{"2001:db8:1::/48", "2001:db8::/48"},
+			[]string{*out[0].IPv6Ranges[0].CIDRIPv6, *out[0].IPv6Ranges[1].CIDRIPv6})
+		assert.Equal(t, []string{"pl-11", "pl-22"},
+			[]string{*out[0].PrefixListIDs[0].PrefixListID, *out[0].PrefixListIDs[1].PrefixListID})
+	})
+
+	t.Run("sorts UserIDGroupPairs so grant order does not matter", func(t *testing.T) {
+		mk := func(gids ...string) []*svcapitypes.IPPermission {
+			pairs := make([]*svcapitypes.UserIDGroupPair, 0, len(gids))
+			for _, g := range gids {
+				pairs = append(pairs, &svcapitypes.UserIDGroupPair{GroupID: aws.String(g), UserID: aws.String(testPeerAcctID)})
+			}
+			return []*svcapitypes.IPPermission{{
+				IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+				UserIDGroupPairs: pairs,
+			}}
+		}
+		a := canonicalizeRuleList(mk("sg-aaa", "sg-bbb"), testSelfID, testOwnerAcctID)
+		b := canonicalizeRuleList(mk("sg-bbb", "sg-aaa"), testSelfID, testOwnerAcctID)
+		assert.Equal(t,
+			[]string{*a[0].UserIDGroupPairs[0].GroupID, *a[0].UserIDGroupPairs[1].GroupID},
+			[]string{*b[0].UserIDGroupPairs[0].GroupID, *b[0].UserIDGroupPairs[1].GroupID},
+			"reordered group pairs must canonicalise to the same order")
+	})
+
+	t.Run("handles nil rule and nil pair entries without panic", func(t *testing.T) {
+		var out []*svcapitypes.IPPermission
+		assert.NotPanics(t, func() {
+			out = canonicalizeRuleList([]*svcapitypes.IPPermission{
+				nil,
+				{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(53), ToPort: aws.Int64(53),
+					UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{
+						nil,
+						{GroupID: aws.String(testSelfID)},
+					}},
+			}, testSelfID, testOwnerAcctID)
+		})
+		assert.Len(t, out, 1, "the nil rule is skipped, the real one is kept")
+	})
+
+	t.Run("mixed self + cross-SG pairs in one rule are handled independently", func(t *testing.T) {
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{
+				{GroupName: nil, UserID: aws.String(testOwnerAcctID)},                  // omitted self-ref
+				{GroupID: aws.String(testOtherID), UserID: aws.String(testPeerAcctID)}, // cross-account
+			},
+		}}, testSelfID, testOwnerAcctID)
+		pairs := out[0].UserIDGroupPairs
+		// find each by GroupID
+		var self, cross *svcapitypes.UserIDGroupPair
+		for _, p := range pairs {
+			if p.GroupID != nil && *p.GroupID == testSelfID {
+				self = p
+			}
+			if p.GroupID != nil && *p.GroupID == testOtherID {
+				cross = p
+			}
+		}
+		assert.NotNil(t, self, "omitted pair canonicalised to selfID")
+		assert.Nil(t, self.UserID, "self-ref owner UserID cleared")
+		assert.NotNil(t, cross, "cross-SG pair kept")
+		assert.Equal(t, testPeerAcctID, *cross.UserID, "cross-account UserID preserved")
+	})
+}
+
+// -----------------------------------------------------------------------------
+// canonicalizeSGRules (resource-level guards)
+// -----------------------------------------------------------------------------
+
+func TestCanonicalizeSGRules_Guards(t *testing.T) {
+	t.Run("nil resource does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() { canonicalizeSGRules(nil) })
+	})
+
+	t.Run("nil ko does not panic", func(t *testing.T) {
+		assert.NotPanics(t, func() { canonicalizeSGRules(&resource{}) })
+	})
+
+	t.Run("nil Status.ID: omitted self-ref pair is left group-id-less", func(t *testing.T) {
+		r := mkResource([]*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("coredns")}},
+		}}, nil)
+		r.ko.Status.ID = nil
+		assert.NotPanics(t, func() { canonicalizeSGRules(r) })
+		assert.Nil(t, r.ko.Spec.IngressRules[0].UserIDGroupPairs[0].GroupID)
+	})
+}
+
+// -----------------------------------------------------------------------------
+// customPreCompare via newResourceDelta (end-to-end delta suppression)
+// -----------------------------------------------------------------------------
+
+// desiredLatestDelta normalises both sides through newResourceDelta (which
+// invokes customPreCompare) and returns the resulting delta.
+func desiredLatestDelta(desired, latest *resource) *struct{ ing, egr bool } {
+	d := newResourceDelta(desired, latest)
+	return &struct{ ing, egr bool }{
+		d.DifferentAt("Spec.IngressRules"),
+		d.DifferentAt("Spec.EgressRules"),
+	}
+}
+
+func TestCustomPreCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
+	// desired mirrors the post-ResolveReferences state: GroupRef set AND
+	// GroupID filled with selfID. latest is the AWS read-back: GroupID set,
+	// UserID/GroupName filled, no GroupRef.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), GroupRef: groupRef("myself"),
+		}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), UserID: aws.String(testOwnerAcctID),
+			GroupName: aws.String(testSelfName),
+		}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "self-ref via groupRef must not produce a diff")
+}
+
+func TestCustomPreCompare_SelfRef_Omitted_NoDiff(t *testing.T) {
+	// The exact #2822 reproducer: userIDGroupPair with only description +
+	// userID, no groupID and no groupRef. latest has GroupID filled by AWS.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			Description: aws.String("coredns"), UserID: aws.String(testOwnerAcctID),
+		}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			Description: aws.String("coredns"), GroupID: aws.String(testSelfID),
+			UserID: aws.String(testOwnerAcctID),
+		}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "omitted-groupID self-ref (#2822) must not produce a diff")
+}
+
+func TestCustomPreCompare_AllProtocolPorts_NoDiff(t *testing.T) {
+	desired := mkResource(nil, []*svcapitypes.IPPermission{{
+		IPProtocol: aws.String("-1"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
+	}})
+	latest := mkResource(nil, []*svcapitypes.IPPermission{{
+		IPProtocol: aws.String("-1"),
+		IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
+	}})
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.egr, "-1 rule with spec ports vs AWS-dropped ports must not diff")
+}
+
+func TestCustomPreCompare_GrantAggregation_NoDiff(t *testing.T) {
+	// desired: two separate rules; latest: AWS-aggregated single rule, and
+	// grants in reversed order to also exercise sorting.
+	desired := mkResource([]*svcapitypes.IPPermission{
+		{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
+		{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
+	}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{
+		{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
+			IPRanges: []*svcapitypes.IPRange{
+				{CIDRIP: aws.String("192.168.0.0/16")},
+				{CIDRIP: aws.String("10.0.0.0/20")},
+			}},
+	}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "split desired rules vs AWS-aggregated latest must not diff")
+}
+
+func TestCustomPreCompare_SelfRef_Egress_NoDiff(t *testing.T) {
+	// Same self-ref suppression must hold on the egress side (symmetric code
+	// path through canonicalizeRuleList).
+	desired := mkResource(nil, []*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{Description: aws.String("egress self")}},
+	}})
+	latest := mkResource(nil, []*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			Description: aws.String("egress self"), GroupID: aws.String(testSelfID),
+			UserID: aws.String(testOwnerAcctID),
+		}},
+	}})
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.egr, "self-ref egress must not produce a diff")
+}
+
+func TestCustomPreCompare_DescriptionChange_StillFires(t *testing.T) {
+	// Description participates in comparison and must NOT be normalised away:
+	// a description-only change on an otherwise-identical rule must diff.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20"), Description: aws.String("before")}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20"), Description: aws.String("after")}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "a description-only change must still produce a diff")
+}
+
+func TestCustomPreCompare_NumericProtocol_NoDiff(t *testing.T) {
+	// Verified against AWS: submitting IpProtocol "6" is stored and returned
+	// as "tcp". The spec numeric form must not perpetually diff from the
+	// name AWS returns.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(22), ToPort: aws.Int64(22), IPProtocol: aws.String("6"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(22), ToPort: aws.Int64(22), IPProtocol: aws.String("tcp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "numeric protocol (6) vs name (tcp) must not diff")
+}
+
+func TestCustomPreCompare_DifferentProtocol_StillFires(t *testing.T) {
+	// A genuine protocol change (tcp -> udp) must still be detected.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("6"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("udp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "tcp vs udp must still produce a diff")
+}
+
+func TestCustomPreCompare_NonCanonicalCIDR_NoDiff(t *testing.T) {
+	// Verified against AWS: submitting "100.68.0.18/18" is stored/returned as
+	// "100.68.0.0/18"; IPv6 is also masked and text-normalised. The spec's
+	// non-canonical form must not perpetually diff from the read-back form.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
+		IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:DB8:abcd:0012::1/64")}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.0/18")}},
+		IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:db8:abcd:12::/64")}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.False(t, got.ing, "non-canonical CIDR vs AWS-canonicalized form must not diff")
+}
+
+func TestCustomPreCompare_DifferentCIDR_StillFires(t *testing.T) {
+	// A genuinely different network must still diff.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/16")}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+		IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.1.0.0/16")}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "a different CIDR network must still produce a diff")
+}
+
+func TestCustomPreCompare_RealDiff_StillFires(t *testing.T) {
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{GroupID: aws.String(testSelfID)}},
+	}}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(80), ToPort: aws.Int64(80), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), UserID: aws.String(testOwnerAcctID),
+		}},
+	}}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "a genuine port change must still produce a diff")
+}
+
+func TestCustomPreCompare_CrossAccount_NotSuppressed(t *testing.T) {
+	// desired omits the cross-account UserID; latest carries the peer
+	// account. Because the peer account differs from the owner account it is
+	// NOT stripped, so the missing UserID on desired remains a real diff.
+	desired := mkResource([]*svcapitypes.IPPermission{ruleWithPairs(
+		&svcapitypes.UserIDGroupPair{GroupID: aws.String(testOtherID)},
+	)}, nil)
+	latest := mkResource([]*svcapitypes.IPPermission{ruleWithPairs(
+		&svcapitypes.UserIDGroupPair{GroupID: aws.String(testOtherID), UserID: aws.String(testPeerAcctID)},
+	)}, nil)
+
+	got := desiredLatestDelta(desired, latest)
+	assert.True(t, got.ing, "cross-account UserID divergence must remain a diff (not silently dropped)")
+}
+
+func TestCustomPreCompare_SelfRef_StaysResolved(t *testing.T) {
+	// customUpdateSecurityGroup relies on GroupID being non-nil after
+	// normalisation so that referencesResolved keeps syncSGRules open for a
+	// self-reference expressed via groupRef.
+	desired := mkResource([]*svcapitypes.IPPermission{{
+		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
+		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+			GroupID: aws.String(testSelfID), GroupRef: groupRef("myself"),
+		}},
+	}}, nil)
+	latest := mkResource(nil, nil)
+
+	_ = newResourceDelta(desired, latest)
+
+	rm := &resourceManager{}
+	assert.True(t, rm.referencesResolved(desired),
+		"after normalisation a self-ref must still be seen as resolved")
+}

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -69,16 +69,15 @@ func mkResource(ingress, egress []*svcapitypes.IPPermission) *resource {
 
 func TestCanonicalizeGroupPair(t *testing.T) {
 	t.Run("nil pair does not panic", func(t *testing.T) {
-		assert.NotPanics(t, func() { canonicalizeGroupPair(nil, testSelfID, testSelfName, testOwnerAcctID) })
+		assert.NotPanics(t, func() { canonicalizeGroupPair(nil, testSelfID, testOwnerAcctID) })
 	})
 
 	t.Run("self-ref by explicit self GroupID: stripped group-id-less", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{
-			GroupID:   aws.String(testSelfID),
-			UserID:    aws.String(testOwnerAcctID),
-			GroupName: aws.String(testSelfName),
+			GroupID: aws.String(testSelfID),
+			UserID:  aws.String(testOwnerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "self GroupID is stripped so it matches the omitted spec form")
 		assert.Nil(t, p.UserID)
 		assert.Nil(t, p.GroupName)
@@ -90,7 +89,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			Description: aws.String("coredns"),
 			UserID:      aws.String(testOwnerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		// The #2822 fix: the omitted-groupID spec form must match the AWS
 		// read-back, whose self GroupID is stripped to nil on the latest side.
 		assert.Nil(t, p.GroupID)
@@ -103,7 +102,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:  aws.String(testSelfID),
 			GroupRef: groupRef("myself"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "self GroupID stripped")
 		assert.Nil(t, p.GroupRef, "GroupRef must be cleared to match AWS read-back form")
 	})
@@ -115,7 +114,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:  aws.String(testOtherID),
 			GroupRef: groupRef("other"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupRef, "GroupRef must never survive into the delta")
 		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
 	})
@@ -125,7 +124,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 		// stripped. Guarding an unresolved reference is referencesResolved's
 		// job, not this function's.
 		p := &svcapitypes.UserIDGroupPair{GroupRef: groupRef("not-yet-created")}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupRef)
 		assert.Nil(t, p.GroupID)
 	})
@@ -135,7 +134,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testOwnerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Nil(t, p.UserID, "server-filled owner account cleared")
 	})
@@ -145,7 +144,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID, "cross-account UserID must be preserved")
 	})
@@ -155,7 +154,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:  aws.String(testOtherID),
 			GroupRef: groupRef("other"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Nil(t, p.GroupRef)
 	})
@@ -172,7 +171,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			PeeringStatus:          aws.String("active"),
 			VPCPeeringConnectionID: aws.String("pcx-123"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID, "resolved GroupID is preserved")
 		assert.Nil(t, p.VPCRef, "VPCRef must be cleared to match AWS read-back form")
 		assert.Nil(t, p.VPCID, "server-derived VPCID must be cleared")
@@ -185,23 +184,24 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID: aws.String(testSelfID),
 			VPCRef:  groupRef("my-vpc"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "self GroupID stripped")
 		assert.Nil(t, p.VPCRef, "VPCRef must be cleared on a self-reference too")
 	})
 
 	t.Run("by-name reference to another SG (non-matching name) is preserved", func(t *testing.T) {
 		p := &svcapitypes.UserIDGroupPair{GroupName: aws.String("some-named-sg")}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "a by-name pair must not be canonicalised to selfID")
 		assert.Equal(t, "some-named-sg", *p.GroupName, "a non-self GroupName must survive")
 	})
 
-	t.Run("self-ref by GroupName matching own name is stripped", func(t *testing.T) {
-		// A self-reference expressed purely by the SG's own name (no GroupID).
+	t.Run("self-ref by GroupName matching own name is left untouched (name refs not canonicalized)", func(t *testing.T) {
+		// GroupName is never canonicalized (see canonicalizeGroupPair), so even a
+		// self-referencing name is preserved rather than stripped.
 		p := &svcapitypes.UserIDGroupPair{GroupName: aws.String(testSelfName)}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
-		assert.Nil(t, p.GroupName, "a GroupName matching the SG's own name is stripped")
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfName, *p.GroupName, "GroupName is preserved, not stripped")
 		assert.Nil(t, p.GroupID)
 	})
 
@@ -212,7 +212,7 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 			GroupID:   aws.String(testSelfID),
 			GroupName: aws.String("some-other-name"),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID, "self GroupID stripped")
 		assert.Equal(t, "some-other-name", *p.GroupName, "a non-self GroupName must not be swallowed")
 	})
@@ -233,7 +233,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 			GroupID: aws.String(testSelfID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID)
 	})
@@ -241,7 +241,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 	t.Run("omitted group + foreign UserID: stays group-id-less, UserID kept", func(t *testing.T) {
 		// {UserID: foreign} with no group is invalid to AWS (MissingParameter).
 		p := &svcapitypes.UserIDGroupPair{UserID: aws.String(testPeerAcctID)}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Nil(t, p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID)
 	})
@@ -251,7 +251,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 			GroupID: aws.String(testOtherID),
 			UserID:  aws.String(testPeerAcctID),
 		}
-		canonicalizeGroupPair(p, testSelfID, testSelfName, testOwnerAcctID)
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
 		assert.Equal(t, testOtherID, *p.GroupID)
 		assert.Equal(t, testPeerAcctID, *p.UserID,
 			"a legitimate cross-account reference (GroupId=peer) must be preserved")
@@ -264,7 +264,7 @@ func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
 
 func TestCanonicalizeRuleList(t *testing.T) {
 	t.Run("nil stays nil (absent == empty)", func(t *testing.T) {
-		assert.Nil(t, canonicalizeRuleList(nil, testSelfID, testSelfName, testOwnerAcctID))
+		assert.Nil(t, canonicalizeRuleList(nil, testSelfID, testOwnerAcctID))
 	})
 
 	t.Run("drops port range for all-protocol -1 rules", func(t *testing.T) {
@@ -273,7 +273,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			FromPort:   aws.Int64(0),
 			ToPort:     aws.Int64(0),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("0.0.0.0/0")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Nil(t, out[0].FromPort)
 		assert.Nil(t, out[0].ToPort)
@@ -288,7 +288,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}}},
 			{IPProtocol: aws.String("47"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 2)
 		for _, r := range out {
 			assert.Nil(t, r.FromPort, "protocol %s must drop fromPort", *r.IPProtocol)
@@ -303,11 +303,11 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		spec := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("50"), FromPort: aws.Int64(-1), ToPort: aws.Int64(-1),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		readBack := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("50"),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Equal(t, readBack, spec, "ported spec and portless read-back must canonicalise equal")
 	})
 
@@ -319,7 +319,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("58")},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("47")}, // GRE: not well-known, kept as number
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		got := map[string]bool{}
 		for _, r := range out {
 			got[*r.IPProtocol] = true
@@ -339,7 +339,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1, "6 and tcp on the same port are the same protocol")
 	})
 
@@ -348,7 +348,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:DB8:abcd:0012::1/64")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Equal(t, "100.68.0.0/18", *out[0].IPRanges[0].CIDRIP)
 		assert.Equal(t, "2001:db8:abcd:12::/64", *out[0].IPv6Ranges[0].CIDRIPv6)
 	})
@@ -359,11 +359,11 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		a := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.18/18")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		b := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("100.68.0.0/18")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Equal(t, *a[0].IPRanges[0].CIDRIP, *b[0].IPRanges[0].CIDRIP)
 	})
 
@@ -371,7 +371,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("not-a-cidr")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Equal(t, "not-a-cidr", *out[0].IPRanges[0].CIDRIP)
 	})
 
@@ -380,7 +380,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("icmp"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.NotNil(t, out[0].FromPort)
 		assert.NotNil(t, out[0].ToPort)
@@ -395,7 +395,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Nil(t, out[0].FromPort)
 		assert.Nil(t, out[0].ToPort)
@@ -408,7 +408,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("58"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.Equal(t, "icmpv6", *out[0].IPProtocol)
 		assert.Nil(t, out[0].FromPort)
@@ -422,13 +422,13 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		omitted := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("icmpv6"),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		wildcard := canonicalizeRuleList([]*svcapitypes.IPPermission{{
 			IPProtocol: aws.String("icmpv6"),
 			FromPort:   aws.Int64(-1),
 			ToPort:     aws.Int64(-1),
 			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.True(t, equality.Semantic.DeepEqual(omitted, wildcard),
 			"omitted and -1/-1 icmpv6 must be indistinguishable after canonicalisation")
 	})
@@ -440,7 +440,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			IPProtocol: aws.String("icmpv6"),
 			FromPort:   aws.Int64(128),
 			ToPort:     aws.Int64(0),
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1)
 		assert.NotNil(t, out[0].FromPort)
 		assert.EqualValues(t, 128, *out[0].FromPort)
@@ -454,7 +454,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/20")}}},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1, "the two rules must merge into one")
 		assert.Len(t, out[0].IPRanges, 2)
 	})
@@ -463,7 +463,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 2)
 	})
 
@@ -476,8 +476,8 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80)},
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443)},
 		}
-		out1 := canonicalizeRuleList(in1, testSelfID, testSelfName, testOwnerAcctID)
-		out2 := canonicalizeRuleList(in2, testSelfID, testSelfName, testOwnerAcctID)
+		out1 := canonicalizeRuleList(in1, testSelfID, testOwnerAcctID)
+		out2 := canonicalizeRuleList(in2, testSelfID, testOwnerAcctID)
 		assert.Equal(t, ruleAggregationKey(out1[0]), ruleAggregationKey(out2[0]))
 		assert.Equal(t, ruleAggregationKey(out1[1]), ruleAggregationKey(out2[1]))
 	})
@@ -491,7 +491,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			orig,
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, orig.IPRanges, 1, "the caller's original rule must not be mutated by aggregation")
 	})
 
@@ -503,7 +503,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			{IPProtocol: aws.String("tcp"), FromPort: aws.Int64(443), ToPort: aws.Int64(443),
 				IPv6Ranges:    []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("2001:db8:1::/48")}},
 				PrefixListIDs: []*svcapitypes.PrefixListID{{PrefixListID: aws.String("pl-11")}}},
-		}, testSelfID, testSelfName, testOwnerAcctID)
+		}, testSelfID, testOwnerAcctID)
 		assert.Len(t, out, 1, "same (proto,from,to) rules merge")
 		// merged and sorted ascending (lexicographic: '1' < ':')
 		assert.Equal(t, []string{"2001:db8:1::/48", "2001:db8::/48"},
@@ -523,8 +523,8 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				UserIDGroupPairs: pairs,
 			}}
 		}
-		a := canonicalizeRuleList(mk("sg-aaa", "sg-bbb"), testSelfID, testSelfName, testOwnerAcctID)
-		b := canonicalizeRuleList(mk("sg-bbb", "sg-aaa"), testSelfID, testSelfName, testOwnerAcctID)
+		a := canonicalizeRuleList(mk("sg-aaa", "sg-bbb"), testSelfID, testOwnerAcctID)
+		b := canonicalizeRuleList(mk("sg-bbb", "sg-aaa"), testSelfID, testOwnerAcctID)
 		assert.Equal(t,
 			[]string{*a[0].UserIDGroupPairs[0].GroupID, *a[0].UserIDGroupPairs[1].GroupID},
 			[]string{*b[0].UserIDGroupPairs[0].GroupID, *b[0].UserIDGroupPairs[1].GroupID},
@@ -541,7 +541,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 						nil,
 						{GroupID: aws.String(testSelfID)},
 					}},
-			}, testSelfID, testSelfName, testOwnerAcctID)
+			}, testSelfID, testOwnerAcctID)
 		})
 		assert.Len(t, out, 1, "the nil rule is skipped, the real one is kept")
 	})
@@ -565,7 +565,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 					nil,
 					{PrefixListID: aws.String("pl-11")},
 				},
-			}}, testSelfID, testSelfName, testOwnerAcctID)
+			}}, testSelfID, testOwnerAcctID)
 		})
 		assert.Len(t, out, 1)
 	})
@@ -577,7 +577,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 				{GroupName: nil, UserID: aws.String(testOwnerAcctID)},                  // omitted self-ref
 				{GroupID: aws.String(testOtherID), UserID: aws.String(testPeerAcctID)}, // cross-account
 			},
-		}}, testSelfID, testSelfName, testOwnerAcctID)
+		}}, testSelfID, testOwnerAcctID)
 		pairs := out[0].UserIDGroupPairs
 		// the self-ref pair is stripped group-id-less; the cross-SG pair keeps its id
 		var self, cross *svcapitypes.UserIDGroupPair
@@ -727,8 +727,8 @@ func desiredLatestDelta(desired, latest *resource) *struct{ ing, egr bool } {
 
 func TestCustomPostCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
 	// desired mirrors the post-ResolveReferences state: GroupRef set AND
-	// GroupID filled with selfID. latest is the AWS read-back: GroupID set,
-	// UserID/GroupName filled, no GroupRef.
+	// GroupID filled with selfID. latest is the AWS read-back: GroupID + UserID
+	// filled, no GroupRef and no GroupName (AWS never returns a name on read-back).
 	desired := mkResource([]*svcapitypes.IPPermission{{
 		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
 		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
@@ -739,7 +739,6 @@ func TestCustomPostCompare_SelfRef_GroupRef_NoDiff(t *testing.T) {
 		FromPort: aws.Int64(53), ToPort: aws.Int64(53), IPProtocol: aws.String("tcp"),
 		UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
 			GroupID: aws.String(testSelfID), UserID: aws.String(testOwnerAcctID),
-			GroupName: aws.String(testSelfName),
 		}},
 	}}, nil)
 

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -278,6 +278,38 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		assert.Nil(t, out[0].ToPort)
 	})
 
+	t.Run("drops ports for protocols outside tcp/udp/icmp/icmpv6", func(t *testing.T) {
+		// AWS omits the port range on read-back for any protocol not in
+		// {tcp, udp, icmp, icmpv6}, e.g. 50 (ESP) or 47 (GRE). A spec that
+		// carries ports for such a protocol must be canonicalised to no ports.
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
+			{IPProtocol: aws.String("50"), FromPort: aws.Int64(-1), ToPort: aws.Int64(-1),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}}},
+			{IPProtocol: aws.String("47"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),
+				IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("192.168.0.0/16")}}},
+		}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 2)
+		for _, r := range out {
+			assert.Nil(t, r.FromPort, "protocol %s must drop fromPort", *r.IPProtocol)
+			assert.Nil(t, r.ToPort, "protocol %s must drop toPort", *r.IPProtocol)
+		}
+	})
+
+	t.Run("non-standard protocol: ported spec matches portless read-back", func(t *testing.T) {
+		// The motivating diff: a spec written with -1/-1 ports on an ESP rule
+		// must compare equal to the AWS read-back, which drops the ports
+		// entirely. After canonicalisation both sides are portless and identical.
+		spec := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("50"), FromPort: aws.Int64(-1), ToPort: aws.Int64(-1),
+			IPRanges: []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
+		}}, testSelfID, testOwnerAcctID)
+		readBack := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("50"),
+			IPRanges:   []*svcapitypes.IPRange{{CIDRIP: aws.String("10.0.0.0/8")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Equal(t, readBack, spec, "ported spec and portless read-back must canonicalise equal")
+	})
+
 	t.Run("maps well-known numeric protocols to names, leaves others as-is", func(t *testing.T) {
 		out := canonicalizeRuleList([]*svcapitypes.IPPermission{
 			{IPProtocol: aws.String("6"), FromPort: aws.Int64(22), ToPort: aws.Int64(22)},

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -596,7 +596,7 @@ func TestCanonicalizeRuleList(t *testing.T) {
 }
 
 // -----------------------------------------------------------------------------
-// canonicalizeCIDR (direct port of EC2-NM-Common CidrBlock.canonicalizeAddress)
+// canonicalizeCIDR
 // -----------------------------------------------------------------------------
 
 func TestCanonicalizeCIDR(t *testing.T) {
@@ -614,7 +614,7 @@ func TestCanonicalizeCIDR(t *testing.T) {
 		// dropped -- the RFC 5952 form AWS returns on read-back.
 		{"IPv6 host bits masked and normalized", aws.String("2001:DB8:abcd:0012::1/64"), aws.String("2001:db8:abcd:12::/64")},
 		{"IPv6 already canonical", aws.String("2600:1f16::/48"), aws.String("2600:1f16::/48")},
-		// The backend rejects a prefix longer than the address; we leave it
+		// AWS rejects a prefix longer than the address; we leave it
 		// untouched rather than emit a bogus network.
 		{"IPv4 prefix too long passes through", aws.String("10.0.0.0/40"), aws.String("10.0.0.0/40")},
 		{"IPv6 prefix too long passes through", aws.String("2001:db8::/129"), aws.String("2001:db8::/129")},
@@ -644,39 +644,37 @@ func TestCanonicalizeCIDR(t *testing.T) {
 	})
 }
 
-// TestCanonicalizeCIDR_BackendParityVectors reuses the boundary vectors from the
-// EC2 backend's own unit test, com.amazon.ec2.nm.TestCidrBlock#testCanonicalizing
-// (and its isValidAndCanonical* cases), in package EC2-NM-Common. The backend
-// tests parseAsCanonical, which *rejects* a non-canonical CIDR; canonicalizeCIDR
-// instead *rewrites* it to the canonical form, so each backend "not canonical"
-// case becomes an input->expected-network assertion here. These vectors exercise
-// the partial-byte mask at the /7, /8, /9, /31 and /127 boundaries -- the part of
-// the ported CidrBlock.canonicalizeAddress loop most prone to off-by-one bugs.
-func TestCanonicalizeCIDR_BackendParityVectors(t *testing.T) {
+// TestCanonicalizeCIDR_BoundaryVectors exercises the partial-byte network mask
+// at the /7, /8, /9, /31 and /127 prefix boundaries -- the part of the
+// canonicalizeCIDR mask loop most prone to off-by-one bugs. Each case pairs a
+// non-canonical input (one that carries host bits, which AWS rejects on input)
+// with the canonical network canonicalizeCIDR rewrites it to, alongside the
+// already-canonical form that must pass through unchanged.
+func TestCanonicalizeCIDR_BoundaryVectors(t *testing.T) {
 	cases := []struct {
 		in   string
 		want string
 	}{
-		// testCanonicalizing: IPv6 /8 boundary (first byte only).
-		{"ff10::/8", "ff00::/8"}, // backend rejects as non-canonical
-		{"ff00::/8", "ff00::/8"}, // backend accepts as canonical
-		// testCanonicalizing: IPv6 /7 boundary (first byte mask 0xfe).
-		{"ff00::/7", "fe00::/7"}, // backend rejects
-		{"fe00::/7", "fe00::/7"}, // backend accepts
-		// testCanonicalizing: IPv4 /9 boundary (second byte mask 0x80).
-		{"10.64.0.0/9", "10.0.0.0/9"},    // backend rejects
-		{"10.128.0.0/9", "10.128.0.0/9"}, // backend accepts
-		// testCanonicalizing: IPv6 /8 with a host bit in the last hextet.
-		{"::1/8", "::/8"}, // backend rejects
-		{"::/8", "::/8"},  // backend accepts
-		// isValidAndCanonicalIpv4: /31 boundary (last byte mask 0xfe).
-		{"255.255.255.255/31", "255.255.255.254/31"}, // backend rejects
-		{"0.0.0.0/0", "0.0.0.0/0"},                   // backend accepts
-		{"255.255.255.255/32", "255.255.255.255/32"}, // backend accepts
-		// isValidAndCanonicalIpv6: /127 boundary and a canonical /64.
-		{"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/127", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/127"}, // backend rejects
-		{"ffff:ffff:ffff:ffff::/64", "ffff:ffff:ffff:ffff::/64"},                                       // backend accepts
-		{"6be8:7177:fd47:df14:f49b:a890:3a67:8000/113", "6be8:7177:fd47:df14:f49b:a890:3a67:8000/113"}, // backend accepts (/113 boundary)
+		// IPv6 /8 boundary (first byte only).
+		{"ff10::/8", "ff00::/8"}, // AWS rejects as non-canonical
+		{"ff00::/8", "ff00::/8"}, // AWS accepts as canonical
+		// IPv6 /7 boundary (first byte mask 0xfe).
+		{"ff00::/7", "fe00::/7"}, // AWS rejects
+		{"fe00::/7", "fe00::/7"}, // AWS accepts
+		// IPv4 /9 boundary (second byte mask 0x80).
+		{"10.64.0.0/9", "10.0.0.0/9"},    // AWS rejects
+		{"10.128.0.0/9", "10.128.0.0/9"}, // AWS accepts
+		// IPv6 /8 with a host bit in the last hextet.
+		{"::1/8", "::/8"}, // AWS rejects
+		{"::/8", "::/8"},  // AWS accepts
+		// IPv4 /31 boundary (last byte mask 0xfe).
+		{"255.255.255.255/31", "255.255.255.254/31"}, // AWS rejects
+		{"0.0.0.0/0", "0.0.0.0/0"},                   // AWS accepts
+		{"255.255.255.255/32", "255.255.255.255/32"}, // AWS accepts
+		// IPv6 /127 boundary and a canonical /64.
+		{"ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/127", "ffff:ffff:ffff:ffff:ffff:ffff:ffff:fffe/127"}, // AWS rejects
+		{"ffff:ffff:ffff:ffff::/64", "ffff:ffff:ffff:ffff::/64"},                                       // AWS accepts
+		{"6be8:7177:fd47:df14:f49b:a890:3a67:8000/113", "6be8:7177:fd47:df14:f49b:a890:3a67:8000/113"}, // AWS accepts (/113 boundary)
 	}
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -171,6 +171,55 @@ func TestCanonicalizeGroupPair(t *testing.T) {
 	})
 }
 
+// TestCanonicalizeGroupPair_InconsistentInputs documents what happens to the
+// UserID/GroupName fields that the self-ref branch drops when the input is
+// inconsistent. Ground truth, verified directly against the EC2 API:
+//
+//   - {GroupId=self}              -> accepted; AWS auto-fills UserId=owner
+//   - {GroupId=self, UserId=owner} -> accepted; identical rule to the above
+//   - {GroupId=self, UserId=foreign} -> REJECTED (InvalidGroup.NotFound): a
+//     foreign UserId scopes the group lookup to that account, where the SG's
+//     own id does not exist
+//   - {UserId=foreign} (no group) -> REJECTED (MissingParameter)
+//
+// So dropping the owner UserId/GroupName on a genuine self-reference is
+// lossless, and the only case a foreign UserId is dropped is when
+// GroupId==selfID -- an impossible input AWS rejects anyway. A legitimate
+// cross-account reference always uses GroupId=peer (!= selfID) and is
+// preserved (see TestCustomPreCompare_CrossAccount_NotSuppressed).
+func TestCanonicalizeGroupPair_InconsistentInputs(t *testing.T) {
+	t.Run("self GroupID + foreign UserID: classified self, foreign UserID dropped", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testSelfID),
+			UserID:  aws.String(testPeerAcctID),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.UserID,
+			"a foreign UserID paired with the SG's own GroupID is nonsensical "+
+				"(AWS rejects it as InvalidGroup.NotFound); dropping it is safe")
+	})
+
+	t.Run("omitted group + foreign UserID: classified self, UserID dropped", func(t *testing.T) {
+		// {UserID: foreign} with no group is invalid to AWS (MissingParameter).
+		p := &svcapitypes.UserIDGroupPair{UserID: aws.String(testPeerAcctID)}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testSelfID, *p.GroupID)
+		assert.Nil(t, p.UserID)
+	})
+
+	t.Run("peer GroupID + foreign UserID: NOT self, cross-account preserved", func(t *testing.T) {
+		p := &svcapitypes.UserIDGroupPair{
+			GroupID: aws.String(testOtherID),
+			UserID:  aws.String(testPeerAcctID),
+		}
+		canonicalizeGroupPair(p, testSelfID, testOwnerAcctID)
+		assert.Equal(t, testOtherID, *p.GroupID)
+		assert.Equal(t, testPeerAcctID, *p.UserID,
+			"a legitimate cross-account reference (GroupId=peer) must be preserved")
+	})
+}
+
 // -----------------------------------------------------------------------------
 // canonicalizeRuleList
 // -----------------------------------------------------------------------------
@@ -363,6 +412,32 @@ func TestCanonicalizeRuleList(t *testing.T) {
 			}, testSelfID, testOwnerAcctID)
 		})
 		assert.Len(t, out, 1, "the nil rule is skipped, the real one is kept")
+	})
+
+	t.Run("handles nil CIDR/prefix grant elements without panic", func(t *testing.T) {
+		// Defensive: sortGrants and the per-element loops must tolerate a nil
+		// element in IPRanges/IPv6Ranges/PrefixListIDs. This cannot occur via
+		// a CR (schema rejects null list entries) or on read-back (the setter
+		// always allocates), but the guards keep the comparators panic-free.
+		var out []*svcapitypes.IPPermission
+		assert.NotPanics(t, func() {
+			out = canonicalizeRuleList([]*svcapitypes.IPPermission{{
+				IPProtocol: aws.String("tcp"), FromPort: aws.Int64(80), ToPort: aws.Int64(80),
+				IPRanges: []*svcapitypes.IPRange{
+					nil,
+					{CIDRIP: aws.String("10.0.0.0/16")},
+				},
+				IPv6Ranges: []*svcapitypes.IPv6Range{
+					nil,
+					{CIDRIPv6: aws.String("2001:db8::/48")},
+				},
+				PrefixListIDs: []*svcapitypes.PrefixListID{
+					nil,
+					{PrefixListID: aws.String("pl-11")},
+				},
+			}}, testSelfID, testOwnerAcctID)
+		})
+		assert.Len(t, out, 1)
 	})
 
 	t.Run("mixed self + cross-SG pairs in one rule are handled independently", func(t *testing.T) {

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -19,6 +19,7 @@ import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/equality"
 
 	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
 )
@@ -350,6 +351,68 @@ func TestCanonicalizeRuleList(t *testing.T) {
 		assert.Len(t, out, 1)
 		assert.NotNil(t, out[0].FromPort)
 		assert.NotNil(t, out[0].ToPort)
+	})
+
+	t.Run("collapses the icmpv6 -1 wildcard type/code to nil", func(t *testing.T) {
+		// icmpv6 read back from AWS as the "all types and codes" wildcard
+		// carries FromPort/ToPort = -1. Canonicalise it to nil so it matches a
+		// spec that simply omits the type/code.
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("icmpv6"),
+			FromPort:   aws.Int64(-1),
+			ToPort:     aws.Int64(-1),
+			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1)
+		assert.Nil(t, out[0].FromPort)
+		assert.Nil(t, out[0].ToPort)
+	})
+
+	t.Run("numeric protocol 58 also collapses the -1 wildcard", func(t *testing.T) {
+		// "58" canonicalises to "icmpv6", so the wildcard collapse must apply to
+		// the numeric spelling too.
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("58"),
+			FromPort:   aws.Int64(-1),
+			ToPort:     aws.Int64(-1),
+		}}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1)
+		assert.Equal(t, "icmpv6", *out[0].IPProtocol)
+		assert.Nil(t, out[0].FromPort)
+		assert.Nil(t, out[0].ToPort)
+	})
+
+	t.Run("omitted and explicit-wildcard icmpv6 canonicalise equal", func(t *testing.T) {
+		// The read-back form (-1/-1) and the spec shorthand (omitted) are the
+		// same rule; both must collapse to the identical canonical shape so no
+		// perpetual diff arises (aws-controllers-k8s/community#2822).
+		omitted := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("icmpv6"),
+			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
+		}}, testSelfID, testOwnerAcctID)
+		wildcard := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("icmpv6"),
+			FromPort:   aws.Int64(-1),
+			ToPort:     aws.Int64(-1),
+			IPv6Ranges: []*svcapitypes.IPv6Range{{CIDRIPv6: aws.String("::/0")}},
+		}}, testSelfID, testOwnerAcctID)
+		assert.True(t, equality.Semantic.DeepEqual(omitted, wildcard),
+			"omitted and -1/-1 icmpv6 must be indistinguishable after canonicalisation")
+	})
+
+	t.Run("preserves a real icmpv6 type/code", func(t *testing.T) {
+		// A concrete type/code (e.g. 128/0, echo request) is not the wildcard
+		// and must survive so a genuine change is not swallowed.
+		out := canonicalizeRuleList([]*svcapitypes.IPPermission{{
+			IPProtocol: aws.String("icmpv6"),
+			FromPort:   aws.Int64(128),
+			ToPort:     aws.Int64(0),
+		}}, testSelfID, testOwnerAcctID)
+		assert.Len(t, out, 1)
+		assert.NotNil(t, out[0].FromPort)
+		assert.EqualValues(t, 128, *out[0].FromPort)
+		assert.NotNil(t, out[0].ToPort)
+		assert.EqualValues(t, 0, *out[0].ToPort)
 	})
 
 	t.Run("aggregates rules sharing (proto, fromPort, toPort)", func(t *testing.T) {

--- a/pkg/resource/security_group/hooks_test.go
+++ b/pkg/resource/security_group/hooks_test.go
@@ -817,6 +817,60 @@ func TestCustomPostCompare_GroupRefOnly_NoDiff(t *testing.T) {
 	assert.False(t, got.ing, "a spec-only groupRef must never produce a diff")
 }
 
+// TestCustomPostCompare_ReadOnlyPeerMetadata_NoDiff proves that VPCID,
+// PeeringStatus and VPCPeeringConnectionID never drive a delta. These are
+// read-only values EC2 derives from the referenced group (populated on a
+// cross-VPC peer read-back, absent on a same-VPC one) -- the authorize path
+// accepts and discards any client-supplied value. Neither an omitted spec
+// value nor a stale/mismatched one may churn against the AWS-filled read-back.
+func TestCustomPostCompare_ReadOnlyPeerMetadata_NoDiff(t *testing.T) {
+	// latest mirrors a cross-VPC peer reference as AWS returns it: GroupID +
+	// owner UserID plus the three derived read-only fields.
+	awsReadBack := func() []*svcapitypes.IPPermission {
+		return []*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				GroupID:                aws.String(testOtherID),
+				UserID:                 aws.String(testOwnerAcctID),
+				VPCID:                  aws.String("vpc-peer-b"),
+				PeeringStatus:          aws.String("active"),
+				VPCPeeringConnectionID: aws.String("pcx-realvalue"),
+			}},
+		}}
+	}
+
+	t.Run("spec omits the read-only fields", func(t *testing.T) {
+		desired := mkResource([]*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				GroupID: aws.String(testOtherID),
+			}},
+		}}, nil)
+		latest := mkResource(awsReadBack(), nil)
+
+		got := desiredLatestDelta(desired, latest)
+		assert.False(t, got.ing, "AWS-derived peer metadata absent from spec must not diff")
+	})
+
+	t.Run("spec carries stale/bogus values for all three", func(t *testing.T) {
+		// Even a spec value that disagrees with the AWS read-back must not
+		// churn: EC2 ignores these on authorize, so they carry no real intent.
+		desired := mkResource([]*svcapitypes.IPPermission{{
+			FromPort: aws.Int64(443), ToPort: aws.Int64(443), IPProtocol: aws.String("tcp"),
+			UserIDGroupPairs: []*svcapitypes.UserIDGroupPair{{
+				GroupID:                aws.String(testOtherID),
+				VPCID:                  aws.String("vpc-STALEbogus"),
+				PeeringStatus:          aws.String("pending-acceptance"),
+				VPCPeeringConnectionID: aws.String("pcx-STALEbogus"),
+			}},
+		}}, nil)
+		latest := mkResource(awsReadBack(), nil)
+
+		got := desiredLatestDelta(desired, latest)
+		assert.False(t, got.ing, "stale spec peer metadata must not diff against AWS-derived values")
+	})
+}
+
 func TestCustomPostCompare_AllProtocolPorts_NoDiff(t *testing.T) {
 	desired := mkResource(nil, []*svcapitypes.IPPermission{{
 		IPProtocol: aws.String("-1"), FromPort: aws.Int64(0), ToPort: aws.Int64(0),

--- a/test/e2e/resources/security_group_aggregation.yaml
+++ b/test/e2e/resources/security_group_aggregation.yaml
@@ -1,0 +1,24 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg grant aggregation
+  vpcID: $VPC_ID
+  ingressRules:
+    # Grant aggregation: two rules sharing (tcp, 8020, 8020) with different
+    # CIDRs. AWS merges them into a single IpPermission with a two-element
+    # ipRanges array.
+    - fromPort: 8020
+      toPort: 8020
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 10.2.0.0/16
+          description: aggregation range A
+    - fromPort: 8020
+      toPort: 8020
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 10.3.0.0/16
+          description: aggregation range B

--- a/test/e2e/resources/security_group_allproto.yaml
+++ b/test/e2e/resources/security_group_allproto.yaml
@@ -1,0 +1,17 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg all-protocol port drop
+  vpcID: $VPC_ID
+  egressRules:
+    # All-protocols ("-1") rule with an explicit port range. AWS ignores the
+    # port range for "-1" and returns the rule with fromPort/toPort unset.
+    - fromPort: 0
+      toPort: 0
+      ipProtocol: "-1"
+      ipRanges:
+        - cidrIP: 0.0.0.0/0
+          description: allow all egress

--- a/test/e2e/resources/security_group_bogus_peer_metadata.yaml
+++ b/test/e2e/resources/security_group_bogus_peer_metadata.yaml
@@ -1,0 +1,23 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg with bogus read-only peer metadata
+  vpcID: $VPC_ID
+  ingressRules:
+    # Self-reference by omitting groupID (the aws-controllers-k8s/community#2822
+    # pattern), but carrying BOGUS read-only peer metadata: vpcID, peeringStatus
+    # and vpcPeeringConnectionID. EC2 accepts these on authorize without error,
+    # silently discards them, and derives the real values from the referenced
+    # group -- so they never match what DescribeSecurityGroups returns. A correct
+    # controller canonicalizes them out of the delta and must not churn the rule.
+    - fromPort: 443
+      toPort: 443
+      ipProtocol: tcp
+      userIDGroupPairs:
+        - description: self-ref with bogus peer metadata
+          vpcID: vpc-00000000000bogus0
+          peeringStatus: made-up-nonsense
+          vpcPeeringConnectionID: pcx-00000000000bogus0

--- a/test/e2e/resources/security_group_cidr_canon.yaml
+++ b/test/e2e/resources/security_group_cidr_canon.yaml
@@ -1,0 +1,27 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg CIDR canonicalization
+  vpcID: $VPC_ID
+  ingressRules:
+    # IPv4 CIDR canonicalization: non-canonical 172.16.5.9/16 is stored and
+    # returned by AWS as 172.16.0.0/16. On its own port to isolate the IPv4
+    # case.
+    - fromPort: 8010
+      toPort: 8010
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 172.16.5.9/16
+          description: non-canonical IPv4 CIDR
+    # IPv6 CIDR canonicalization: non-canonical (uppercase, zero-padded, host
+    # bits set) is masked and text-normalised by AWS to
+    # 2001:db8:abcd:12::/64. On its own port to isolate the IPv6 case.
+    - fromPort: 8011
+      toPort: 8011
+      ipProtocol: tcp
+      ipv6Ranges:
+        - cidrIPv6: 2001:DB8:abcd:0012::1/64
+          description: non-canonical IPv6 CIDR

--- a/test/e2e/resources/security_group_combined_canon.yaml
+++ b/test/e2e/resources/security_group_combined_canon.yaml
@@ -1,0 +1,61 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg combined canonicalizations
+  vpcID: $VPC_ID
+  ingressRules:
+    # Self-reference by omitting groupID (community#2822): AWS fills in the
+    # group's own groupID and the owner userID on read-back.
+    - fromPort: 443
+      toPort: 443
+      ipProtocol: tcp
+      userIDGroupPairs:
+        - description: self-referencing rule
+    # Numeric protocol "6" (== tcp) with a non-canonical IPv4 CIDR: exercises
+    # the protocol-notation and CIDR canonicalization paths in a single rule
+    # ("6" -> "tcp", 172.16.5.9/16 -> 172.16.0.0/16).
+    - fromPort: 8006
+      toPort: 8006
+      ipProtocol: "6"
+      ipRanges:
+        - cidrIP: 172.16.5.9/16
+          description: numeric proto + non-canonical cidr
+    # icmpv6 with no type/code: read back as the -1/-1 "all types and codes"
+    # wildcard.
+    - ipProtocol: icmpv6
+      ipv6Ranges:
+        - cidrIPv6: ::/0
+          description: icmpv6 all types and codes
+    # Grant aggregation: two rules sharing (tcp, 9090, 9090) with different
+    # CIDRs collapse into one IpPermission on read-back.
+    - fromPort: 9090
+      toPort: 9090
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 10.10.0.0/16
+          description: aggregation A
+    - fromPort: 9090
+      toPort: 9090
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 10.20.0.0/16
+          description: aggregation B
+  egressRules:
+    # All-protocol "-1": AWS ignores the port range and returns no ports.
+    - fromPort: 0
+      toPort: 0
+      ipProtocol: "-1"
+      ipRanges:
+        - cidrIP: 0.0.0.0/0
+          description: allow all egress
+    # ESP (protocol 50) with the -1/-1 sentinel: a non-standard protocol, so
+    # AWS returns it without a port range.
+    - fromPort: -1
+      toPort: -1
+      ipProtocol: "50"
+      ipRanges:
+        - cidrIP: 10.0.0.0/8
+          description: allow ESP egress

--- a/test/e2e/resources/security_group_icmpv6_no_typecode.yaml
+++ b/test/e2e/resources/security_group_icmpv6_no_typecode.yaml
@@ -1,0 +1,19 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg icmpv6 wildcard type/code
+  vpcID: $VPC_ID
+  ingressRules:
+    # ICMPv6 with no type/code (fromPort/toPort omitted). Unlike icmp, icmpv6
+    # does not require a type/code, so the EC2 backend treats this as the "all
+    # types and codes" wildcard and returns it as fromPort/toPort = -1 on
+    # read-back. This is a distinct path from the all-protocols "-1" rule:
+    # ICMP/ICMPv6 overload fromPort/toPort as type/code, so the "-1" port-drop
+    # branch does not cover it.
+    - ipProtocol: icmpv6
+      ipv6Ranges:
+        - cidrIPv6: ::/0
+          description: icmpv6 all types and codes

--- a/test/e2e/resources/security_group_multi_grant.yaml
+++ b/test/e2e/resources/security_group_multi_grant.yaml
@@ -7,11 +7,9 @@ spec:
   description: test sg multi-grant deterministic sort
   vpcID: $VPC_ID
   ingressRules:
-    # A single rule carrying several already-canonical CIDRs (IPv4 + IPv6) in
-    # deliberately non-sorted order. sortGrants must order the grants
-    # deterministically; if it did not, the read-back order would drive a
-    # perpetual diff. This exercises the reachable (populated, non-nil) grant
-    # path of sortGrants.
+    # Several already-canonical CIDRs (IPv4 + IPv6) in deliberately non-sorted
+    # order. sortGrants must order them deterministically, else read-back order
+    # would drive a perpetual diff.
     - fromPort: 9090
       toPort: 9090
       ipProtocol: tcp

--- a/test/e2e/resources/security_group_multi_grant.yaml
+++ b/test/e2e/resources/security_group_multi_grant.yaml
@@ -1,0 +1,29 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg multi-grant deterministic sort
+  vpcID: $VPC_ID
+  ingressRules:
+    # A single rule carrying several already-canonical CIDRs (IPv4 + IPv6) in
+    # deliberately non-sorted order. sortGrants must order the grants
+    # deterministically; if it did not, the read-back order would drive a
+    # perpetual diff. This exercises the reachable (populated, non-nil) grant
+    # path of sortGrants.
+    - fromPort: 9090
+      toPort: 9090
+      ipProtocol: tcp
+      ipRanges:
+        - cidrIP: 10.30.0.0/16
+          description: c
+        - cidrIP: 10.10.0.0/16
+          description: a
+        - cidrIP: 10.20.0.0/16
+          description: b
+      ipv6Ranges:
+        - cidrIPv6: 2001:db8:2::/48
+          description: v6-b
+        - cidrIPv6: 2001:db8:1::/48
+          description: v6-a

--- a/test/e2e/resources/security_group_nonstandard_proto.yaml
+++ b/test/e2e/resources/security_group_nonstandard_proto.yaml
@@ -1,0 +1,19 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg non-standard protocol port drop
+  vpcID: $VPC_ID
+  egressRules:
+    # ESP (IP protocol 50) is outside {tcp, udp, icmp, icmpv6}, so AWS ignores
+    # the port range and returns the rule with fromPort/toPort unset. The spec
+    # carries the -1/-1 "not applicable" sentinel to exercise the port-drop
+    # canonicalization for non-standard protocols.
+    - fromPort: -1
+      toPort: -1
+      ipProtocol: "50"
+      ipRanges:
+        - cidrIP: 10.0.0.0/8
+          description: allow ESP egress

--- a/test/e2e/resources/security_group_protocol_notation.yaml
+++ b/test/e2e/resources/security_group_protocol_notation.yaml
@@ -1,0 +1,18 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg numeric protocol notation
+  vpcID: $VPC_ID
+  ingressRules:
+    # Protocol notation: numeric "6" is the same protocol as "tcp". AWS
+    # stores/returns it as "tcp". The CIDR is already canonical so this rule
+    # isolates the protocol normalization.
+    - fromPort: 8006
+      toPort: 8006
+      ipProtocol: "6"
+      ipRanges:
+        - cidrIP: 10.1.0.0/16
+          description: numeric protocol rule

--- a/test/e2e/resources/security_group_self_owner_userid.yaml
+++ b/test/e2e/resources/security_group_self_owner_userid.yaml
@@ -7,11 +7,9 @@ spec:
   description: self-ref via omitted group carrying an explicit owner userID
   vpcID: $VPC_ID
   ingressRules:
-    # An omitted-group self-reference (the #2822 shorthand) that ALSO carries
-    # the redundant owner account in userID. canonicalizeGroupPair classifies
-    # this as self and drops the userID. This must be lossless: AWS produces
-    # the identical self-ref rule (GroupId=self, UserId=owner auto-filled)
-    # whether or not the owner userID is supplied.
+    # An omitted-group self-reference (#2822 shorthand) that also carries the
+    # redundant owner account in userID. Dropping that userID is lossless: AWS
+    # produces the identical self-ref rule either way.
     - fromPort: 443
       toPort: 443
       ipProtocol: tcp

--- a/test/e2e/resources/security_group_self_owner_userid.yaml
+++ b/test/e2e/resources/security_group_self_owner_userid.yaml
@@ -1,0 +1,20 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: self-ref via omitted group carrying an explicit owner userID
+  vpcID: $VPC_ID
+  ingressRules:
+    # An omitted-group self-reference (the #2822 shorthand) that ALSO carries
+    # the redundant owner account in userID. canonicalizeGroupPair classifies
+    # this as self and drops the userID. This must be lossless: AWS produces
+    # the identical self-ref rule (GroupId=self, UserId=owner auto-filled)
+    # whether or not the owner userID is supplied.
+    - fromPort: 443
+      toPort: 443
+      ipProtocol: tcp
+      userIDGroupPairs:
+        - description: self-ref with explicit owner userID
+          userID: "$USER_ID"

--- a/test/e2e/resources/security_group_self_ref.yaml
+++ b/test/e2e/resources/security_group_self_ref.yaml
@@ -7,10 +7,9 @@ spec:
   description: test sg self-ref
   vpcID: $VPC_ID
   ingressRules:
-    # Self-reference expressed by omitting groupID entirely (no groupRef,
-    # no groupID) -- the exact pattern reported in
-    # aws-controllers-k8s/community#2822. AWS auto-fills groupID (the SG's
-    # own ID) and userID on DescribeSecurityGroups read-back.
+    # Self-reference by omitting groupID entirely (no groupRef, no groupID) --
+    # the aws-controllers-k8s/community#2822 pattern. AWS auto-fills groupID
+    # (self) and userID on read-back.
     - fromPort: 443
       toPort: 443
       ipProtocol: tcp

--- a/test/e2e/resources/security_group_self_ref.yaml
+++ b/test/e2e/resources/security_group_self_ref.yaml
@@ -1,0 +1,18 @@
+apiVersion: ec2.services.k8s.aws/v1alpha1
+kind: SecurityGroup
+metadata:
+  name: $SECURITY_GROUP_NAME
+spec:
+  name: $SECURITY_GROUP_NAME
+  description: test sg self-ref
+  vpcID: $VPC_ID
+  ingressRules:
+    # Self-reference expressed by omitting groupID entirely (no groupRef,
+    # no groupID) -- the exact pattern reported in
+    # aws-controllers-k8s/community#2822. AWS auto-fills groupID (the SG's
+    # own ID) and userID on DescribeSecurityGroups read-back.
+    - fromPort: 443
+      toPort: 443
+      ipProtocol: tcp
+      userIDGroupPairs:
+        - description: self-referencing rule

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -666,7 +666,10 @@ class TestSecurityGroup:
         # populates GroupID from GroupRef (so GroupRef is set on desired but
         # nil on the AWS read-back), and it resolves only on the second
         # reconcile once the SG's own ID is known.
-        name = random_suffix_name("sg-selfref-groupref", 24)
+        # NB: the resource name is also used as the EC2 GroupName, and AWS
+        # rejects any GroupName in the "sg-*" format, so it must not start with
+        # "sg-".
+        name = random_suffix_name("selfref-groupref", 24)
         ref = create_security_group_with_sg_ref(name, name)  # references itself
         try:
             time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
@@ -701,7 +704,9 @@ class TestSecurityGroup:
         assert k8s.wait_on_condition(peer_ref, "ACK.ResourceSynced", "True", wait_periods=8)
         peer_id = k8s.get_resource(peer_ref)["status"]["id"]
 
-        name = random_suffix_name("sg-cross-ref", 24)
+        # See note above: the name doubles as the EC2 GroupName, which cannot
+        # be in the "sg-*" format.
+        name = random_suffix_name("cross-ref", 24)
         ref = create_security_group_with_sg_ref(name, peer_ref.name)  # references the peer
         try:
             time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -213,6 +213,44 @@ def security_groups_cyclic_ref():
         pass
 
 
+def _sg_status_rule_ids(ref):
+    """Return the sorted securityGroupRuleIDs currently in the CR's status."""
+    latest = k8s.get_resource(ref)
+    rules = latest.get("status", {}).get("rules", []) or []
+    ids = sorted(r.get("securityGroupRuleID") for r in rules if r.get("securityGroupRuleID"))
+    assert ids, f"no securityGroupRuleIDs populated in status: {rules}"
+    return ids
+
+
+def _assert_no_perpetual_diff(ref):
+    """Force a reconcile with an update unrelated to the rules and assert the
+    security group rule IDs in status do not change.
+
+    A tag edit bumps metadata.generation, so the controller reconciles right
+    away rather than waiting for the (up to 10h) resync period. That reconcile
+    recomputes the ingress/egress rule delta; if any rule diff is spurious the
+    rules are revoked and re-authorized and AWS assigns brand new
+    securityGroupRuleIDs. Stable IDs across this forced reconcile are therefore
+    the definitive signal that the delta logic sees no rule change --
+    ACK.ResourceSynced=True alone is not, since the original #2822 bug churned
+    the rules while still reporting Synced=True.
+    """
+    ids_before = _sg_status_rule_ids(ref)
+
+    # Unrelated update: add a tag. This does not touch any ingress/egress rule.
+    k8s.patch_custom_resource(
+        ref, {"spec": {"tags": [{"key": "force-reconcile", "value": "1"}]}}
+    )
+    time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+    assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
+    ids_after = _sg_status_rule_ids(ref)
+    assert ids_after == ids_before, (
+        f"security group rules churned after an unrelated (tag) update: "
+        f"{ids_before} -> {ids_after}; a perpetual delta re-authorized the rules"
+    )
+
+
 @service_marker
 @pytest.mark.canary
 class TestSecurityGroup:
@@ -587,3 +625,191 @@ class TestSecurityGroup:
         ec2_validator.assert_security_group(resource_id_1, exists=False)
         ec2_validator.assert_security_group(resource_id_2, exists=False)
         ec2_validator.assert_security_group(resource_id_3, exists=False)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_self_ref"})
+    def test_self_ref_rule_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # 1. Create the SecurityGroup (self-reference expressed by omitting
+        #    groupID entirely -- the #2822 pattern).
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+
+        # 2. Wait for the resource to sync.
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        # 3. Verify via the AWS API that the security group looks correct: the
+        #    self-referencing ingress rule exists with GroupId auto-filled to
+        #    the SG's own ID.
+        ec2_validator = EC2Validator(ec2_client)
+        ec2_validator.assert_security_group(resource_id)
+        sg_group = ec2_validator.get_security_group(resource_id)
+        assert len(sg_group["IpPermissions"]) == 1
+        rule = sg_group["IpPermissions"][0]
+        assert rule["IpProtocol"] == "tcp"
+        assert rule["FromPort"] == 443
+        assert rule["ToPort"] == 443
+        assert len(rule["UserIdGroupPairs"]) == 1
+        assert rule["UserIdGroupPairs"][0]["GroupId"] == resource_id
+
+        # 4 + 5. Force a reconcile with an unrelated (tag) update and confirm
+        #        the self-ref rule ID in status does not change.
+        _assert_no_perpetual_diff(ref)
+
+        # Delete k8s resource
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    def test_self_ref_groupref_no_perpetual_diff(self, ec2_client):
+        # Self-reference expressed via groupRef pointing at the SG itself. This
+        # is a distinct code path from the omitted-groupID form: ResolveRefs
+        # populates GroupID from GroupRef (so GroupRef is set on desired but
+        # nil on the AWS read-back), and it resolves only on the second
+        # reconcile once the SG's own ID is known.
+        name = random_suffix_name("sg-selfref-groupref", 24)
+        ref = create_security_group_with_sg_ref(name, name)  # references itself
+        try:
+            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+            cr = k8s.get_resource(ref)
+            resource_id = cr["status"]["id"]
+            ec2_validator = EC2Validator(ec2_client)
+            ec2_validator.assert_security_group(resource_id)
+            sg = ec2_validator.get_security_group(resource_id)
+
+            # Both the ingress and egress tcp/443 self-ref rules resolve to the
+            # SG's own ID (also exercises egress self-reference).
+            for perms in (sg["IpPermissions"], sg["IpPermissionsEgress"]):
+                match = [p for p in perms if p.get("FromPort") == 443]
+                assert len(match) == 1, f"expected one tcp/443 rule, got {perms}"
+                pairs = match[0]["UserIdGroupPairs"]
+                assert len(pairs) == 1
+                assert pairs[0]["GroupId"] == resource_id
+
+            _assert_no_perpetual_diff(ref)
+        finally:
+            k8s.delete_custom_resource(ref)
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+    def test_cross_sg_userid_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # A rule referencing a *different* (peer) SG in the same account. The
+        # user omits userID; AWS auto-fills it with the owning account. The fix
+        # must clear that owner userID (while keeping the peer GroupID), so no
+        # perpetual diff -- distinct from the self-ref branch.
+        (peer_ref, _) = simple_security_group
+        assert k8s.wait_on_condition(peer_ref, "ACK.ResourceSynced", "True", wait_periods=8)
+        peer_id = k8s.get_resource(peer_ref)["status"]["id"]
+
+        name = random_suffix_name("sg-cross-ref", 24)
+        ref = create_security_group_with_sg_ref(name, peer_ref.name)  # references the peer
+        try:
+            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
+            assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+            cr = k8s.get_resource(ref)
+            resource_id = cr["status"]["id"]
+            ec2_validator = EC2Validator(ec2_client)
+            sg = ec2_validator.get_security_group(resource_id)
+
+            ing = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
+            assert len(ing) == 1
+            pairs = ing[0]["UserIdGroupPairs"]
+            assert len(pairs) == 1
+            assert pairs[0]["GroupId"] == peer_id, "cross-SG GroupID must be preserved"
+            # AWS auto-fills the owner account id even though the spec omits it.
+            assert pairs[0]["UserId"] == str(get_account_id())
+
+            _assert_no_perpetual_diff(ref)
+        finally:
+            k8s.delete_custom_resource(ref)
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_allproto"})
+    def test_all_protocol_ports_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: AWS drops the port range for an all-protocols ("-1") rule.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        egress = [e for e in sg["IpPermissionsEgress"] if e["IpProtocol"] == "-1"]
+        assert len(egress) == 1
+        assert "FromPort" not in egress[0]
+        assert "ToPort" not in egress[0]
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_protocol_notation"})
+    def test_protocol_notation_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: numeric protocol "6" is stored/returned by AWS as "tcp".
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        rule = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8006]
+        assert len(rule) == 1, f"expected one tcp/8006 rule, got {sg['IpPermissions']}"
+        assert rule[0]["IpProtocol"] == "tcp"
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_cidr_canon"})
+    def test_cidr_canonicalization_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: AWS canonicalizes CIDRs. IPv4 and IPv6 are on separate
+        # ports so a regression in one cannot mask the other.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+
+        ipv4 = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8010]
+        assert len(ipv4) == 1
+        assert ipv4[0]["IpRanges"][0]["CidrIp"] == "172.16.0.0/16"
+
+        ipv6 = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8011]
+        assert len(ipv6) == 1
+        assert ipv6[0]["Ipv6Ranges"][0]["CidrIpv6"] == "2001:db8:abcd:12::/64"
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_aggregation"})
+    def test_grant_aggregation_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: two spec rules sharing (tcp, 8020, 8020) are returned by
+        # AWS as a single aggregated IpPermission carrying both CIDRs.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        agg = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8020]
+        assert len(agg) == 1, f"expected one aggregated permission, got {sg['IpPermissions']}"
+        cidrs = sorted(r["CidrIp"] for r in agg[0]["IpRanges"])
+        assert cidrs == ["10.2.0.0/16", "10.3.0.0/16"]
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -178,6 +178,33 @@ def create_security_group_with_sg_ref(resource_name, reference_name):
     return ref
 
 
+def create_security_group_self_owner_userid(resource_name):
+    """Create an SG with an omitted-group self-ref pair that also carries the
+    redundant owner account in userID (exercises the field-drop path in
+    canonicalizeGroupPair)."""
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements["VPC_ID"] = get_bootstrap_resources().SharedTestVPC.vpc_id
+    replacements["SECURITY_GROUP_NAME"] = resource_name
+    replacements["USER_ID"] = str(get_account_id())
+
+    resource_data = load_ec2_resource(
+        "security_group_self_owner_userid",
+        additional_replacements=replacements,
+    )
+    logging.debug(resource_data)
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP,
+        CRD_VERSION,
+        RESOURCE_PLURAL,
+        resource_name,
+        namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+
+    return ref
+
+
 @pytest.fixture
 def security_groups_cyclic_ref():
     resource_name_1 = random_suffix_name("security-group-test", 24)
@@ -818,3 +845,185 @@ class TestSecurityGroup:
         assert deleted is True
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_multi_grant"})
+    def test_multiple_grants_sorted_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Comment 2 (sortGrants): a single rule carrying several CIDRs must be
+        # ordered deterministically so the read-back order never drives a
+        # perpetual diff. This validates the reachable (populated) sortGrants
+        # path. A nil grant element -- the case the nil-guard question was
+        # about -- cannot occur: the CRD schema rejects null list entries and
+        # the read-back setter always allocates each element, so it is not
+        # exercisable end-to-end.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        rule = [p for p in sg["IpPermissions"] if p.get("FromPort") == 9090]
+        assert len(rule) == 1, f"expected one tcp/9090 rule, got {sg['IpPermissions']}"
+        v4 = sorted(r["CidrIp"] for r in rule[0].get("IpRanges", []))
+        assert v4 == ["10.10.0.0/16", "10.20.0.0/16", "10.30.0.0/16"]
+        v6 = sorted(r["CidrIpv6"] for r in rule[0].get("Ipv6Ranges", []))
+        assert v6 == ["2001:db8:1::/48", "2001:db8:2::/48"]
+
+        # A forced reconcile must not churn despite the many grants in the rule.
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    def test_dangling_groupref_not_self_authorized(self, ec2_client):
+        # Comment 3 (why the omitted-self check excludes GroupRef): a groupRef
+        # is NOT an omitted self-reference. A groupRef whose target does not
+        # exist must fail reference resolution rather than be silently
+        # canonicalized into a self-reference. If the GroupRef term were
+        # dropped from the omitted-self detection, such a pair would be stamped
+        # to the SG's own id and wrongly self-authorized.
+        name = random_suffix_name("dangling-ref", 24)
+        missing = random_suffix_name("nonexistent-peer", 24)
+        ref = create_security_group_with_sg_ref(name, missing)
+        try:
+            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
+            # The reference cannot resolve, so the SG must NOT become synced ...
+            synced = k8s.wait_on_condition(
+                ref, "ACK.ResourceSynced", "True", wait_periods=3
+            )
+            assert not synced, "an unresolved groupRef must not reach Synced=True"
+            # ... and must not have been created and self-authorized in AWS.
+            resource_id = k8s.get_resource(ref).get("status", {}).get("id")
+            if resource_id:
+                ec2_validator = EC2Validator(ec2_client)
+                sg = ec2_validator.get_security_group(resource_id)
+                for p in (sg or {}).get("IpPermissions", []):
+                    for pair in p.get("UserIdGroupPairs", []):
+                        assert pair.get("GroupId") != resource_id, (
+                            "a dangling groupRef must not be canonicalized "
+                            "into a self-reference"
+                        )
+        finally:
+            k8s.delete_custom_resource(ref)
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+    def test_self_ref_groupref_persisted_in_spec(self, ec2_client):
+        # Comment 4 (clearing GroupRef during compare): nilling GroupRef inside
+        # the delta comparison must not clear the user's groupRef from the
+        # persisted CR spec, nor inject a canonical groupID into it -- neither
+        # on first sync nor after an update-path reconcile.
+        name = random_suffix_name("selfref-persist", 24)
+        ref = create_security_group_with_sg_ref(name, name)  # references itself
+        try:
+            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
+            assert k8s.wait_on_condition(
+                ref, "ACK.ResourceSynced", "True", wait_periods=8
+            )
+
+            def _assert_groupref_retained():
+                pair = k8s.get_resource(ref)["spec"]["ingressRules"][0][
+                    "userIDGroupPairs"
+                ][0]
+                assert (
+                    pair.get("groupRef", {}).get("from", {}).get("name") == name
+                ), f"user groupRef must be preserved in the persisted spec, got: {pair}"
+                assert "groupID" not in pair, (
+                    f"canonical groupID must not leak into the persisted spec, "
+                    f"got: {pair}"
+                )
+
+            _assert_groupref_retained()      # after initial sync
+            _assert_no_perpetual_diff(ref)   # force an update-path reconcile
+            _assert_groupref_retained()      # still intact after the update
+        finally:
+            k8s.delete_custom_resource(ref)
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)
+
+    @pytest.mark.resource_data({"resource_file": "security_group_self_ref"})
+    def test_self_ref_port_change_applied(self, ec2_client, simple_security_group):
+        # Regression guard (NOT comment 5): self-ref canonicalization must not
+        # mask a genuine change made *within* a normalized rule. Change the
+        # port of a self-referencing rule and confirm the edit is applied. This
+        # covers the "edit not swallowed" property; comment 5 (field dropping)
+        # is covered by test_self_ref_owner_userid_no_data_loss below.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        orig = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
+        assert len(orig) == 1
+        assert orig[0]["UserIdGroupPairs"][0]["GroupId"] == resource_id
+
+        # Change only the port; keep the (omitted-groupID) self-reference form.
+        patch = {
+            "spec": {
+                "ingressRules": [
+                    {
+                        "fromPort": 8443,
+                        "toPort": 8443,
+                        "ipProtocol": "tcp",
+                        "userIDGroupPairs": [{"description": "self-referencing rule"}],
+                    }
+                ]
+            }
+        }
+        k8s.patch_custom_resource(ref, patch)
+        time.sleep(CREATE_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        sg = ec2_validator.get_security_group(resource_id)
+        assert not [
+            p for p in sg["IpPermissions"] if p.get("FromPort") == 443
+        ], "old tcp/443 self-ref rule should have been revoked"
+        updated = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8443]
+        assert len(updated) == 1, (
+            f"port change to 8443 was not applied: {sg['IpPermissions']}"
+        )
+        assert updated[0]["UserIdGroupPairs"][0]["GroupId"] == resource_id
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
+    def test_self_ref_owner_userid_no_data_loss(self, ec2_client):
+        # Comment 5 (does clearing UserID/GroupName/GroupRef on a self-ref drop
+        # meaningful data?): an omitted-group self-ref pair that ALSO carries
+        # the redundant owner account in userID is classified as self, and
+        # canonicalizeGroupPair drops that userID. This is lossless -- verified
+        # against the EC2 API: {GroupId=self} and {GroupId=self,UserId=owner}
+        # produce the identical rule (AWS auto-fills the owner account either
+        # way). So the resulting self-ref rule is correct and does not churn.
+        #
+        # (The only case a *foreign* userID is dropped is when GroupId==selfID,
+        # which AWS itself rejects as InvalidGroup.NotFound; a legitimate
+        # cross-account ref uses GroupId=peer and is preserved -- covered by the
+        # unit test TestCustomPreCompare_CrossAccount_NotSuppressed.)
+        name = random_suffix_name("selfref-owner-uid", 24)
+        ref = create_security_group_self_owner_userid(name)
+        try:
+            time.sleep(CREATE_WAIT_AFTER_SECONDS)
+            assert k8s.wait_on_condition(
+                ref, "ACK.ResourceSynced", "True", wait_periods=8
+            )
+            resource_id = k8s.get_resource(ref)["status"]["id"]
+
+            ec2_validator = EC2Validator(ec2_client)
+            sg = ec2_validator.get_security_group(resource_id)
+            rule = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
+            assert len(rule) == 1, f"expected one tcp/443 rule, got {sg['IpPermissions']}"
+            pairs = rule[0]["UserIdGroupPairs"]
+            assert len(pairs) == 1
+            # Correct self-reference; the owner account is present exactly as it
+            # would be for a bare self-ref -- the dropped userID lost nothing.
+            assert pairs[0]["GroupId"] == resource_id
+            assert pairs[0]["UserId"] == str(get_account_id())
+
+            # The dropped owner userID must not drive a perpetual diff.
+            _assert_no_perpetual_diff(ref)
+        finally:
+            k8s.delete_custom_resource(ref)
+            time.sleep(DELETE_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -776,6 +776,52 @@ class TestSecurityGroup:
             k8s.delete_custom_resource(ref)
             time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
+    @pytest.mark.resource_data({"resource_file": "security_group_bogus_peer_metadata"})
+    def test_bogus_peer_metadata_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # vpcID, peeringStatus and vpcPeeringConnectionID on a userIDGroupPair
+        # are read-only values EC2 derives from the referenced group. The spec
+        # here supplies deliberately BOGUS values for all three on a self-ref
+        # rule; EC2 discards them on authorize (verified empirically) and returns
+        # its own derived form, so the spec can never match the read-back. A
+        # correct controller canonicalizes them out of the delta -- the rule must
+        # not churn, and the user's (bogus) spec values must survive unmutated.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+
+        # AWS resolved the omitted-groupID pair to the SG itself and dropped all
+        # three bogus read-only fields (same-VPC self-ref returns none of them).
+        ing = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
+        assert len(ing) == 1, f"expected one tcp/443 rule, got {sg['IpPermissions']}"
+        pairs = ing[0]["UserIdGroupPairs"]
+        assert len(pairs) == 1
+        pair = pairs[0]
+        assert pair["GroupId"] == resource_id, "self-ref must resolve to the SG's own id"
+        assert "VpcId" not in pair, f"AWS must not echo the bogus vpcID: {pair}"
+        assert "PeeringStatus" not in pair, f"AWS must not echo the bogus peeringStatus: {pair}"
+        assert "VpcPeeringConnectionId" not in pair, (
+            f"AWS must not echo the bogus vpcPeeringConnectionID: {pair}"
+        )
+
+        # The decisive assertion: despite the spec values never matching the AWS
+        # read-back, a forced reconcile must not re-authorize the rule.
+        _assert_no_perpetual_diff(ref)
+
+        # Canonicalization runs on copies, so the user's bogus values must remain
+        # in the persisted spec (no silent mutation of user input).
+        spec_pairs = k8s.get_resource(ref)["spec"]["ingressRules"][0]["userIDGroupPairs"]
+        assert spec_pairs[0]["vpcID"] == "vpc-00000000000bogus0"
+        assert spec_pairs[0]["peeringStatus"] == "made-up-nonsense"
+        assert spec_pairs[0]["vpcPeeringConnectionID"] == "pcx-00000000000bogus0"
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
     @pytest.mark.resource_data({"resource_file": "security_group_allproto"})
     def test_all_protocol_ports_no_perpetual_diff(self, ec2_client, simple_security_group):
         # Isolated: AWS drops the port range for an all-protocols ("-1") rule.

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -954,22 +954,58 @@ class TestSecurityGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
 
-    @pytest.mark.resource_data({"resource_file": "security_group_self_ref"})
-    def test_self_ref_port_change_applied(self, ec2_client, simple_security_group):
-        # Self-ref canonicalization must not mask a genuine change within a
-        # normalized rule: change the port of a self-referencing rule and
-        # confirm the edit is applied.
+    @pytest.mark.resource_data({"resource_file": "security_group_combined_canon"})
+    def test_combined_canonicalizations_update_applied(self, ec2_client, simple_security_group):
+        # Broad coverage: a single SecurityGroup that exercises every
+        # canonicalization path at once -- self-reference (omitted groupID),
+        # numeric protocol notation, IPv4 CIDR canonicalization, the icmpv6
+        # -1/-1 wildcard, grant aggregation, all-protocol ("-1") egress, and a
+        # non-standard (ESP/50) egress. It confirms the combined create has no
+        # perpetual diff, then applies an update that touches several canonical
+        # paths simultaneously and verifies the edits land while the untouched
+        # rules do not churn. (Supersedes the narrower self-ref-only port-change
+        # test; the self-ref port change is retained as one of the paths.)
         (ref, cr) = simple_security_group
         resource_id = cr["status"]["id"]
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
 
         ec2_validator = EC2Validator(ec2_client)
         sg = ec2_validator.get_security_group(resource_id)
-        orig = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
-        assert len(orig) == 1
-        assert orig[0]["UserIdGroupPairs"][0]["GroupId"] == resource_id
 
-        # Change only the port; keep the (omitted-groupID) self-reference form.
+        # --- Each canonical form must land as AWS returns it ---
+        # self-ref tcp/443 -> groupID auto-filled to self
+        selfref = [p for p in sg["IpPermissions"] if p.get("FromPort") == 443]
+        assert len(selfref) == 1, f"expected one tcp/443 rule, got {sg['IpPermissions']}"
+        assert selfref[0]["IpProtocol"] == "tcp"
+        assert selfref[0]["UserIdGroupPairs"][0]["GroupId"] == resource_id
+        # numeric "6" -> "tcp"; CIDR 172.16.5.9/16 -> 172.16.0.0/16
+        numeric = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8006]
+        assert len(numeric) == 1
+        assert numeric[0]["IpProtocol"] == "tcp"
+        assert numeric[0]["IpRanges"][0]["CidrIp"] == "172.16.0.0/16"
+        # icmpv6 with no type/code -> -1/-1 wildcard
+        icmpv6 = [p for p in sg["IpPermissions"] if p.get("IpProtocol") in ("icmpv6", "58")]
+        assert len(icmpv6) == 1
+        assert icmpv6[0].get("FromPort") == -1 and icmpv6[0].get("ToPort") == -1
+        # grant aggregation -> one tcp/9090 rule carrying both CIDRs
+        agg = [p for p in sg["IpPermissions"] if p.get("FromPort") == 9090]
+        assert len(agg) == 1, f"expected one aggregated tcp/9090 rule, got {sg['IpPermissions']}"
+        assert sorted(r["CidrIp"] for r in agg[0]["IpRanges"]) == ["10.10.0.0/16", "10.20.0.0/16"]
+        # egress: ESP (50) returned without a port range
+        esp = [e for e in sg["IpPermissionsEgress"] if e["IpProtocol"] == "50"]
+        assert len(esp) == 1
+        assert "FromPort" not in esp[0] and "ToPort" not in esp[0]
+
+        # The full combined spec must not churn on a forced reconcile.
+        _assert_no_perpetual_diff(ref)
+
+        # --- Update touching multiple canonical paths at once ---
+        # * self-ref port 443 -> 8443 (self-ref canon + a genuine change)
+        # * numeric-proto rule CIDR 172.16.5.9/16 -> non-canonical 192.168.5.9/24
+        #   (protocol-notation + CIDR canon; canonicalises to 192.168.5.0/24)
+        # icmpv6 and the two aggregation grants are repeated unchanged; egress is
+        # omitted from the merge patch so it stays put -- together verifying those
+        # paths neither get lost nor churn while other rules change.
         patch = {
             "spec": {
                 "ingressRules": [
@@ -978,7 +1014,31 @@ class TestSecurityGroup:
                         "toPort": 8443,
                         "ipProtocol": "tcp",
                         "userIDGroupPairs": [{"description": "self-referencing rule"}],
-                    }
+                    },
+                    {
+                        "fromPort": 8006,
+                        "toPort": 8006,
+                        "ipProtocol": "6",
+                        "ipRanges": [
+                            {"cidrIP": "192.168.5.9/24", "description": "numeric proto + non-canonical cidr"}
+                        ],
+                    },
+                    {
+                        "ipProtocol": "icmpv6",
+                        "ipv6Ranges": [{"cidrIPv6": "::/0", "description": "icmpv6 all types and codes"}],
+                    },
+                    {
+                        "fromPort": 9090,
+                        "toPort": 9090,
+                        "ipProtocol": "tcp",
+                        "ipRanges": [{"cidrIP": "10.10.0.0/16", "description": "aggregation A"}],
+                    },
+                    {
+                        "fromPort": 9090,
+                        "toPort": 9090,
+                        "ipProtocol": "tcp",
+                        "ipRanges": [{"cidrIP": "10.20.0.0/16", "description": "aggregation B"}],
+                    },
                 ]
             }
         }
@@ -987,14 +1047,41 @@ class TestSecurityGroup:
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
 
         sg = ec2_validator.get_security_group(resource_id)
+        # self-ref moved 443 -> 8443
         assert not [
             p for p in sg["IpPermissions"] if p.get("FromPort") == 443
         ], "old tcp/443 self-ref rule should have been revoked"
         updated = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8443]
-        assert len(updated) == 1, (
-            f"port change to 8443 was not applied: {sg['IpPermissions']}"
-        )
+        assert len(updated) == 1, f"port change to 8443 was not applied: {sg['IpPermissions']}"
         assert updated[0]["UserIdGroupPairs"][0]["GroupId"] == resource_id
+        # numeric-proto rule CIDR changed and canonicalised: 192.168.5.9/24 -> 192.168.5.0/24
+        numeric = [p for p in sg["IpPermissions"] if p.get("FromPort") == 8006]
+        assert len(numeric) == 1
+        assert numeric[0]["IpRanges"][0]["CidrIp"] == "192.168.5.0/24", (
+            f"numeric-proto rule CIDR not updated/canonicalised: {numeric[0]['IpRanges']}"
+        )
+        # untouched paths still present and intact
+        assert [
+            p for p in sg["IpPermissions"] if p.get("IpProtocol") in ("icmpv6", "58")
+        ], "icmpv6 rule should have survived the update"
+        agg = [p for p in sg["IpPermissions"] if p.get("FromPort") == 9090]
+        assert len(agg) == 1 and len(agg[0]["IpRanges"]) == 2, "aggregated tcp/9090 rule should be intact"
+        assert [
+            e for e in sg["IpPermissionsEgress"] if e["IpProtocol"] == "50"
+        ], "ESP egress rule should have survived the update"
+
+        # The post-update combined state must itself be free of perpetual diff.
+        # Use a distinct tag value so the reconcile is genuinely re-triggered
+        # (the pre-update _assert_no_perpetual_diff already set force-reconcile=1).
+        ids_before = _sg_status_rule_ids(ref)
+        k8s.patch_custom_resource(
+            ref, {"spec": {"tags": [{"key": "force-reconcile", "value": "2"}]}}
+        )
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+        assert _sg_status_rule_ids(ref) == ids_before, (
+            "combined security group rules churned after the update settled"
+        )
 
         _, deleted = k8s.delete_custom_resource(ref)
         assert deleted is True

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -889,37 +889,6 @@ class TestSecurityGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
 
-    def test_dangling_groupref_not_self_authorized(self, ec2_client):
-        # A groupRef pointing at a security group that does not exist must fail
-        # reference resolution (the referenced object can't be read), so the SG
-        # never reaches Synced and is never created or self-authorized. The
-        # delta's self-detection is not involved -- an unresolved reference
-        # never reaches it.
-        name = random_suffix_name("dangling-ref", 24)
-        missing = random_suffix_name("nonexistent-peer", 24)
-        ref = create_security_group_with_sg_ref(name, missing)
-        try:
-            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
-            # The reference cannot resolve, so the SG must NOT become synced ...
-            synced = k8s.wait_on_condition(
-                ref, "ACK.ResourceSynced", "True", wait_periods=3
-            )
-            assert not synced, "an unresolved groupRef must not reach Synced=True"
-            # ... and must not have been created and self-authorized in AWS.
-            resource_id = k8s.get_resource(ref).get("status", {}).get("id")
-            if resource_id:
-                ec2_validator = EC2Validator(ec2_client)
-                sg = ec2_validator.get_security_group(resource_id)
-                for p in (sg or {}).get("IpPermissions", []):
-                    for pair in p.get("UserIdGroupPairs", []):
-                        assert pair.get("GroupId") != resource_id, (
-                            "a dangling groupRef must not be canonicalized "
-                            "into a self-reference"
-                        )
-        finally:
-            k8s.delete_custom_resource(ref)
-            time.sleep(DELETE_WAIT_AFTER_SECONDS)
-
     def test_self_ref_groupref_persisted_in_spec(self, ec2_client):
         # The delta canonicalizes copies (clearing GroupRef, stamping groupID);
         # that must never leak into the persisted spec. The user's groupRef must

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -250,17 +250,14 @@ def _sg_status_rule_ids(ref):
 
 
 def _assert_no_perpetual_diff(ref):
-    """Force a reconcile with an update unrelated to the rules and assert the
-    security group rule IDs in status do not change.
+    """Force a reconcile unrelated to the rules and assert the security group
+    rule IDs in status do not change.
 
-    A tag edit bumps metadata.generation, so the controller reconciles right
-    away rather than waiting for the (up to 10h) resync period. That reconcile
-    recomputes the ingress/egress rule delta; if any rule diff is spurious the
-    rules are revoked and re-authorized and AWS assigns brand new
-    securityGroupRuleIDs. Stable IDs across this forced reconcile are therefore
-    the definitive signal that the delta logic sees no rule change --
-    ACK.ResourceSynced=True alone is not, since the original #2822 bug churned
-    the rules while still reporting Synced=True.
+    A tag edit bumps metadata.generation, forcing an immediate reconcile that
+    recomputes the rule delta. A spurious diff revokes and re-authorizes the
+    rules, so AWS assigns new securityGroupRuleIDs. Stable IDs are the definitive
+    signal of no rule churn -- ACK.ResourceSynced=True is not, since the #2822
+    bug churned rules while still reporting Synced=True.
     """
     ids_before = _sg_status_rule_ids(ref)
 
@@ -688,14 +685,11 @@ class TestSecurityGroup:
         ec2_validator.assert_security_group(resource_id, exists=False)
 
     def test_self_ref_groupref_no_perpetual_diff(self, ec2_client):
-        # Self-reference expressed via groupRef pointing at the SG itself. This
-        # is a distinct code path from the omitted-groupID form: ResolveRefs
-        # populates GroupID from GroupRef (so GroupRef is set on desired but
-        # nil on the AWS read-back), and it resolves only on the second
-        # reconcile once the SG's own ID is known.
-        # NB: the resource name is also used as the EC2 GroupName, and AWS
-        # rejects any GroupName in the "sg-*" format, so it must not start with
-        # "sg-".
+        # Self-reference via a groupRef pointing at the SG itself -- a distinct
+        # path from the omitted-groupID form: GroupID resolves from GroupRef only
+        # once the SG's own ID is known (second reconcile).
+        # NB: the name doubles as the EC2 GroupName, which AWS rejects in the
+        # "sg-*" format, so it must not start with "sg-".
         name = random_suffix_name("selfref-groupref", 24)
         ref = create_security_group_with_sg_ref(name, name)  # references itself
         try:
@@ -723,10 +717,9 @@ class TestSecurityGroup:
             time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
     def test_cross_sg_userid_no_perpetual_diff(self, ec2_client, simple_security_group):
-        # A rule referencing a *different* (peer) SG in the same account. The
-        # user omits userID; AWS auto-fills it with the owning account. The fix
-        # must clear that owner userID (while keeping the peer GroupID), so no
-        # perpetual diff -- distinct from the self-ref branch.
+        # A rule referencing a *different* (peer) SG in the same account: the
+        # user omits userID, AWS auto-fills the owner account. Clearing that
+        # owner userID while keeping the peer GroupID avoids a perpetual diff.
         (peer_ref, _) = simple_security_group
         assert k8s.wait_on_condition(peer_ref, "ACK.ResourceSynced", "True", wait_periods=8)
         peer_id = k8s.get_resource(peer_ref)["status"]["id"]
@@ -848,13 +841,11 @@ class TestSecurityGroup:
 
     @pytest.mark.resource_data({"resource_file": "security_group_multi_grant"})
     def test_multiple_grants_sorted_no_perpetual_diff(self, ec2_client, simple_security_group):
-        # Comment 2 (sortGrants): a single rule carrying several CIDRs must be
-        # ordered deterministically so the read-back order never drives a
-        # perpetual diff. This validates the reachable (populated) sortGrants
-        # path. A nil grant element -- the case the nil-guard question was
-        # about -- cannot occur: the CRD schema rejects null list entries and
-        # the read-back setter always allocates each element, so it is not
-        # exercisable end-to-end.
+        # A single rule carrying several CIDRs must be ordered deterministically
+        # so read-back order never drives a perpetual diff. (A nil grant element
+        # can't occur end-to-end -- the schema rejects null entries and the
+        # read-back setter always allocates -- so only the populated sort path
+        # is reachable here.)
         (ref, cr) = simple_security_group
         resource_id = cr["status"]["id"]
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
@@ -877,12 +868,11 @@ class TestSecurityGroup:
         ec2_validator.assert_security_group(resource_id, exists=False)
 
     def test_dangling_groupref_not_self_authorized(self, ec2_client):
-        # Comment 3 (why the omitted-self check excludes GroupRef): a groupRef
-        # is NOT an omitted self-reference. A groupRef whose target does not
-        # exist must fail reference resolution rather than be silently
-        # canonicalized into a self-reference. If the GroupRef term were
-        # dropped from the omitted-self detection, such a pair would be stamped
-        # to the SG's own id and wrongly self-authorized.
+        # A groupRef pointing at a security group that does not exist must fail
+        # reference resolution (the referenced object can't be read), so the SG
+        # never reaches Synced and is never created or self-authorized. The
+        # delta's self-detection is not involved -- an unresolved reference
+        # never reaches it.
         name = random_suffix_name("dangling-ref", 24)
         missing = random_suffix_name("nonexistent-peer", 24)
         ref = create_security_group_with_sg_ref(name, missing)
@@ -909,10 +899,10 @@ class TestSecurityGroup:
             time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
     def test_self_ref_groupref_persisted_in_spec(self, ec2_client):
-        # Comment 4 (clearing GroupRef during compare): nilling GroupRef inside
-        # the delta comparison must not clear the user's groupRef from the
-        # persisted CR spec, nor inject a canonical groupID into it -- neither
-        # on first sync nor after an update-path reconcile.
+        # The delta canonicalizes copies (clearing GroupRef, stamping groupID);
+        # that must never leak into the persisted spec. The user's groupRef must
+        # survive and no canonical groupID may be injected -- on first sync and
+        # after an update-path reconcile.
         name = random_suffix_name("selfref-persist", 24)
         ref = create_security_group_with_sg_ref(name, name)  # references itself
         try:
@@ -942,11 +932,9 @@ class TestSecurityGroup:
 
     @pytest.mark.resource_data({"resource_file": "security_group_self_ref"})
     def test_self_ref_port_change_applied(self, ec2_client, simple_security_group):
-        # Regression guard (NOT comment 5): self-ref canonicalization must not
-        # mask a genuine change made *within* a normalized rule. Change the
-        # port of a self-referencing rule and confirm the edit is applied. This
-        # covers the "edit not swallowed" property; comment 5 (field dropping)
-        # is covered by test_self_ref_owner_userid_no_data_loss below.
+        # Self-ref canonicalization must not mask a genuine change within a
+        # normalized rule: change the port of a self-referencing rule and
+        # confirm the edit is applied.
         (ref, cr) = simple_security_group
         resource_id = cr["status"]["id"]
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
@@ -990,18 +978,14 @@ class TestSecurityGroup:
         ec2_validator.assert_security_group(resource_id, exists=False)
 
     def test_self_ref_owner_userid_no_data_loss(self, ec2_client):
-        # Comment 5 (does clearing UserID/GroupName/GroupRef on a self-ref drop
-        # meaningful data?): an omitted-group self-ref pair that ALSO carries
-        # the redundant owner account in userID is classified as self, and
-        # canonicalizeGroupPair drops that userID. This is lossless -- verified
-        # against the EC2 API: {GroupId=self} and {GroupId=self,UserId=owner}
-        # produce the identical rule (AWS auto-fills the owner account either
-        # way). So the resulting self-ref rule is correct and does not churn.
-        #
-        # (The only case a *foreign* userID is dropped is when GroupId==selfID,
-        # which AWS itself rejects as InvalidGroup.NotFound; a legitimate
-        # cross-account ref uses GroupId=peer and is preserved -- covered by the
-        # unit test TestCustomPreCompare_CrossAccount_NotSuppressed.)
+        # An omitted-group self-ref that also carries the redundant owner
+        # account in userID is classified as self, and canonicalizeGroupPair
+        # drops that userID. This is lossless: {GroupId=self} and
+        # {GroupId=self,UserId=owner} produce the identical rule (AWS auto-fills
+        # the owner). A foreign userID is only dropped when paired with the SG's
+        # own GroupID -- an input AWS rejects; a cross-account ref uses
+        # GroupId=peer and is preserved (unit test
+        # TestCustomPostCompare_CrossAccount_NotSuppressed).
         name = random_suffix_name("selfref-owner-uid", 24)
         ref = create_security_group_self_owner_userid(name)
         try:

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -797,6 +797,38 @@ class TestSecurityGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
 
+    @pytest.mark.resource_data({"resource_file": "security_group_icmpv6_no_typecode"})
+    def test_icmpv6_no_typecode_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: icmpv6 does not require a type/code (it is excluded from the
+        # backend's must-receive-type/code set), so the spec may omit
+        # fromPort/toPort. The EC2 backend treats protocol 58 with no type/code
+        # as the "all types and codes" wildcard and returns it as
+        # FromPort=-1/ToPort=-1 on read-back -- a path distinct from the "-1"
+        # all-protocols port drop, since ICMP/ICMPv6 overload the ports as
+        # type/code.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        # AWS may report protocol 58 as the name "icmpv6" or the number "58".
+        icmpv6 = [p for p in sg["IpPermissions"] if p.get("IpProtocol") in ("icmpv6", "58")]
+        assert len(icmpv6) == 1, f"expected one icmpv6 rule, got {sg['IpPermissions']}"
+        # Document the backend contract this fix depends on: the omitted
+        # type/code reads back as the -1/-1 wildcard. Canonicalisation must
+        # collapse it to the omitted spec form, or the rule churns every
+        # reconcile.
+        assert icmpv6[0].get("FromPort") == -1
+        assert icmpv6[0].get("ToPort") == -1
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
     @pytest.mark.resource_data({"resource_file": "security_group_protocol_notation"})
     def test_protocol_notation_no_perpetual_diff(self, ec2_client, simple_security_group):
         # Isolated: numeric protocol "6" is stored/returned by AWS as "tcp".

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -814,7 +814,7 @@ class TestSecurityGroup:
         # Protocol 50 has no well-known name, so AWS returns it as the number.
         esp = [e for e in sg["IpPermissionsEgress"] if e.get("IpProtocol") == "50"]
         assert len(esp) == 1, f"expected one ESP egress rule, got {sg['IpPermissionsEgress']}"
-        # The backend contract this fix depends on: ports are omitted for
+        # The AWS behavior this fix depends on: ports are omitted for
         # protocols outside {tcp, udp, icmp, icmpv6}.
         assert "FromPort" not in esp[0]
         assert "ToPort" not in esp[0]
@@ -828,13 +828,11 @@ class TestSecurityGroup:
 
     @pytest.mark.resource_data({"resource_file": "security_group_icmpv6_no_typecode"})
     def test_icmpv6_no_typecode_no_perpetual_diff(self, ec2_client, simple_security_group):
-        # Isolated: icmpv6 does not require a type/code (it is excluded from the
-        # backend's must-receive-type/code set), so the spec may omit
-        # fromPort/toPort. The EC2 backend treats protocol 58 with no type/code
-        # as the "all types and codes" wildcard and returns it as
-        # FromPort=-1/ToPort=-1 on read-back -- a path distinct from the "-1"
-        # all-protocols port drop, since ICMP/ICMPv6 overload the ports as
-        # type/code.
+        # Isolated: icmpv6 does not require a type/code, so the spec may omit
+        # fromPort/toPort. AWS treats protocol 58 with no type/code as the "all
+        # types and codes" wildcard and returns it as FromPort=-1/ToPort=-1 on
+        # read-back -- a path distinct from the "-1" all-protocols port drop,
+        # since ICMP/ICMPv6 overload the ports as type/code.
         (ref, cr) = simple_security_group
         resource_id = cr["status"]["id"]
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
@@ -844,10 +842,9 @@ class TestSecurityGroup:
         # AWS may report protocol 58 as the name "icmpv6" or the number "58".
         icmpv6 = [p for p in sg["IpPermissions"] if p.get("IpProtocol") in ("icmpv6", "58")]
         assert len(icmpv6) == 1, f"expected one icmpv6 rule, got {sg['IpPermissions']}"
-        # Document the backend contract this fix depends on: the omitted
-        # type/code reads back as the -1/-1 wildcard. Canonicalisation must
-        # collapse it to the omitted spec form, or the rule churns every
-        # reconcile.
+        # Document the AWS behavior this fix depends on: the omitted type/code
+        # reads back as the -1/-1 wildcard. Canonicalisation must collapse it to
+        # the omitted spec form, or the rule churns every reconcile.
         assert icmpv6[0].get("FromPort") == -1
         assert icmpv6[0].get("ToPort") == -1
 

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -728,8 +728,12 @@ class TestSecurityGroup:
                 assert len(pairs) == 1
                 assert pairs[0]["GroupId"] == resource_id
 
+            # The delta canonicalizes copies (clearing GroupRef, stamping
+            # groupID); that must never leak into the persisted spec. Verify the
+            # user's groupRef survives -- both after the initial sync and after a
+            # forced update-path reconcile -- with no canonical groupID injected.
+            _assert_groupref_retained(ref, name)
             _assert_no_perpetual_diff(ref)
-            # The self groupRef must survive the forced reconcile intact.
             _assert_groupref_retained(ref, name)
         finally:
             k8s.delete_custom_resource(ref)
@@ -888,26 +892,6 @@ class TestSecurityGroup:
         assert deleted is True
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
-
-    def test_self_ref_groupref_persisted_in_spec(self, ec2_client):
-        # The delta canonicalizes copies (clearing GroupRef, stamping groupID);
-        # that must never leak into the persisted spec. The user's groupRef must
-        # survive and no canonical groupID may be injected -- on first sync and
-        # after an update-path reconcile.
-        name = random_suffix_name("selfref-persist", 24)
-        ref = create_security_group_with_sg_ref(name, name)  # references itself
-        try:
-            time.sleep(CREATE_CYCLIC_REF_AFTER_SECONDS)
-            assert k8s.wait_on_condition(
-                ref, "ACK.ResourceSynced", "True", wait_periods=8
-            )
-
-            _assert_groupref_retained(ref, name)   # after initial sync
-            _assert_no_perpetual_diff(ref)         # force an update-path reconcile
-            _assert_groupref_retained(ref, name)   # still intact after the update
-        finally:
-            k8s.delete_custom_resource(ref)
-            time.sleep(DELETE_WAIT_AFTER_SECONDS)
 
     @pytest.mark.resource_data({"resource_file": "security_group_self_ref"})
     def test_self_ref_port_change_applied(self, ec2_client, simple_security_group):

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -797,6 +797,35 @@ class TestSecurityGroup:
         time.sleep(DELETE_WAIT_AFTER_SECONDS)
         ec2_validator.assert_security_group(resource_id, exists=False)
 
+    @pytest.mark.resource_data({"resource_file": "security_group_nonstandard_proto"})
+    def test_nonstandard_protocol_ports_no_perpetual_diff(self, ec2_client, simple_security_group):
+        # Isolated: a protocol outside {tcp, udp, icmp, icmpv6} -- here ESP (IP
+        # protocol 50) -- has its port range dropped by AWS on read-back, even
+        # though the spec carries the -1/-1 sentinel. This is distinct from the
+        # "-1" all-protocols drop: it covers every other IP protocol number.
+        # Canonicalization must drop the spec ports to match, or the rule churns
+        # every reconcile.
+        (ref, cr) = simple_security_group
+        resource_id = cr["status"]["id"]
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
+
+        ec2_validator = EC2Validator(ec2_client)
+        sg = ec2_validator.get_security_group(resource_id)
+        # Protocol 50 has no well-known name, so AWS returns it as the number.
+        esp = [e for e in sg["IpPermissionsEgress"] if e.get("IpProtocol") == "50"]
+        assert len(esp) == 1, f"expected one ESP egress rule, got {sg['IpPermissionsEgress']}"
+        # The backend contract this fix depends on: ports are omitted for
+        # protocols outside {tcp, udp, icmp, icmpv6}.
+        assert "FromPort" not in esp[0]
+        assert "ToPort" not in esp[0]
+
+        _assert_no_perpetual_diff(ref)
+
+        _, deleted = k8s.delete_custom_resource(ref)
+        assert deleted is True
+        time.sleep(DELETE_WAIT_AFTER_SECONDS)
+        ec2_validator.assert_security_group(resource_id, exists=False)
+
     @pytest.mark.resource_data({"resource_file": "security_group_icmpv6_no_typecode"})
     def test_icmpv6_no_typecode_no_perpetual_diff(self, ec2_client, simple_security_group):
         # Isolated: icmpv6 does not require a type/code (it is excluded from the

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -275,6 +275,23 @@ def _assert_no_perpetual_diff(ref):
     )
 
 
+def _assert_groupref_retained(ref, expected_ref_name):
+    """Assert the user's groupRef survives in the persisted spec (ingress and
+    egress) and that no canonical groupID leaked into it."""
+    spec = k8s.get_resource(ref)["spec"]
+    for rules_field in ("ingressRules", "egressRules"):
+        for rule in spec.get(rules_field, []):
+            for pair in rule.get("userIDGroupPairs", []):
+                assert (
+                    pair.get("groupRef", {}).get("from", {}).get("name")
+                    == expected_ref_name
+                ), f"{rules_field}: user groupRef must survive in the spec, got: {pair}"
+                assert "groupID" not in pair, (
+                    f"{rules_field}: canonical groupID must not leak into the "
+                    f"spec, got: {pair}"
+                )
+
+
 @service_marker
 @pytest.mark.canary
 class TestSecurityGroup:
@@ -712,6 +729,8 @@ class TestSecurityGroup:
                 assert pairs[0]["GroupId"] == resource_id
 
             _assert_no_perpetual_diff(ref)
+            # The self groupRef must survive the forced reconcile intact.
+            _assert_groupref_retained(ref, name)
         finally:
             k8s.delete_custom_resource(ref)
             time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -746,6 +765,9 @@ class TestSecurityGroup:
             assert pairs[0]["UserId"] == str(get_account_id())
 
             _assert_no_perpetual_diff(ref)
+            # The peer groupRef must survive the forced reconcile intact (not
+            # rewritten to a concrete groupID).
+            _assert_groupref_retained(ref, peer_ref.name)
         finally:
             k8s.delete_custom_resource(ref)
             time.sleep(DELETE_WAIT_AFTER_SECONDS)
@@ -911,21 +933,9 @@ class TestSecurityGroup:
                 ref, "ACK.ResourceSynced", "True", wait_periods=8
             )
 
-            def _assert_groupref_retained():
-                pair = k8s.get_resource(ref)["spec"]["ingressRules"][0][
-                    "userIDGroupPairs"
-                ][0]
-                assert (
-                    pair.get("groupRef", {}).get("from", {}).get("name") == name
-                ), f"user groupRef must be preserved in the persisted spec, got: {pair}"
-                assert "groupID" not in pair, (
-                    f"canonical groupID must not leak into the persisted spec, "
-                    f"got: {pair}"
-                )
-
-            _assert_groupref_retained()      # after initial sync
-            _assert_no_perpetual_diff(ref)   # force an update-path reconcile
-            _assert_groupref_retained()      # still intact after the update
+            _assert_groupref_retained(ref, name)   # after initial sync
+            _assert_no_perpetual_diff(ref)         # force an update-path reconcile
+            _assert_groupref_retained(ref, name)   # still intact after the update
         finally:
             k8s.delete_custom_resource(ref)
             time.sleep(DELETE_WAIT_AFTER_SECONDS)

--- a/test/e2e/tests/test_security_group.py
+++ b/test/e2e/tests/test_security_group.py
@@ -963,8 +963,15 @@ class TestSecurityGroup:
         # non-standard (ESP/50) egress. It confirms the combined create has no
         # perpetual diff, then applies an update that touches several canonical
         # paths simultaneously and verifies the edits land while the untouched
-        # rules do not churn. (Supersedes the narrower self-ref-only port-change
-        # test; the self-ref port change is retained as one of the paths.)
+        # rules survive intact. (Supersedes the narrower self-ref-only
+        # port-change test; the self-ref port change is retained as one of the
+        # paths.)
+        #
+        # NOTE: sync operates on the raw spec rules, so a non-canonically-spelled
+        # untouched rule may be revoked and re-authorized (its ruleID churns)
+        # during an update; it still ends up present and correct. The invariant
+        # asserted here is "not lost", not "same ruleID". Steady-state no-churn
+        # (no update pending) is covered by _assert_no_perpetual_diff.
         (ref, cr) = simple_security_group
         resource_id = cr["status"]["id"]
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=8)
@@ -1005,7 +1012,7 @@ class TestSecurityGroup:
         #   (protocol-notation + CIDR canon; canonicalises to 192.168.5.0/24)
         # icmpv6 and the two aggregation grants are repeated unchanged; egress is
         # omitted from the merge patch so it stays put -- together verifying those
-        # paths neither get lost nor churn while other rules change.
+        # paths are not lost while other rules change.
         patch = {
             "spec": {
                 "ingressRules": [


### PR DESCRIPTION
## Issue

Fixes
- https://github.com/aws-controllers-k8s/community/issues/2822
- https://github.com/aws-controllers-k8s/community/issues/2951

## Description

`SecurityGroup` rules whose spec form differs from the form AWS returns on
`DescribeSecurityGroups` are revoked and re-authorized on **every** reconcile.
Besides the constant churn, a controller crash between the revoke and the
re-authorize leaves the rule missing, degrading any workload that depends on it
(the reporter hit this with CoreDNS node-to-node traffic).

The root cause is that the generated `newResourceDelta` compares
`Spec.IngressRules`/`Spec.EgressRules` with `DeepEqual`, while AWS normalizes
rules server-side on read-back, so the desired and observed forms never compare
equal.

## Fix

Mark `IngressRules`/`EgressRules` with `compare.is_ignored` so the generated
delta skips them, and add a `delta_post_compare` hook (`customPostCompare`) that
compares **canonical copies** of both rule lists and records a delta only for a
genuine difference.

Crucially, the hook works on deep copies and **never mutates** the desired or
latest objects. Those same objects are the merge-patch base the runtime uses to
persist the spec, so the user's `groupRef` (and every other spec field) is left
untouched — the canonical form exists only for the comparison. The
canonicalization is confined to the delta: `syncSGRules` continues to
authorize/revoke the **raw** spec rules exactly as it did before this change, so
a canonicalization defect can only mis-scope which rules a genuine update
touches — it can never change the rule content submitted to AWS.

Canonicalization closes every read-back normalization that drives a spurious
diff:

1. **Reference wrappers & self-references** — `groupRef`/`vpcRef` are spec-only
   wrappers that ACK resolves to concrete ids before the delta and that AWS
   never returns; they are cleared in the copy. A pair is a self-reference when
   `groupID` equals the SG's own id, or when the group identifiers are all
   omitted (the spec shorthand); it is canonicalized by stripping the self
   `groupID` and the server-filled owner `userID` (`groupName` is left
   untouched — see the tradeoff below).
2. **All-protocol (`-1`) rules** — AWS drops the port range for `-1`; we drop
   `fromPort`/`toPort` to match.
3. **Server-filled owner account** — AWS fills `userID` with the owning account
   for same-account grants; we clear it. Cross-account grants (`userID` != owner)
   are preserved so the reference stays intact.
4. **Grant aggregation** — AWS merges grants sharing `(protocol, fromPort,
   toPort)` into one `IpPermission`; we aggregate both sides by that key and sort
   deterministically so ordering never drives a diff.
5. **Protocol notation** — AWS returns well-known protocols by name, so a numeric
   spec value (`"6"`) is mapped to the name AWS returns (`"tcp"`).
6. **CIDR canonicalization** — AWS masks host bits and normalizes IPv6 text
   (`100.68.0.18/18` -> `100.68.0.0/18`); we rewrite CIDRs to the same network
   form.
7. **Read-only peer metadata** — `vpcID`, `peeringStatus` and
   `vpcPeeringConnectionID` are reference metadata EC2 derives from the
   referenced group (populated only for a cross-VPC peer reference) and ignores
   on authorize; the customer cannot set them meaningfully (verified live — a
   bogus spec value is discarded and the derived value returned). We clear them
   in the copy so an AWS-filled cross-VPC read-back never churns against an
   omitted or stale spec value.

The delta assumes `groupID` is resolved by the time it runs; the existing
`referencesResolved` guard already defers rule sync until a `groupRef` resolves,
so the delta never needs to reason about unresolved references.

The fix lives in the manually-maintained `hooks.go`, wired via
`delta_post_compare` and `compare.is_ignored` in `generator.yaml`, so it survives
code-generator regenerations. It builds on the delta-hook idea first proposed in
#325 (thanks @kbujanecki-dt), reworked to compare copies in `delta_post_compare`
so nothing is mutated: genuine rule changes still produce a delta and are
applied, while no meaningful spec data is lost.

### Scope

Only same-account references are normalized for `userID`; cross-account grants
are intentionally left untouched (and preserved).

`groupName` is deliberately **not** canonicalized. AWS never returns a
`groupName` on rule read-back — it resolves any supplied name to a `groupID` and
returns only the id — and a by-name reference is only valid for a group in the
account's default VPC (verified against the EC2 backend and live). Because the
observed state never carries a name, a rule that references a group purely by
`groupName` cannot be reconciled by the delta and will re-diff every reconcile.
Fully supporting it would require a per-read `DescribeSecurityGroups` call to
backfill names into the observed rules (and matching changes to the sync path);
given that by-name references only work in a rare, discouraged default-VPC setup
and `groupID`/`groupRef` is the supported path, that cost is not justified. The
residual churn for the bare-`groupName` case is an accepted tradeoff, and leaving
`groupName` untouched also means a genuine by-name change still surfaces as a
diff rather than being swallowed.

The canonicalization is deliberately confined to delta detection. The sync path
(`syncSGRules`) is left exactly as it was — it matches and authorizes/revokes the
raw spec rules — so this change carries no risk to the code that actually mutates
a user's security group. Improving the sync path itself (see the tradeoff below)
is intentionally out of scope.

### Known tradeoff

Because the sync path operates on the raw spec rules, a genuine update
re-authorizes any rule whose desired spec form differs textually from the form
AWS returns on read-back — an unmasked CIDR (`100.68.0.18/18`), a numeric
protocol (`"6"`), a self-reference by omitted `groupID`, an `icmpv6` rule without
a type/code, or grants written as separate entries that AWS aggregates. Such a
rule is revoked and re-authorized (one revoke + one authorize) even when only a
sibling rule actually changed. This is a one-time action on the edit — not
perpetual churn — and the end state is correct, but it briefly revokes those
rules.

This is a pre-existing property of the sync path and is unchanged by this PR,
which strictly improves delta detection. Moving the sync path to canonical-key or
per-grant matching would narrow the window, but it is intentionally deferred so
the fix stays confined to the delta and the sync path's existing behavior
(delete-before-create, no rollback) is left untouched.

## Testing

**Unit tests** (`pkg/resource/security_group/hooks_test.go`): cover each
canonicalization (`canonicalizeGroupPair`, `canonicalizeRuleList`) and, through
the real `newResourceDelta`, assert every normalization produces **no** diff
while genuine changes (port, protocol, CIDR network, description) still diff.
Additional coverage: the canonicalization runs on copies and never mutates the
source resource; nil-safety of the grant sort; and the inconsistent-input cases
(a foreign `userID` is dropped only when paired with the SG's own `groupID` — an
input AWS itself rejects — while a legitimate cross-account `groupID = peer`
reference is preserved).

**E2E tests** (`test/e2e/tests/test_security_group.py`): each normalization is
exercised in isolation so a regression pinpoints rather than hides behind
another's churn:

- self-reference via omitted `groupID`
- self-reference via `groupRef` (ingress + egress) — also asserts the user's
  `groupRef` survives in the persisted spec after the initial sync and after a
  forced reconcile, with no canonical `groupID` injected
- cross-SG reference to a peer SG — the rule resolves to the **peer** id (not
  self), the server-filled owner `userID` is cleared, and the `groupRef` survives
- all-protocol `-1` port drop
- numeric protocol notation
- IPv4 and IPv6 CIDR canonicalization
- grant aggregation
- multi-grant rule with deterministic sort
- a genuine port change on a self-referencing rule is still applied
- self-reference with a redundant owner `userID` (lossless drop)

Each test creates the SG, verifies the AWS state via the API, then forces a
reconcile with an unrelated (tag) update and asserts the `securityGroupRuleID`s
in `status` do not change — a stable rule id across a forced reconcile is the
definitive signal that no spurious delta re-authorized the rule.

Validated end-to-end against a live EKS cluster: a self-reference (both the
omitted-`groupID` and the `groupRef` form) resolves to `groupID = self`; a
cross-SG `groupRef` referencing a peer resolves to the peer id (not self); the
user's `groupRef` survives in the persisted spec across forced reconciles; and
across multiple forced reconciles the `securityGroupRuleID`s stay stable with
zero `AuthorizeSecurityGroup`/`RevokeSecurityGroup` calls and zero
ingress/egress deltas.

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.

