### PR TITLE
fix(managed_prefix_list): stop perpetual diff on entry order

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,9 +1,9 @@
 ack_generate_info:
-  build_date: "2026-08-26T02:49:09Z"
-  build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
+  build_date: "2026-08-26T18:34:44Z"
+  build_hash: d4aaca5e1dd6acfd81094936dc825ad30d2bbb39
   go_version: go1.26.0
-  version: v0.62.1
-api_directory_checksum: 55717efb3996c41b42b7978b2f20551c7ad5cdcc
+  version: v0.62.1-4-gd4aaca5
+api_directory_checksum: a80968686fdeff40b93f27e9672dfad4d0cfa109
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-26T18:34:44Z"
+  build_date: "2026-08-26T19:34:36Z"
   build_hash: d4aaca5e1dd6acfd81094936dc825ad30d2bbb39
   go_version: go1.26.0
   version: v0.62.1-4-gd4aaca5
-api_directory_checksum: a80968686fdeff40b93f27e9672dfad4d0cfa109
+api_directory_checksum: 5fea3349fbeeddd7871cf889f2b3d9d610e4de05
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 350f6c11c38b51c3dea9d0d2e85ef15a29c5b9c5
+  file_checksum: a4c43eb7c1c882ddcc82c5b19894b97991e73b99
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,5 +1,5 @@
 ack_generate_info:
-  build_date: "2026-08-13T22:19:55Z"
+  build_date: "2026-08-26T02:49:09Z"
   build_hash: 65d45b2e6c9efd6aca20e0d36826d1e18e4ba2b7
   go_version: go1.26.0
   version: v0.62.1
@@ -7,7 +7,7 @@ api_directory_checksum: 55717efb3996c41b42b7978b2f20551c7ad5cdcc
 api_version: v1alpha1
 aws_sdk_go_version: v1.41.2
 generator_config_info:
-  file_checksum: 0c5abac411df329d8e52a2bcfe969f7271f0424e
+  file_checksum: 350f6c11c38b51c3dea9d0d2e85ef15a29c5b9c5
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -794,8 +794,11 @@ resources:
       Entries:
         custom_field:
           list_of: AddPrefixListEntry
+        # Compared as a CIDR-keyed set in the delta_post_compare hook
+        # (customPostCompare), since AWS returns entries in its own order; the
+        # generated order-sensitive comparison is skipped.
         compare:
-          is_ignored: false
+          is_ignored: true
       Tags:
         from:
           operation: CreateTags
@@ -813,6 +816,8 @@ resources:
         - delete-complete
         - delete-failed
     hooks:
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/managed_prefix_list/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_build_request:

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -780,6 +780,11 @@ resources:
         is_read_only: true
         print:
           name: ID
+      AddressFamily:
+        # AddressFamily is not supported in ModifyManagedPrefixList's input, so
+        # a change to it can never be reconciled. Reject it at admission rather
+        # than letting it sit as drift no update can clear.
+        is_immutable: true
       Name: {}
       State:
         is_read_only: true

--- a/apis/v1alpha1/managed_prefix_list.go
+++ b/apis/v1alpha1/managed_prefix_list.go
@@ -28,6 +28,7 @@ type ManagedPrefixListSpec struct {
 	// The IP address type.
 	//
 	// Valid Values: IPv4 | IPv6
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="Value is immutable once set"
 	// +kubebuilder:validation:Required
 	AddressFamily *string               `json:"addressFamily"`
 	Entries       []*AddPrefixListEntry `json:"entries,omitempty"`

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -17,14 +17,12 @@ package v1alpha1
 
 import (
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
-	"github.com/aws/aws-sdk-go/aws"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // Hack to avoid import errors during build...
 var (
 	_ = &metav1.Time{}
-	_ = &aws.JSONValue{}
 	_ = ackv1alpha1.AWSAccountID("")
 )
 

--- a/config/crd/bases/ec2.services.k8s.aws_managedprefixlists.yaml
+++ b/config/crd/bases/ec2.services.k8s.aws_managedprefixlists.yaml
@@ -58,6 +58,9 @@ spec:
 
                   Valid Values: IPv4 | IPv6
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               entries:
                 items:
                   description: An entry for a prefix list.

--- a/generator.yaml
+++ b/generator.yaml
@@ -794,8 +794,11 @@ resources:
       Entries:
         custom_field:
           list_of: AddPrefixListEntry
+        # Compared as a CIDR-keyed set in the delta_post_compare hook
+        # (customPostCompare), since AWS returns entries in its own order; the
+        # generated order-sensitive comparison is skipped.
         compare:
-          is_ignored: false
+          is_ignored: true
       Tags:
         from:
           operation: CreateTags
@@ -813,6 +816,8 @@ resources:
         - delete-complete
         - delete-failed
     hooks:
+      delta_post_compare:
+        code: customPostCompare(delta, a, b)
       sdk_create_post_build_request:
         template_path: hooks/managed_prefix_list/sdk_create_post_build_request.go.tpl
       sdk_read_many_post_build_request:

--- a/generator.yaml
+++ b/generator.yaml
@@ -780,6 +780,11 @@ resources:
         is_read_only: true
         print:
           name: ID
+      AddressFamily:
+        # AddressFamily is not supported in ModifyManagedPrefixList's input, so
+        # a change to it can never be reconciled. Reject it at admission rather
+        # than letting it sit as drift no update can clear.
+        is_immutable: true
       Name: {}
       State:
         is_read_only: true

--- a/helm/crds/ec2.services.k8s.aws_managedprefixlists.yaml
+++ b/helm/crds/ec2.services.k8s.aws_managedprefixlists.yaml
@@ -58,6 +58,9 @@ spec:
 
                   Valid Values: IPv4 | IPv6
                 type: string
+                x-kubernetes-validations:
+                - message: Value is immutable once set
+                  rule: self == oldSelf
               entries:
                 items:
                   description: An entry for a prefix list.

--- a/pkg/resource/managed_prefix_list/delta.go
+++ b/pkg/resource/managed_prefix_list/delta.go
@@ -20,7 +20,6 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
-	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -49,13 +48,6 @@ func newResourceDelta(
 			delta.Add("Spec.AddressFamily", a.ko.Spec.AddressFamily, b.ko.Spec.AddressFamily)
 		}
 	}
-	if len(a.ko.Spec.Entries) != len(b.ko.Spec.Entries) {
-		delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
-	} else if len(a.ko.Spec.Entries) > 0 {
-		if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.Entries, b.ko.Spec.Entries) {
-			delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
-		}
-	}
 	if ackcompare.HasNilDifference(a.ko.Spec.MaxEntries, b.ko.Spec.MaxEntries) {
 		delta.Add("Spec.MaxEntries", a.ko.Spec.MaxEntries, b.ko.Spec.MaxEntries)
 	} else if a.ko.Spec.MaxEntries != nil && b.ko.Spec.MaxEntries != nil {
@@ -76,5 +68,6 @@ func newResourceDelta(
 		delta.Add("Spec.Tags", a.ko.Spec.Tags, b.ko.Spec.Tags)
 	}
 
+	customPostCompare(delta, a, b)
 	return delta
 }

--- a/pkg/resource/managed_prefix_list/hooks.go
+++ b/pkg/resource/managed_prefix_list/hooks.go
@@ -49,6 +49,29 @@ func updateTagSpecificationsInCreateRequest(r *resource,
 	}
 }
 
+// customPostCompare compares Spec.Entries as a set keyed by CIDR.
+//
+// GetManagedPrefixListEntries returns entries in an order AWS chooses, which
+// need not match the order declared in the Spec. An order-sensitive comparison
+// therefore reports a difference that no update can ever resolve: the entries
+// to add and remove are computed from CIDR-keyed maps, so both come back empty
+// and the next reconcile sees the same difference again.
+func customPostCompare(
+	delta *ackcompare.Delta,
+	a *resource,
+	b *resource,
+) {
+	if a == nil || b == nil || a.ko == nil || b.ko == nil {
+		return
+	}
+	if !ackcompare.MapStringStringEqual(
+		buildEntriesMap(a.ko.Spec.Entries),
+		buildEntriesMap(b.ko.Spec.Entries),
+	) {
+		delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
+	}
+}
+
 // customUpdateManagedPrefixList provides custom logic for updating ManagedPrefixList
 func (rm *resourceManager) customUpdateManagedPrefixList(
 	ctx context.Context,
@@ -75,8 +98,12 @@ func (rm *resourceManager) customUpdateManagedPrefixList(
 	input := &svcsdk.ModifyManagedPrefixListInput{}
 	input.PrefixListId = latest.ko.Status.ID
 
-	// Always set the Name field from desired state
-	input.PrefixListName = desired.ko.Spec.Name
+	// Only set the Name when it actually changed. Setting it unconditionally
+	// defeats the "are there changes?" guard below, so a reconcile with nothing
+	// to change still issues a request.
+	if delta.DifferentAt("Spec.Name") {
+		input.PrefixListName = desired.ko.Spec.Name
+	}
 
 	if delta.DifferentAt("Spec.MaxEntries") {
 		if desired.ko.Spec.MaxEntries != nil {
@@ -103,8 +130,11 @@ func (rm *resourceManager) customUpdateManagedPrefixList(
 		}
 	}
 
-	// Set current version for optimistic locking (required by AWS for any modification)
-	if latest.ko.Status.Version != nil {
+	// Set current version for optimistic locking. Only entry modifications
+	// create a new version, so AWS rejects CurrentVersion on a request that
+	// carries none.
+	if (len(input.AddEntries) > 0 || len(input.RemoveEntries) > 0) &&
+		latest.ko.Status.Version != nil {
 		input.CurrentVersion = latest.ko.Status.Version
 	}
 

--- a/pkg/resource/managed_prefix_list/hooks_test.go
+++ b/pkg/resource/managed_prefix_list/hooks_test.go
@@ -1,0 +1,140 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package managed_prefix_list
+
+import (
+	"testing"
+
+	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/ec2-controller/apis/v1alpha1"
+)
+
+func entry(cidr, desc string) *svcapitypes.AddPrefixListEntry {
+	e := &svcapitypes.AddPrefixListEntry{CIDR: aws.String(cidr)}
+	if desc != "" {
+		e.Description = aws.String(desc)
+	}
+	return e
+}
+
+func resourceWithEntries(entries ...*svcapitypes.AddPrefixListEntry) *resource {
+	return &resource{ko: &svcapitypes.ManagedPrefixList{
+		Spec: svcapitypes.ManagedPrefixListSpec{
+			Name:    aws.String("pl-test"),
+			Entries: entries,
+		},
+	}}
+}
+
+// Asserted through the real newResourceDelta so the generator.yaml wiring
+// (compare.is_ignored plus the delta_post_compare hook) is covered too, not just
+// customPostCompare in isolation.
+func TestEntriesDelta(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        *resource
+		b        *resource
+		expectPL bool
+	}{
+		{
+			// The regression: GetManagedPrefixListEntries returns entries in an
+			// order AWS chooses, and an order-sensitive comparison reported a
+			// difference that no update could resolve.
+			name:     "same entries, different order",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a"), entry("10.0.2.0/24", "b")),
+			b:        resourceWithEntries(entry("10.0.2.0/24", "b"), entry("10.0.1.0/24", "a")),
+			expectPL: false,
+		},
+		{
+			name:     "identical entries",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			b:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			expectPL: false,
+		},
+		{
+			name:     "added entry",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a"), entry("10.0.2.0/24", "b")),
+			b:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			expectPL: true,
+		},
+		{
+			name:     "removed entry",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			b:        resourceWithEntries(entry("10.0.1.0/24", "a"), entry("10.0.2.0/24", "b")),
+			expectPL: true,
+		},
+		{
+			name:     "same CIDR, changed description",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "before")),
+			b:        resourceWithEntries(entry("10.0.1.0/24", "after")),
+			expectPL: true,
+		},
+		{
+			name:     "description added",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			b:        resourceWithEntries(entry("10.0.1.0/24", "")),
+			expectPL: true,
+		},
+		{
+			name:     "replaced entry",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			b:        resourceWithEntries(entry("10.0.9.0/24", "a")),
+			expectPL: true,
+		},
+		{
+			name:     "both empty",
+			a:        resourceWithEntries(),
+			b:        resourceWithEntries(),
+			expectPL: false,
+		},
+		{
+			name:     "entries added to an empty list",
+			a:        resourceWithEntries(entry("10.0.1.0/24", "a")),
+			b:        resourceWithEntries(),
+			expectPL: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			delta := newResourceDelta(tt.a, tt.b)
+			assert.Equal(t, tt.expectPL, delta.DifferentAt("Spec.Entries"))
+		})
+	}
+}
+
+// customPostCompare runs on every delta, including before the resource exists,
+// so it must tolerate nil inputs rather than panic.
+func TestCustomPostCompareNilSafety(t *testing.T) {
+	empty := &resource{}
+	for _, tt := range []struct {
+		name string
+		a    *resource
+		b    *resource
+	}{
+		{"both nil", nil, nil},
+		{"a nil", nil, resourceWithEntries(entry("10.0.1.0/24", "a"))},
+		{"b nil", resourceWithEntries(entry("10.0.1.0/24", "a")), nil},
+		{"nil ko", empty, empty},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				customPostCompare(ackcompare.NewDelta(), tt.a, tt.b)
+			})
+		})
+	}
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -27,6 +27,6 @@ var (
 // that generated this controller's code. They are baked in at code-generation
 // time and are immutable for the life of the generated code.
 const (
-	ACKGenerateVersion   = "v0.62.1"
-	ACKGenerateBuildDate = "2026-08-13T22:19:55Z"
+	ACKGenerateVersion   = "v0.62.1-4-gd4aaca5"
+	ACKGenerateBuildDate = "2026-08-26T18:34:44Z"
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -28,5 +28,5 @@ var (
 // time and are immutable for the life of the generated code.
 const (
 	ACKGenerateVersion   = "v0.62.1-4-gd4aaca5"
-	ACKGenerateBuildDate = "2026-08-26T18:34:44Z"
+	ACKGenerateBuildDate = "2026-08-26T19:34:36Z"
 )

--- a/test/e2e/tests/test_managed_prefix_list.py
+++ b/test/e2e/tests/test_managed_prefix_list.py
@@ -218,7 +218,13 @@ class TestManagedPrefixList:
         cr = k8s.get_resource(ref)
         assert cr['status']['state'] == 'create-complete', f"K8s state is {cr['status']['state']}, expected create-complete"
 
+        version_before_add = ec2_validator.get_managed_prefix_list(prefix_list_id)['Version']
+
         # ===== TEST 1: Add an entry (3 → 4) =====
+        # 10.0.2.0/24 sorts between the existing entries rather than after them,
+        # so AWS reads the list back in an order that differs from the declared
+        # one. That divergence is the whole point of this step: it must not be
+        # mistaken for a change. See test_entry_reorder_is_not_a_change.
         cr['spec']['entries'].append({
             'cidr': '10.0.2.0/24',
             'description': 'New network C'
@@ -246,6 +252,13 @@ class TestManagedPrefixList:
         aws_prefix_list = ec2_validator.get_managed_prefix_list(prefix_list_id)
         after_add_count = len(aws_prefix_list.get('Entries', []))
         assert after_add_count == 4, f"Expected 4 entries after add, got {after_add_count}"
+
+        # Exactly one modification. Adding or removing entries bumps the version,
+        # so a version that advanced by more than one means the controller issued
+        # extra modify calls -- the signature of a delta that never clears.
+        after_add_version = aws_prefix_list['Version']
+        assert after_add_version == version_before_add + 1, \
+            f"Expected version {version_before_add + 1} after one add, got {after_add_version}"
 
         # ===== TEST 2: Remove an entry (4 → 3) =====
         cr = k8s.get_resource(ref)
@@ -291,6 +304,49 @@ class TestManagedPrefixList:
         assert entry_to_remove not in k8s_cidrs, \
             f"Entry {entry_to_remove} should not be in K8s: {k8s_cidrs}"
 
+    def test_entry_reorder_is_not_a_change(self, prefix_list_ipv4, ec2_validator):
+        """Reordering entries without changing the set must not drive an update.
+
+        GetManagedPrefixListEntries returns entries in an order AWS chooses, so
+        the declared order and the observed order routinely disagree. Comparing
+        them as ordered lists produces a difference that no update can resolve:
+        the add and remove sets are keyed by CIDR and both come back empty, so
+        the controller re-requests the same no-op modification forever. AWS
+        rejects a request that carries a version but modifies no entries, which
+        leaves the resource stuck short of Synced.
+        """
+        (ref, _) = prefix_list_ipv4
+        prefix_list_id = k8s.get_resource(ref)['status']['id']
+
+        aws_prefix_list = ec2_validator.get_managed_prefix_list(prefix_list_id)
+        version_before = aws_prefix_list['Version']
+        aws_cidrs = [e['Cidr'] for e in aws_prefix_list.get('Entries', [])]
+        assert len(aws_cidrs) > 1, \
+            f"Need at least two entries to reorder, got {aws_cidrs}"
+
+        # Reverse the order AWS reports rather than asserting a specific
+        # divergence, so the test does not depend on how AWS chooses to sort.
+        cr = k8s.get_resource(ref)
+        by_cidr = {e['cidr']: e for e in cr['spec']['entries']}
+        cr['spec']['entries'] = [by_cidr[cidr] for cidr in reversed(aws_cidrs)]
+
+        k8s.patch_custom_resource(ref, cr)
+        time.sleep(UPDATE_WAIT_AFTER_SECONDS)
+
+        # The spec change bumps metadata.generation, so a reconcile is
+        # guaranteed to have run against the reordered list.
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10), \
+            "Resource did not stay synced after reordering entries"
+
+        # An unchanged version is the definitive signal that the reorder was not
+        # mistaken for a change: any entry modification would have bumped it.
+        aws_prefix_list = ec2_validator.get_managed_prefix_list(prefix_list_id)
+        assert aws_prefix_list['Version'] == version_before, \
+            f"Reorder modified the prefix list: version went " \
+            f"{version_before} -> {aws_prefix_list['Version']}"
+        assert sorted(e['Cidr'] for e in aws_prefix_list.get('Entries', [])) == sorted(aws_cidrs), \
+            "Reorder changed the entries in AWS"
+
     def test_update_tags(self, prefix_list_ipv4, ec2_validator):
         """Test adding, updating, and removing prefix list tags."""
         (ref, cr) = prefix_list_ipv4
@@ -310,6 +366,8 @@ class TestManagedPrefixList:
             cr['spec']['tags'] = []
         cr['spec']['tags'].append(new_tag)
 
+        version_before_tag = ec2_validator.get_managed_prefix_list(prefix_list_id)['Version']
+
         # Apply the update
         k8s.patch_custom_resource(ref, cr)
         time.sleep(UPDATE_WAIT_AFTER_SECONDS)
@@ -317,6 +375,11 @@ class TestManagedPrefixList:
         # Wait for the resource to be synced
         assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5), \
             "Resource did not sync after adding tag"
+
+        # A tags-only change must not touch the entries. The version staying put
+        # proves the reconcile did not also issue an entry modification.
+        assert ec2_validator.get_managed_prefix_list(prefix_list_id)['Version'] == version_before_tag, \
+            "Adding a tag modified the prefix list entries"
 
         # Get the updated resource
         cr = k8s.get_resource(ref)


### PR DESCRIPTION
Issue #, if available: none filed yet.

Description of changes:

`ManagedPrefixList` never reaches `Synced=True` after an entries update. The resource settles on `Synced=Unknown` and stays there, while AWS holds the correct entries.

The generated `newResourceDelta` compares `Spec.Entries` with an order-sensitive `DeepEqual`:

```go
if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.Entries, b.ko.Spec.Entries) {
    delta.Add("Spec.Entries", a.ko.Spec.Entries, b.ko.Spec.Entries)
}
```

`sdkFind` fills `Spec.Entries` from `GetManagedPrefixListEntries`, which returns entries in an order AWS chooses. Once that order differs from the declared one, `Spec.Entries` differs on every reconcile, and no update can resolve it: `computeEntriesToAdd` and `computeEntriesToRemove` key off CIDR, so both return empty.

`customUpdateManagedPrefixList` issued a request regardless, because `PrefixListName` was set unconditionally and so always satisfied the "only call if there are actual changes" guard. That request carries `CurrentVersion` with no entry modification, which AWS rejects:

```
InvalidParameterCombination: You cannot include a version unless your request
includes a modification to the entries of the prefix list.
```

`customUpdate` returns the error, `ensureConditions` records `Synced=Unknown`, and the next reconcile repeats it.

### Fix

Three changes:

1. Mark `Entries` with `compare.is_ignored` and add a `delta_post_compare` hook that compares the entries as a CIDR-keyed set, matching how the add and remove sets are already computed. This is the treatment `SecurityGroup` rules received in #359.
2. Set `PrefixListName` only when `Spec.Name` differs, so a reconcile with nothing to change no longer builds a request.
3. Set `CurrentVersion` only when the request modifies entries. Per the EC2 API, entry additions and removals create a new version while a name change does not, so a version on a request that modifies no entries is what AWS rejects.

The first change fixes the loop. The other two prevent a request that cannot succeed from being built at all.

The comparison lives in the manually maintained `hooks.go`, wired through `generator.yaml`, so it survives regeneration. Regenerated with code-generator `v0.62.1`, matching the `build_hash` already recorded in `apis/v1alpha1/ack-generate-metadata.yaml`; `api_directory_checksum` is unchanged, so no API types moved.

### Testing

**Unit** (`pkg/resource/managed_prefix_list/hooks_test.go`): nine cases asserted through the real `newResourceDelta`, so the `generator.yaml` wiring is covered alongside the comparison. Same entries in a different order produce no delta; added, removed, and replaced entries, and a changed or added description on the same CIDR, all still produce one. Plus nil-safety for `customPostCompare`.

**Live cluster** (EKS, 60s resync). The scenario from `test_update_entries`: create with three entries, then add a fourth. AWS returned `10.0.0.0/24  10.0.1.0/24  10.0.2.0/24  192.168.1.0/24` against a declared order of `10.0.0.0/24  10.0.1.0/24  192.168.1.0/24  10.0.2.0/24`, so the order divergence was present in both arms.

| | before | after |
|---|---|---|
| CR after update | `Synced=Unknown` for 40 polls | `Synced=True` in ~35s |
| `ACK.Recoverable` | `InvalidParameterCombination` | absent |
| AWS state | `modify-complete`, version 2 | `modify-complete`, version 2 |
| `ModifyManagedPrefixList` errors in log | repeating | none |

Held `Synced=True` across more than a full resync period with the AWS version pinned at 2, confirming no residual diff drives repeat modifications. A tags-only update, the scenario from `test_update_tags`, converges immediately and leaves the version at 2.

### Note on the e2e tests

`test_update_entries` and `test_update_tags` pass on `main` today, so this is not a visible CI failure. They pass because `customUpdate` returns `desired`, which the runtime also uses as the base of the status merge patch, making the patch empty and leaving the CR on the stale `Synced=True` from creation. The 400 loop happens either way; only the reporting is suppressed. aws-controllers-k8s/runtime#265 fixes that aliasing, at which point both tests fail against this resource. Merging this first keeps that change green.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
