### PR TITLE
fix: wait on Synced condition before attempting updates

### DIFF
--- a/test/e2e/tests/test_vpc_adoption.py
+++ b/test/e2e/tests/test_vpc_adoption.py
@@ -70,6 +70,7 @@ class TestVpcAdoption:
     def test_vpc_adopt_update(self, ec2_client, vpc_adoption):
         (ref, cr) = vpc_adoption
 
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=10)
         assert cr is not None
         assert 'status' in cr
         assert 'vpcID' in cr['status']


### PR DESCRIPTION
Description of changes:
VPC test_vpc_adopt_update was flaky. The update in the test waits for 
Synced condition, which was stale from the initial adoption Sync.
Adding a wait for synced before attempting to update.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
